### PR TITLE
Fix top margin issue for author actions section

### DIFF
--- a/apps/frontend/src/components/ui/ProjectMemberHeader.vue
+++ b/apps/frontend/src/components/ui/ProjectMemberHeader.vue
@@ -384,6 +384,8 @@ const submitForReview = async () => {
 }
 
 .author-actions {
+  margin-top: var(--spacing-card-md);
+
   &:empty {
     display: none;
   }


### PR DESCRIPTION
CSS one-liner that fixes the lack of a top margin on the author actions section when creating a new project.
See below for a before and after:
![image](https://github.com/user-attachments/assets/c668597d-5d10-488d-a8b3-c97eda5b0785)
![image](https://github.com/user-attachments/assets/2145dcb3-640f-4a5d-ac27-346a30e503fb)
