### PR TITLE
fix(frontend): swap version name and version number on the versions page

### DIFF
--- a/apps/frontend/src/pages/[type]/[id]/versions.vue
+++ b/apps/frontend/src/pages/[type]/[id]/versions.vue
@@ -94,8 +94,8 @@
               <div
                 class="pointer-events-none relative z-[1] flex flex-col justify-center group-hover:underline"
               >
-                <div class="font-bold text-contrast">{{ version.version_number }}</div>
-                <div class="text-xs font-medium">{{ version.name }}</div>
+                <div class="font-bold text-contrast">{{ version.name }}</div>
+                <div class="text-xs font-medium">{{ version.version_number }}</div>
               </div>
             </div>
             <div class="flex flex-col justify-center gap-2 sm:contents">


### PR DESCRIPTION
The version number is often used as an identifier, while the version name is more user-facing. This also matches the app better.

Currently, it looks like this:
![afbeelding](https://github.com/user-attachments/assets/2e5e5252-f0e6-4d67-a136-5b0d7a1b439e)

This PR will change it to this:
![afbeelding](https://github.com/user-attachments/assets/e964729b-482c-4ad4-b853-3cc20adee58a)
