### PR TITLE
Fix NeoForge mrpack export

### DIFF
--- a/theseus/src/api/pack/install_from.rs
+++ b/theseus/src/api/pack/install_from.rs
@@ -69,7 +69,7 @@ pub enum EnvType {
 #[serde(rename_all = "kebab-case")]
 pub enum PackDependency {
     Forge,
-    NeoForge,
+    Neoforge,
     FabricLoader,
     QuiltLoader,
     Minecraft,
@@ -335,7 +335,7 @@ pub async fn set_profile_information(
                 mod_loader = Some(ModLoader::Forge);
                 loader_version = Some(value);
             }
-            PackDependency::NeoForge => {
+            PackDependency::Neoforge => {
                 mod_loader = Some(ModLoader::NeoForge);
                 loader_version = Some(value);
             }

--- a/theseus/src/api/profile/mod.rs
+++ b/theseus/src/api/profile/mod.rs
@@ -965,7 +965,7 @@ pub async fn create_mrpack_json(
             dependencies.insert(PackDependency::Forge, v.id)
         }
         (crate::prelude::ModLoader::NeoForge, Some(v)) => {
-            dependencies.insert(PackDependency::NeoForge, v.id)
+            dependencies.insert(PackDependency::Neoforge, v.id)
         }
         (crate::prelude::ModLoader::Fabric, Some(v)) => {
             dependencies.insert(PackDependency::FabricLoader, v.id)
@@ -1068,7 +1068,7 @@ fn sanitize_loader_version_string(s: &str, loader: PackDependency) -> &str {
         // If two or more, take the second
         // If one, take the first
         // If none, take the whole thing
-        PackDependency::Forge | PackDependency::NeoForge => {
+        PackDependency::Forge | PackDependency::Neoforge => {
             let mut split: std::str::Split<'_, char> = s.split('-');
             match split.next() {
                 Some(first) => match split.next() {


### PR DESCRIPTION
Packerator and labrinth both expect a dependency ID of `neoforge`. Currently this is creating NeoForge mrpacks with a dependency of `neo-forge`.
