### PR TITLE
feat(frontend): show date of user join

### DIFF
--- a/apps/frontend/src/pages/user/[id].vue
+++ b/apps/frontend/src/pages/user/[id].vue
@@ -36,13 +36,13 @@
               downloads
             </div>
             <div
-              class="flex items-center gap-2 font-semibold"
               v-tooltip="
                 formatMessage(commonMessages.dateAtTimeTooltip, {
                   date: new Date(user.created),
                   time: new Date(user.created),
                 })
               "
+              class="flex items-center gap-2 font-semibold"
             >
               <CalendarIcon class="h-6 w-6 text-secondary" />
               Joined

--- a/apps/frontend/src/pages/user/[id].vue
+++ b/apps/frontend/src/pages/user/[id].vue
@@ -35,7 +35,15 @@
               {{ formatCompactNumber(sumDownloads) }}
               downloads
             </div>
-            <div class="flex items-center gap-2 font-semibold">
+            <div
+              class="flex items-center gap-2 font-semibold"
+              v-tooltip="
+                formatMessage(commonMessages.dateAtTimeTooltip, {
+                  date: new Date(user.created),
+                  time: new Date(user.created),
+                })
+              "
+            >
               <CalendarIcon class="h-6 w-6 text-secondary" />
               Joined
               {{ formatRelativeTime(user.created) }}


### PR DESCRIPTION
Shows and formats the date when the user joined, on hover. Stole the code from version date rendering. Can add `cursor-help` if wanted.

Resolves #2243