### PR TITLE
fix(frontend): generate auth URL with provider

### DIFF
--- a/apps/frontend/src/composables/auth.js
+++ b/apps/frontend/src/composables/auth.js
@@ -113,7 +113,7 @@ export const getAuthUrl = (provider, redirect = "") => {
   }
   const fullURL = `${config.public.siteUrl}${redirect}`;
 
-  return `${config.public.apiBaseUrl}auth/init?url=${fullURL}&provider=${provider}`;
+  return `${config.public.apiBaseUrl}auth/init?provider=${provider}&url=${fullURL}`;
 };
 
 export const removeAuthProvider = async (provider) => {


### PR DESCRIPTION
Resolves an issue where the frontend generated URLs without provider property when there is a frontend redirect uri. Without the provider, labrinth defaults to GitHub. My fix is shitty, but I didn't want to bother with URL encoding.

Fixes #2884