### PR TITLE
fix: update old docs links

### DIFF
--- a/apps/app/src/main.rs
+++ b/apps/app/src/main.rs
@@ -317,7 +317,7 @@ fn main() {
                     MessageDialog::new()
                         .set_type(MessageType::Error)
                         .set_title("Initialization error")
-                        .set_text("Your Microsoft Edge WebView2 installation is corrupt.\n\nMicrosoft Edge WebView2 is required to run Modrinth App.\n\nLearn how to repair it at https://docs.modrinth.com/faq/app/webview2")
+                        .set_text("Your Microsoft Edge WebView2 installation is corrupt.\n\nMicrosoft Edge WebView2 is required to run Modrinth App.\n\nLearn how to repair it at https://support.modrinth.com/en/articles/8797765-corrupted-microsoft-edge-webview2-installation")
                         .show_alert()
                         .unwrap();
 

--- a/apps/labrinth/README.md
+++ b/apps/labrinth/README.md
@@ -2,4 +2,4 @@
 
 ## Modrinth's laboratory for its backend service & API!
 
-For contributing information, please see the labrinth section of the [Modrinth contributing guide](https://docs.modrinth.com/docs/details/contributing/#labrinth-backend-and-api). For documentation on the API itself, see the [API Spec](https://docs.modrinth.com/api-spec/).
+For contributing information, please see the labrinth section of the [Modrinth contributing guide](https://docs.modrinth.com/contributing/labrinth/). For documentation on the API itself, see the [API Spec](https://docs.modrinth.com/api/).

--- a/apps/labrinth/src/queue/moderation.rs
+++ b/apps/labrinth/src/queue/moderation.rs
@@ -145,7 +145,7 @@ impl ModerationMessage {
             ModerationMessage::NoPrimaryFile => "Please attach a file to this version. All files on Modrinth must have files associated with their versions.\n".to_string(),
             ModerationMessage::PackFilesNotAllowed { files, .. } => {
                 let mut str = "".to_string();
-                str.push_str("This pack redistributes copyrighted material. Please refer to [Modrinth's guide on obtaining modpack permissions](https://docs.modrinth.com/modpacks/permissions) for more information.\n\n");
+                str.push_str("This pack redistributes copyrighted material. Please refer to [Modrinth's guide on obtaining modpack permissions](https://support.modrinth.com/en/articles/8797527-obtaining-modpack-permissions) for more information.\n\n");
 
                 let mut attribute_mods = Vec::new();
                 let mut no_mods = Vec::new();

--- a/apps/labrinth/src/routes/mod.rs
+++ b/apps/labrinth/src/routes/mod.rs
@@ -69,7 +69,7 @@ pub fn root_config(cfg: &mut web::ServiceConfig) {
                 Ok(req.into_response(
                     HttpResponse::Gone()
                         .content_type("application/json")
-                        .body(r#"{"error":"api_deprecated","description":"You are using an application that uses an outdated version of Modrinth's API. Please either update it or switch to another application. For developers: https://docs.modrinth.com/docs/migrations/v1-to-v2/"}"#)
+                        .body(r#"{"error":"api_deprecated","description":"You are using an application that uses an outdated version of Modrinth's API. Please either update it or switch to another application. For developers: https://docs.modrinth.com/api/#versioning"}"#)
                 ))
             }.boxed_local()
         })

--- a/packages/ui/src/components/base/MarkdownEditor.vue
+++ b/packages/ui/src/components/base/MarkdownEditor.vue
@@ -237,7 +237,7 @@
           >This editor supports
           <a
             class="markdown-resource-link"
-            href="https://docs.modrinth.com/markdown"
+            href="https://support.modrinth.com/en/articles/8801962-advanced-markdown-formatting"
             target="_blank"
             >Markdown formatting</a
           >.</span


### PR DESCRIPTION
- Markdown guide link to support article
- API version deprecated error to new docs
- Modpack permissions error to support article
- Labrinth README links to new docs
- App WebView2 link to support article
- Cheery-pick to new branch