### PR TITLE
Non-modloader specific projects should not filter by loaders

### DIFF
--- a/apps/app-frontend/src/pages/project/Versions.vue
+++ b/apps/app-frontend/src/pages/project/Versions.vue
@@ -184,10 +184,14 @@ const props = defineProps({
     type: String,
     default: null,
   },
+  project: {
+    type: Object,
+    required: true,
+  }
 })
 
 const filterVersions = ref([])
-const filterLoader = ref(props.instance ? [props.instance?.loader] : [])
+const filterLoader = ref(props.project.project_type === 'mod' ? props.instance ? [props.instance?.loader] : [] : [])
 const filterGameVersions = ref(props.instance ? [props.instance?.game_version] : [])
 
 const currentPage = ref(1)


### PR DESCRIPTION
Small fix to address #2478 it will only load the filterLoader if the project is a mod. I noticed at least some datapacks are affected as their projectType is a mod though