### PR TITLE
fix(servers): standalone versions not showing up in loader page

### DIFF
--- a/apps/frontend/src/pages/servers/manage/[id]/options/loader.vue
+++ b/apps/frontend/src/pages/servers/manage/[id]/options/loader.vue
@@ -334,9 +334,12 @@ const mcVersions = tags.value.gameVersions
   .filter((x) => x.version_type === "release")
   .map((x) => x.version)
   .filter((x) => {
-    const num = parseInt(x.replace(/\./g, ""), 10);
+    // const num = parseInt(x.replace(/\./g, ""), 10);
     // Versions 1.2.4 and below don't have server jars from Mojang
-    return isNaN(num) || num >= 125;
+    // return isNaN(num) || num >= 125;
+    // above code broke singular versions up until 1.24 (ie 1.25 showed)
+    const segment = parseInt(x.split(".")[1], 10);
+    return !isNaN(segment) && segment > 2;
   });
 
 const selectedLoaderVersions = computed(() => {


### PR DESCRIPTION
standalone versions (ie 1.21, 1.20, 1.19 etc) didn't show up before. this fixes that