### PR TITLE
Fix Game versions input not showing

### DIFF
--- a/apps/frontend/src/pages/[type]/[id]/version/[version].vue
+++ b/apps/frontend/src/pages/[type]/[id]/version/[version].vue
@@ -567,6 +567,7 @@
               :show-labels="false"
               :limit="6"
               :hide-selected="true"
+              :custom-label="(version) => version"
               placeholder="Choose versions..."
             />
             <Checkbox


### PR DESCRIPTION
There is a bug in vue-multiselect library where it will default
`custom-label` property to raw properies object. Presumably this is a
bug that appeared because they ported library to Vue 3 and have not
considered that the signature for `default` prop's function has changed.

To work around this, we can provide custom `custom-label` property that
is just a function that returns the input itself. In other places, where
objects are passed, `label` property can be used. In this case the first
suggestion applies. DO NOT USE VUE-MULTISELECT WITOUT `LABEL` OR
`CUSTOM-LABEL` PROPS!

Fixes #2293
Fixes #2343