### PR TITLE
fix(knossos): remove auto margin from square button svg

### DIFF
--- a/apps/frontend/src/assets/styles/components.scss
+++ b/apps/frontend/src/assets/styles/components.scss
@@ -620,7 +620,6 @@ tr.button-transparent {
     max-width: 1.25rem;
     min-height: 1.25rem;
     max-height: 1.25rem;
-    margin: auto;
   }
 
   flex-shrink: 0;


### PR DESCRIPTION
Closes: #2179 

### Description

Removes the auto margin property from the inner svg inside of square-button classes.

### Media:

#### Before:
Member list:
<img width="193" alt="image" src="https://github.com/user-attachments/assets/020e77d9-7a1e-4269-b4ea-7474e69971fd">

#### After:

Member list:
<img width="176" alt="image" src="https://github.com/user-attachments/assets/eb37317f-f197-4498-908d-7486fd1c744d">


Publishing list:
<img width="237" alt="image" src="https://github.com/user-attachments/assets/21fb9888-1e57-481a-880c-66ca4125d048">

### Testing:

I've tested this by navigating to other pages where the square button is used and verified it still looks okay.