### PR TITLE
fix: loader selection not showing in normal search

### DIFF
--- a/apps/app-frontend/src/pages/Browse.vue
+++ b/apps/app-frontend/src/pages/Browse.vue
@@ -585,7 +585,10 @@ const isModProject = computed(() => ['modpack', 'mod'].includes(projectType.valu
           <ClearIcon /> Clear filters
         </Button>
         <div
-          v-if="(isModProject && ignoreInstanceLoaders) || projectType === 'shader'"
+          v-if="
+            (isModProject && (ignoreInstanceLoaders || !instanceContext)) ||
+            projectType === 'shader'
+          "
           class="loaders"
         >
           <h2>Loaders</h2>


### PR DESCRIPTION
This fixes a bug where loader filters are not shown in normal searches. I belive this was introduced when switching to sqllite