### PR TITLE
feat(labrinth): totp skew

### DIFF
--- a/apps/labrinth/src/routes/internal/flows.rs
+++ b/apps/labrinth/src/routes/internal/flows.rs
@@ -1678,26 +1678,26 @@ async fn validate_2fa_code(
             .map_err(|_| AuthenticationError::InvalidCredentials)?,
     )
     .map_err(|_| AuthenticationError::InvalidCredentials)?;
-    let token = totp
-        .generate_current()
-        .map_err(|_| AuthenticationError::InvalidCredentials)?;
 
     const TOTP_NAMESPACE: &str = "used_totp";
     let mut conn = redis.connect().await?;
 
     // Check if TOTP has already been used
     if conn
-        .get(TOTP_NAMESPACE, &format!("{}-{}", token, user_id.0))
+        .get(TOTP_NAMESPACE, &format!("{}-{}", input, user_id.0))
         .await?
         .is_some()
     {
         return Err(AuthenticationError::InvalidCredentials);
     }
 
-    if input == token {
+    if totp
+        .check_current(input.as_str())
+        .map_err(|_| AuthenticationError::InvalidCredentials)?
+    {
         conn.set(
             TOTP_NAMESPACE,
-            &format!("{}-{}", token, user_id.0),
+            &format!("{}-{}", input, user_id.0),
             "",
             Some(60),
         )


### PR DESCRIPTION
Fixes #2875 by using totp-rs's method for checking validity, which accounts for the configured skew. The standard recommends a value of one period of skew, which is what we are configured to support. This was however not supported because of how the TOTP was checked.