### PR TITLE
Fix: Issue templates all saying "Modrinth Website"

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-app-bug.yml
+++ b/.github/ISSUE_TEMPLATE/1-app-bug.yml
@@ -1,5 +1,5 @@
 name: 🎮 Modrinth App bug
-description: Report an issue on the Modrinth website.
+description: Report an issue on the Modrinth app.
 labels: [bug, app]
 body:
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/3-api-bug.yml
+++ b/.github/ISSUE_TEMPLATE/3-api-bug.yml
@@ -1,5 +1,5 @@
 name: 🛠️ API issue (api.modrinth.com)
-description: Report an issue on the Modrinth website.
+description: Report an issue on the Modrinth API.
 labels: [bug, api]
 body:
   - type: checkboxes


### PR DESCRIPTION
On the issues template, the App, Website and API templates all say "Report an issue on the Modrinth **website**"
![image](https://github.com/user-attachments/assets/cdac65a8-3a61-42ad-ac2b-b9dac9831d52)
