### PR TITLE
Consistent alignment for 'project settings page confirmation' buttons

### DIFF
--- a/apps/frontend/src/assets/styles/components.scss
+++ b/apps/frontend/src/assets/styles/components.scss
@@ -648,7 +648,7 @@ tr.button-transparent {
   grid-gap: var(--spacing-card-sm);
   flex-wrap: wrap;
   margin-top: var(--spacing-card-md);
-  justify-content: right;
+  justify-content: flex-start;
 }
 
 .multiselect--above .multiselect__content-wrapper {


### PR DESCRIPTION
Currently, project pages such as General, Tags, Links etc. have inconsistent locations for the 'Save Changes' button:

Right Side: <kbd>General</kbd>, <kbd>Tags</kbd>, <kbd>Links</kbd>
Left Side: <kbd>Description</kbd>, <kbd>License</kbd>

This PR changes 1 line of css for the .button-group class, unifying the buttons on the left side of the button group.

Things to consider:
- I haven't tested the entire site to check where else .button-group is used. If it's used in unexpected places there may be unforseen layout shifts from this PR (Scoping the styles to each page would likely be preferable if this is the case)
- Moving the buttons to the left hand side was an arbitrary decision on my part. They can just as easily be on the right if that would be preferred. (Although it definitely looks better on the left side for the <kbd>Links</kbd> page):
#### Button on the right (current live site)
![image](https://github.com/user-attachments/assets/669ba84a-7e86-4e0c-af55-1d69eb751e04)

#### Button on the left
![image](https://github.com/user-attachments/assets/26140e19-1782-4484-9e90-c90f2e22507e)
