### PR TITLE
fix(frontend): internal server error on 404

### DIFF
--- a/apps/frontend/src/layouts/default.vue
+++ b/apps/frontend/src/layouts/default.vue
@@ -203,7 +203,7 @@
 
           <ButtonStyled
             type="transparent"
-            :highlighted="route.name.startsWith('servers')"
+            :highlighted="route.name?.startsWith('servers')"
             :highlighted-style="
               route.name === 'servers' ? 'main-nav-primary' : 'main-nav-secondary'
             "


### PR DESCRIPTION
`route.name` isn't necessarily defined, so this may cause an exception leading to 500 internal server error.

Resolves #2989