### PR TITLE
fix(frontend): project search page with trailing slash

### DIFF
--- a/apps/frontend/src/pages/search/[searchProjectType].vue
+++ b/apps/frontend/src/pages/search/[searchProjectType].vue
@@ -473,7 +473,7 @@ async function serverInstall(project) {
 }
 
 projectType.value = tags.value.projectTypes.find(
-  (x) => x.id === route.path.substring(1, route.path.length - 1),
+  (x) => x.id === route.path.replaceAll(/^\/|s\/?$/g, ""), // Removes prefix `/` and suffixes `s` and `s/`
 );
 
 const noLoad = ref(false);


### PR DESCRIPTION
Replaces the substring operation to find project type with a regex. The regex is a bit complex, so I added a comment explaining it.

Resolves #1382