### PR TITLE
fix(docs): correct favicon url

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
-import starlight from '@astrojs/starlight';
+import starlight from '@astrojs/starlight'
+import { defineConfig } from 'astro/config'
 import starlightOpenAPI, { openAPISidebarGroups } from 'starlight-openapi'
 
 // https://astro.build/config
@@ -8,15 +8,16 @@ export default defineConfig({
   integrations: [
     starlight({
       title: 'Modrinth Documentation',
+      favicon: '/favicon.ico',
       editLink: {
         baseUrl: 'https://github.com/modrinth/code/edit/main/apps/docs/',
       },
       social: {
-          github: 'https://github.com/modrinth/code',
-          discord: 'https://discord.modrinth.com',
-          'x.com': 'https://x.com/modrinth',
-          mastodon: 'https://floss.social/@modrinth',
-          threads: 'https://threads.net/@modrinth',
+        github: 'https://github.com/modrinth/code',
+        discord: 'https://discord.modrinth.com',
+        'x.com': 'https://x.com/modrinth',
+        mastodon: 'https://floss.social/@modrinth',
+        threads: 'https://threads.net/@modrinth',
       },
       logo: {
         light: './src/assets/light-logo.svg',
@@ -36,16 +37,16 @@ export default defineConfig({
             label: 'Modrinth API',
             schema: './public/openapi.yaml',
           },
-        ])
+        ]),
       ],
       sidebar: [
         {
-            label: 'Contributing to Modrinth',
-            autogenerate: { directory: 'contributing' },
+          label: 'Contributing to Modrinth',
+          autogenerate: { directory: 'contributing' },
         },
         // Add the generated sidebar group to the sidebar.
         ...openAPISidebarGroups,
       ],
     }),
   ],
-});
+})


### PR DESCRIPTION
Starlight defaults to favicon.svg, however a favicon.ico was added to the repo.

Changes:

- Format astro config according to Prettier
- Properly set favicon path