### PR TITLE
fix(frontend): hide report button on own projects

### DIFF
--- a/apps/frontend/src/pages/[type]/[id].vue
+++ b/apps/frontend/src/pages/[type]/[id].vue
@@ -606,6 +606,7 @@
                       auth.user ? reportProject(project.id) : navigateTo('/auth/sign-in'),
                     color: 'red',
                     hoverOnly: true,
+                    shown: !currentMember,
                   },
                   { id: 'copy-id', action: () => copyId() },
                 ]"

--- a/apps/frontend/src/pages/[type]/[id]/version/[version].vue
+++ b/apps/frontend/src/pages/[type]/[id]/version/[version].vue
@@ -158,7 +158,7 @@
             Report
           </nuxt-link>
         </ButtonStyled>
-        <ButtonStyled v-else>
+        <ButtonStyled v-else-if="!currentMember">
           <button @click="() => reportVersion(version.id)">
             <ReportIcon aria-hidden="true" />
             Report

--- a/apps/frontend/src/pages/[type]/[id]/versions.vue
+++ b/apps/frontend/src/pages/[type]/[id]/versions.vue
@@ -205,6 +205,7 @@
                     color: 'red',
                     hoverFilled: true,
                     action: () => reportVersion(version.id),
+                    shown: !currentMember,
                   },
                   { divider: true, shown: currentMember },
                   {

--- a/apps/frontend/src/pages/user/[id].vue
+++ b/apps/frontend/src/pages/user/[id].vue
@@ -63,6 +63,7 @@
                     action: () => reportUser(user.id),
                     color: 'red',
                     hoverOnly: true,
+                    shown: auth.user?.id !== user.id,
                   },
                   { id: 'copy-id', action: () => copyId() },
                 ]"


### PR DESCRIPTION
Hides the report button from your own projects, versions, and user. There might be some still showing in the app, but I am not comfortable developing for it yet.

Places updated:
- Project view overflow menu
- Version list overflow menu
- Version view
- User view

Resolves #1381