### PR TITLE
Switch to explicit Turborepo config

### DIFF
--- a/apps/app-frontend/package.json
+++ b/apps/app-frontend/package.json
@@ -4,8 +4,8 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
     "build": "vite build",
+    "dev": "vite",
     "lint": "eslint . && prettier --check .",
     "fix": "eslint . --fix && prettier --write ."
   },

--- a/apps/app-playground/package.json
+++ b/apps/app-playground/package.json
@@ -2,9 +2,9 @@
   "name": "@modrinth/app-playground",
   "scripts": {
     "build": "cargo build --release",
-    "lint": "cargo fmt --check && cargo clippy -- -D warnings",
-    "fix": "cargo fmt && cargo clippy --fix",
     "dev": "cargo run",
-    "test": "cargo test"
+    "test": "cargo test",
+    "lint": "cargo fmt --check && cargo clippy -- -D warnings",
+    "fix": "cargo fmt && cargo clippy --fix"
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -1,30 +1,164 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "tasks": {
-    "build": {
+    // @modrinth/app
+    "@modrinth/app#build": {
       "dependsOn": ["^build"],
-      "inputs": ["$TURBO_DEFAULT$", ".env*"],
-      "outputs": [".nuxt/**", "dist/**", ".output/**", "target/**"],
+      "inputs": ["$TURBO_DEFAULT$", "!**/*.md", "!LICENSE"],
+      "outputs": ["target"]
+    },
+    "@modrinth/app#dev": {
+      "cache": false,
+      "persistent": true,
+      "env": ["*"]
+    },
+    "@modrinth/app#test": {
+      "inputs": ["$TURBO_DEFAULT$", "!**/*.md", "!LICENSE"]
+    },
+    "@modrinth/app#lint": {
+      "inputs": ["$TURBO_DEFAULT$", "!LICENSE"]
+    },
+    "@modrinth/app#fix": {
+      "inputs": ["$TURBO_DEFAULT$", "!LICENSE"]
+    },
+
+    // @modrinth/app-frontend
+    "@modrinth/app-frontend#build": {
+      "dependsOn": ["^build"],
+      "inputs": ["$TURBO_DEFAULT$", "!**/*.md", "!LICENSE"],
+      "outputs": ["dist"],
+      "env": ["BASE_URL", "BROWSER_BASE_URL"]
+    },
+    "@modrinth/app-frontend#dev": {
+      "cache": false,
+      "persistent": true,
+      "env": ["BASE_URL", "BROWSER_BASE_URL"]
+    },
+    "@modrinth/app-frontend#lint": {
+      "inputs": ["$TURBO_DEFAULT$", "!LICENSE"]
+    },
+    "@modrinth/app-frontend#fix": {
+      "inputs": ["$TURBO_DEFAULT$", "!LICENSE"]
+    },
+
+    // @modrinth/app-playground
+    "@modrinth/app-playground#build": {
+      "dependsOn": ["^build"],
+      "inputs": ["$TURBO_DEFAULT$", "!**/*.md", "!LICENSE"],
+      "outputs": ["target"]
+    },
+    "@modrinth/app-playground#dev": {
+      "cache": false,
+      "persistent": true,
+      "env": ["*"]
+    },
+    "@modrinth/app-playground#test": {
+      "inputs": ["$TURBO_DEFAULT$", "!**/*.md", "!LICENSE"]
+    },
+    "@modrinth/app-playground#lint": {
+      "inputs": ["$TURBO_DEFAULT$", "!LICENSE"]
+    },
+    "@modrinth/app-playground#fix": {
+      "inputs": ["$TURBO_DEFAULT$", "!LICENSE"]
+    },
+
+    // @modrinth/frontend
+    "@modrinth/frontend#build": {
+      "dependsOn": ["^build"],
+      "inputs": ["$TURBO_DEFAULT$", ".env", ".env.*", "!*.md", "!LICENSE", "!src/generated"],
+      "outputs": [".nuxt", ".output", "src/generated"],
       "env": [
-        "NODE_ENV",
-        "SITE_URL",
         "BASE_URL",
-        "FLAG_OVERRIDES",
         "BROWSER_BASE_URL",
         "RATE_LIMIT_IGNORE_KEY",
-        "VERCEL_*",
-        "CF_PAGES_*",
-        "HEROKU_APP_NAME"
+        "SITE_URL",
+        "FLAG_OVERRIDES",
+        "STRIPE_PUBLISHABLE_KEY"
       ]
     },
-    "lint": {},
-    "dev": {
+    "@modrinth/frontend#dev": {
       "cache": false,
       "persistent": true,
       "env": [
-        "*"
+        "BASE_URL",
+        "BROWSER_BASE_URL",
+        "RATE_LIMIT_IGNORE_KEY",
+        "SITE_URL",
+        "FLAG_OVERRIDES",
+        "STRIPE_PUBLISHABLE_KEY"
       ]
     },
-    "test": {}
-  }
+    "@modrinth/frontend#preview": {
+      "dependsOn": ["build"],
+      "inputs": [".output"]
+    },
+    "@modrinth/frontend#lint": {
+      "inputs": ["$TURBO_DEFAULT$", "!LICENSE"]
+    },
+    "@modrinth/frontend#fix": {
+      "inputs": ["$TURBO_DEFAULT$", "!LICENSE"]
+    },
+    "@modrinth/frontend#intl:extract": {
+      "inputs": [
+        "src/**/*.vue",
+        "src/**/*.ts",
+        "src/**/*.tsx",
+        "src/**/*.js",
+        "src/**/*.jsx",
+        "src/**/*.mts",
+        "src/**/*.cts",
+        "src/**/*.mjs",
+        "src/**/*.cjs",
+        "!src/**/*.d.ts"
+      ],
+      "outputs": ["src/locales/en-US/index.json"]
+    },
+
+    // @modrinth/app-lib
+    "@modrinth/app-lib#build": {
+      "inputs": ["$TURBO_DEFAULT$", "!**/*.md", "!LICENSE"],
+      "outputs": ["target"]
+    },
+    "@modrinth/app-lib#lint": {
+      "inputs": ["$TURBO_DEFAULT$", "!LICENSE"]
+    },
+    "@modrinth/app-lib#fix": {
+      "inputs": ["$TURBO_DEFAULT$", "!LICENSE"]
+    },
+    "@modrinth/app-lib#test": {
+      "inputs": ["$TURBO_DEFAULT$", "!LICENSE"]
+    },
+
+    // @modrinth/assets
+    "@modrinth/assets#lint": {
+      "inputs": ["$TURBO_DEFAULT$", "!LICENSE"]
+    },
+    "@modrinth/assets#fix": {
+      "inputs": ["$TURBO_DEFAULT$", "!LICENSE"]
+    },
+
+    // @modrinth/ui
+    "@modrinth/ui#lint": {
+      "inputs": ["$TURBO_DEFAULT$", "!LICENSE"]
+    },
+    "@modrinth/ui#fix": {
+      "inputs": ["$TURBO_DEFAULT$", "!LICENSE"]
+    },
+
+    // @modrinth/utils
+    "@modrinth/utils#lint": {
+      "inputs": ["$TURBO_DEFAULT$", "!LICENSE"]
+    },
+    "@modrinth/utils#fix": {
+      "inputs": ["$TURBO_DEFAULT$", "!LICENSE"]
+    },
+
+    "build": {},
+    "dev": {},
+    "test": {},
+    "lint": {},
+    "fix": {},
+    "intl:extract": {}
+  },
+  "globalEnv": ["NODE_ENV", "TAURI_*", "VERCEL_*", "HEROKU_*", "CF_PAGES_*"]
 }


### PR DESCRIPTION
This changes Turborepo config in the workspace root to be explicit.
Explicity in this case means that all tasks are defined manually and all
inputs are also specified manually.

While that might seem redundant, this allows to orchestrate and adjust
tasks more carefully - ignoring some files while taking other files into
account, only hashing and providing project-specific variables,
explicitly reviewing and specifying dependencies. That might come in
handy in the future.

There's an alternative way to approach this, which is to have every
package contain "turbo.json" file, however, for now the flat approach
has been chosen as it seems to be the most cleanest and easiest to
review.
