### PR TITLE
Theseus: Fix scrolling to top problems

### DIFF
--- a/apps/app/src/pages/Browse.vue
+++ b/apps/app/src/pages/Browse.vue
@@ -892,7 +892,6 @@ onUnmounted(() => unlistenOffline())
 
 .search-container {
   display: flex;
-  height: 100%; /* takes up only the necessary height */
   overflow-y: auto;
   scroll-behavior: smooth;
 

--- a/apps/app/src/routes.js
+++ b/apps/app/src/routes.js
@@ -138,7 +138,11 @@ export default new createRouter({
   linkActiveClass: 'router-link-active',
   linkExactActiveClass: 'router-link-exact-active',
   scrollBehavior() {
-    // always scroll to top
-    return { top: 0 }
+    // Sometimes Vue's scroll behavior is not working as expected, so we need to manually scroll to top (especially on Linux)
+    document.querySelector(".router-view").scrollTop = 0;
+    return {
+      el: ".router-view",
+      top: 0
+    }
   },
 })


### PR DESCRIPTION
**Note: PR #1232 has been reopened following the switch to a monorepo organization.**

This PR fixes an issue where Vue's scrolling behaviour inconsistently failed to scroll to the top of the entire page on certain desktop environments or operating systems. The problem occurred because Theseus has scrolling within an inner container rather than the entire page, leading to inconsistent behaviour.