### PR TITLE
fix(app): import listener trait to fix ci

### DIFF
--- a/apps/app/src/api/ads.rs
+++ b/apps/app/src/api/ads.rs
@@ -66,6 +66,7 @@ pub async fn init_ads_window<R: Runtime>(
     height: f32,
     override_shown: bool,
 ) -> crate::api::Result<()> {
+    use tauri::Listener;
     use tauri::WebviewUrl;
     const LINK_SCRIPT: &str = include_str!("ads-init.js");
 


### PR DESCRIPTION
Attempts to fix CI again, as there was some commits between #2411 being created and being merged. The code that uses `listen_any` also seems pointless as it's purely logging, perhaps we could just remove it?