### PR TITLE
Possible fix to #968

### DIFF
--- a/theseus_gui/src-tauri/Info.plist
+++ b/theseus_gui/src-tauri/Info.plist
@@ -7,7 +7,7 @@
             <dict>
                 <key>CFBundleURLName</key>
                 <!-- Obviously needs to be replaced with your app's bundle identifier -->
-                <string>com.modrinth.theseus</string>
+                <string>com.mojang.minecraftlauncher</string>
                 <key>CFBundleURLSchemes</key>
                 <array>
                     <!-- register the myapp:// and myscheme:// schemes -->


### PR DESCRIPTION
**Completely untested - I don't have a Mac or access to one.**
*I also have no idea how to make MacOS apps, I just saw this file and assumed it would be where you put the flag.*

In theory, this could fix https://github.com/modrinth/theseus/issues/968 by flagging Modrinth as a game, which will tell MacOS that once the game is in fullscreen it can enable [Game Mode](https://support.apple.com/en-gb/105118). Uses [this developer forum post](https://forums.developer.apple.com/forums/thread/739387) as a source for the flag name.