### PR TITLE
fix: issue templates used outdated label names

### DIFF
--- a/.github/ISSUE_TEMPLATE/2-web-bug.yml
+++ b/.github/ISSUE_TEMPLATE/2-web-bug.yml
@@ -1,6 +1,6 @@
 name: 🌐 Website bug (modrinth.com)
 description: Report an issue on the Modrinth website.
-labels: [bug, frontend]
+labels: [bug, web]
 body:
   - type: checkboxes
     attributes:

--- a/.github/ISSUE_TEMPLATE/3-api-bug.yml
+++ b/.github/ISSUE_TEMPLATE/3-api-bug.yml
@@ -1,6 +1,6 @@
 name: 🛠️ API issue (api.modrinth.com)
 description: Report an issue regarding the Modrinth API.
-labels: [bug, api]
+labels: [bug, backend]
 body:
   - type: checkboxes
     attributes:


### PR DESCRIPTION
The issue labels seem to have been renamed without updating the issue templates, resulting in those labels not being applied.

`api` → `backend`
`frontend` → `web`