### PR TITLE
feat: support hook parameters/environment variables for pre-launch hook for Modrinth Desktop App

### DIFF
--- a/packages/app-lib/src/api/profile/mod.rs
+++ b/packages/app-lib/src/api/profile/mod.rs
@@ -788,6 +788,7 @@ pub async fn run_credentials(
         
         let full_path = path.get_full_path().await?;
         let jre_key = get_optimal_jre_key(&path).await?;
+        // The hook parameters are compatible with MultiMC-based and other launchers. See https://github.com/MultiMC/Launcher/wiki/Instance-settings#custom-commands
         let cmd_with_hook_parameters = hook
             .replace("$INST_NAME", profile.metadata.name.as_str())
             .replace("$INST_ID", profile.metadata.name.as_str())

--- a/packages/app-lib/src/api/profile/mod.rs
+++ b/packages/app-lib/src/api/profile/mod.rs
@@ -776,10 +776,10 @@ pub async fn run_credentials(
     })?;
 
     let java_args = profile
-    .java
-    .as_ref()
-    .and_then(|it| it.extra_arguments.as_ref())
-    .unwrap_or(&settings.custom_java_args);
+        .java
+        .as_ref()
+        .and_then(|it| it.extra_arguments.as_ref())
+        .unwrap_or(&settings.custom_java_args);
 
     let pre_launch_hooks =
         &profile.hooks.as_ref().unwrap_or(&settings.hooks).pre_launch;

--- a/packages/app-lib/src/api/profile/mod.rs
+++ b/packages/app-lib/src/api/profile/mod.rs
@@ -787,13 +787,13 @@ pub async fn run_credentials(
         // TODO: Improve Hook parameters
         
         let full_path = path.get_full_path().await?;
+        let jre_key = get_optimal_jre_key(&path).await.unwrap();
         let cmd_with_hook_parameters = hook
             .replace("$INST_NAME", profile.metadata.name.as_str())
             .replace("$INST_ID", profile.metadata.name.as_str())
             .replace("$INST_DIR", full_path.to_str().unwrap())
             .replace("$INST_MC_DIR", full_path.to_str().unwrap())
-            // TODO: Avoid harcoding Java executable
-            .replace("$INST_JAVA", settings.java_globals.get(&"JAVA_21".to_string()).unwrap().path.as_str())
+            .replace("$INST_JAVA", jre_key.unwrap().path.as_str())
             // TODO: Pass the args correctly
             .replace("$INST_JAVA_ARGS", java_args.join(" ").as_str());
 

--- a/packages/app-lib/src/api/profile/mod.rs
+++ b/packages/app-lib/src/api/profile/mod.rs
@@ -787,7 +787,7 @@ pub async fn run_credentials(
         // TODO: Improve Hook parameters
         
         let full_path = path.get_full_path().await?;
-        let jre_key = get_optimal_jre_key(&path).await.unwrap();
+        let jre_key = get_optimal_jre_key(&path).await?;
         let cmd_with_hook_parameters = hook
             .replace("$INST_NAME", profile.metadata.name.as_str())
             .replace("$INST_ID", profile.metadata.name.as_str())


### PR DESCRIPTION
**Support Hook Parameters for the Pre-Launch Hook**

The parameter/variable names are the same as [MultiMC](https://multimc.org/) and MultiMC-based launchers (e.g., [Prism Launcher](https://prismlauncher.org/)). It's also adapted by some other launchers that are not based on MutliMC (e.g., [ATLauncher](https://atlauncher.com/)).

As this is my first time working with [Rust](https://www.rust-lang.org/) and [Tauri](https://tauri.app/v1/guides/getting-started/prerequisites/#installing), this code may not adhere to high-quality code standards.

This PR has a few issues:

- ~~**Java Version**: It always uses `JAVA_21` from the settings instead of the one from the profile if available, also the profile or settings could use a different **Java path**, to solve this we need to call the function `get_java_version_from_profile` which requires the `Profile` and `VersionInfo`, I'm unfamiliar with the code though it seems that we need to either use `get_optimal_jre_key` or require an additional parameter in `run_credentials` to require `VersionInfo`, We also need to update the function call from JS since the project use bridge between JS and Rust code, and we probably don't have access to `VersionInfo` from there too, we might need to move this logic into somewhere else~~ Issue solved, though we still might need to review it
- **Only support `Pre-Launch`**: We need to refactor the code or move the Hooks parameters logic somewhere else along with `Pre-Launch`
- **Incorrect Handling of `$INST_JAVA_ARGS`**: The current implementation does not pass `$INST_JAVA_ARGS` correctly.
- **Code Quality**: The code could likely benefit from improvements. Feel free to request changes or leave a review. We could also consider closing this PR if it is not suitable.
- **Error Handling**: The code uses the `unwrap` function which seems to throw an error in case the result has not succeeded. It seems some of the code in the project uses this too, I'm uncertain if there is a possibility the functions we're using won't succeed though we might want to consider handling the errors.

To solve the first and second issues, we might consider moving the code to `launch_minecraft` as currently the logic for Wrapper and Post Exit hooks are in there, and in there, we have access to `VersionInfo`. The first issue could be solved without refactoring the code. 

<details>
<summary>Unrelated</summary>

In `launch_minecraft`, Noticed that the parameter name for Wrapper Hook is `wrapper` while Post Exit Hook is `post_exit_hook`, I'm not sure if there is a reason though this might make the code a bit inconsistent.

The hooks expect an executable to be used instead of executing the command in the command line, which doesn't allow to use of something like `java --version` in case `java` is in the path.

You will get an error: 
```
An error occurred

I/O error: program not found, path:
```

The variable `jre_key` is of type `JavaVersion`, it seems to have the Java Path instead of the key in the settings/profile, called it `jre_key` because it uses the function `get_optimal_jre_key`

</details>

## Related Feature requests

- #1238
- #952

In case this PR will be merged (after reviewing it and improving it), we will also need to add docs, we could document this in Modrinth App Docs, then add a link in the app to the page for more details.

<details>
<summary>Screenshot of using Pre-Launch Hook parameters with an executable JAR file</summary>

![Pre-Launch Hook parameters with an executable JAR file](https://github.com/modrinth/code/assets/73608287/7abdec65-e0d6-4122-9ddd-f45d4077c0ac)


</details>