### PR TITLE
fix(theseus): Allow running `app:dev` on Linux

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -22,7 +22,8 @@
     "dev": {
       "cache": false,
       "persistent": true,
-      "inputs": ["$TURBO_DEFAULT$", ".env*"]
+      "inputs": ["$TURBO_DEFAULT$", ".env*"],
+      "env": ["DISPLAY", "WEBKIT_DISABLE_DMABUF_RENDERER"]
     },
     "test": {},
     "fix": {


### PR DESCRIPTION
Fixes bug introduced in https://github.com/modrinth/code/commit/2d416d491c9a139a584799e2c3a06b4eceaa7fdc, now app window correctly launches.