### PR TITLE
fix: Change platform button leads to wrong page

### DIFF
--- a/apps/frontend/src/pages/servers/manage/[id]/content/index.vue
+++ b/apps/frontend/src/pages/servers/manage/[id]/content/index.vue
@@ -265,7 +265,7 @@
           </ButtonStyled>
           <div>or</div>
           <ButtonStyled class="mt-8">
-            <NuxtLink :to="`/${type}s?sid=${props.server.serverId}`">
+            <NuxtLink :to="`/servers/manage/${props.server.serverId}/options/loader`">
               <WrenchIcon />
               Change platform
             </NuxtLink>


### PR DESCRIPTION
The "Change platform" Button on a Vanilla Server, currently leads to the wrong page, this PR fixes it to instead redirect to the Choose Loader page in the Options