### PR TITLE
fix(frontend): ignore case in collection search for followed

### DIFF
--- a/apps/frontend/src/pages/dashboard/collections.vue
+++ b/apps/frontend/src/pages/dashboard/collections.vue
@@ -22,7 +22,7 @@
     </div>
     <div class="collections-grid">
       <nuxt-link
-        v-if="'followed projects'.includes(filterQuery)"
+        v-if="'followed projects'.includes(filterQuery.toLowerCase())"
         :to="`/collection/following`"
         class="universal-card recessed collection"
       >
@@ -94,7 +94,7 @@
   </div>
 </template>
 <script setup>
-import { BoxIcon, SearchIcon, XIcon, PlusIcon, LinkIcon, LockIcon } from "@modrinth/assets";
+import { BoxIcon, LinkIcon, LockIcon, PlusIcon, SearchIcon, XIcon } from "@modrinth/assets";
 import { Avatar, Button } from "@modrinth/ui";
 import WorldIcon from "~/assets/images/utils/world.svg?component";
 import CollectionCreateModal from "~/components/ui/CollectionCreateModal.vue";

--- a/apps/frontend/src/pages/dashboard/collections.vue
+++ b/apps/frontend/src/pages/dashboard/collections.vue
@@ -94,7 +94,7 @@
   </div>
 </template>
 <script setup>
-import { BoxIcon, LinkIcon, LockIcon, PlusIcon, SearchIcon, XIcon } from "@modrinth/assets";
+import { BoxIcon, SearchIcon, XIcon, PlusIcon, LinkIcon, LockIcon } from "@modrinth/assets";
 import { Avatar, Button } from "@modrinth/ui";
 import WorldIcon from "~/assets/images/utils/world.svg?component";
 import CollectionCreateModal from "~/components/ui/CollectionCreateModal.vue";


### PR DESCRIPTION
When searching for collections, the casing will normally be ignored. The item for "Followed Projects" will be removed if using capitalized characters though. This is especially confusing since it's titled with partially capital letters.

Resolves modrinth/code#1370