### PR TITLE
fix(labrinth): validate PAT name

### DIFF
--- a/apps/labrinth/src/routes/internal/pats.rs
+++ b/apps/labrinth/src/routes/internal/pats.rs
@@ -165,6 +165,10 @@ pub async fn edit_pat(
     redis: Data<RedisPool>,
     session_queue: Data<AuthQueue>,
 ) -> Result<HttpResponse, ApiError> {
+    info.0.validate().map_err(|err| {
+        ApiError::InvalidInput(validation_errors_to_string(err, None))
+    })?;
+
     let user = get_user_from_headers(
         &req,
         &**pool,


### PR DESCRIPTION
Uses the macros provided by validator to validate the name. The name already had a macro, but `.validate()` was not called. Stole the snippet from PAT creation route.

Resolves #1549