### PR TITLE
chore: add .env to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ npm-debug.log
 yarn-error.log
 testem.log
 /typings
+**/.env
 
 # System Files
 .DS_Store


### PR DESCRIPTION
not sure if there is a reason why this hasn't been done so far, but i don't see a reason why .env files should be checked in