### PR TITLE
Make the update checker work for non-mods

### DIFF
--- a/packages/app-lib/src/api/pack/install_mrpack.rs
+++ b/packages/app-lib/src/api/pack/install_mrpack.rs
@@ -13,13 +13,13 @@ use crate::util::io;
 use crate::{profile, State};
 use async_zip::base::read::seek::ZipFileReader;
 
-use std::io::Cursor;
-use std::path::{Component, PathBuf};
-
 use super::install_from::{
     generate_pack_from_file, generate_pack_from_version_id, CreatePack,
     CreatePackLocation, PackFormat,
 };
+use crate::data::ProjectType;
+use std::io::Cursor;
+use std::path::{Component, PathBuf};
 
 /// Install a pack
 /// Wrapper around install_pack_files that generates a pack creation description, and
@@ -189,6 +189,7 @@ pub async fn install_zipped_mrpack_files(
                                 .hashes
                                 .get(&PackFileHash::Sha1)
                                 .map(|x| &**x),
+                            ProjectType::get_from_parent_folder(&path),
                             &state.pool,
                         )
                         .await?;
@@ -247,6 +248,7 @@ pub async fn install_zipped_mrpack_files(
                         &profile_path,
                         &new_path.to_string_lossy(),
                         None,
+                        ProjectType::get_from_parent_folder(&new_path),
                         &state.pool,
                     )
                     .await?;

--- a/packages/app-lib/src/state/legacy_converter.rs
+++ b/packages/app-lib/src/state/legacy_converter.rs
@@ -1,4 +1,4 @@
-use crate::data::{Dependency, User, Version};
+use crate::data::{Dependency, ProjectType, User, Version};
 use crate::jre::check_jre;
 use crate::prelude::ModLoader;
 use crate::state;
@@ -226,6 +226,7 @@ where
                                             path: file_name,
                                             size: metadata.len(),
                                             hash: sha1.clone(),
+                                            project_type: ProjectType::get_from_parent_folder(&full_path),
                                         },
                                     ));
                                 }
@@ -249,9 +250,9 @@ where
                                                     .metadata
                                                     .game_version
                                                     .clone(),
-                                                loader: mod_loader
+                                                loaders: vec![mod_loader
                                                     .as_str()
-                                                    .to_string(),
+                                                    .to_string()],
                                                 update_version_id:
                                                     update_version.id.clone(),
                                             },

--- a/packages/app-lib/src/state/profiles.rs
+++ b/packages/app-lib/src/state/profiles.rs
@@ -176,7 +176,7 @@ impl ProjectType {
         }
     }
 
-    pub fn get_from_parent_folder(path: &PathBuf) -> Option<Self> {
+    pub fn get_from_parent_folder(path: &Path) -> Option<Self> {
         // Get parent folder
         let path = path.parent()?.file_name()?;
         match path.to_str()? {

--- a/packages/app-lib/src/state/profiles.rs
+++ b/packages/app-lib/src/state/profiles.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use sqlx::SqlitePool;
 use std::convert::TryFrom;
 use std::convert::TryInto;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 // Represent a Minecraft instance.
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/packages/app-lib/src/state/profiles.rs
+++ b/packages/app-lib/src/state/profiles.rs
@@ -146,7 +146,7 @@ pub struct FileMetadata {
     pub version_id: String,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, Copy)]
+#[derive(Serialize, Deserialize, Clone, Debug, Copy, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum ProjectType {
     Mod,
@@ -604,6 +604,7 @@ impl Profile {
                             x.hash,
                             // TODO: Maybe deduplicate this code? But where to put the function?
                             x.project_type
+                                .filter(|x| *x != ProjectType::Mod)
                                 .map(|x| x.get_loaders().join("+"))
                                 .unwrap_or_else(|| profile
                                     .loader
@@ -710,6 +711,7 @@ impl Profile {
                     "{}-{}-{}",
                     x.hash,
                     x.project_type
+                        .filter(|x| *x != ProjectType::Mod)
                         .map(|x| x.get_loaders().join("+"))
                         .unwrap_or_else(|| self.loader.as_str().to_string()),
                     self.game_version


### PR DESCRIPTION
This works by ignoring the profile loader for the non-mods and instead using a set of loaders defined by the file type.

Fixes #1057