### PR TITLE
Change wording of default creator bio

### DIFF
--- a/apps/frontend/src/pages/user/[id].vue
+++ b/apps/frontend/src/pages/user/[id].vue
@@ -17,7 +17,7 @@
                 ? user.bio
                 : projects.length === 0
                   ? "A Modrinth user."
-                  : "A Modrinth creator."
+                  : "Creator on Modrinth."
             }}
           </template>
           <template #stats>


### PR DESCRIPTION
Default creator bio "A Modrinth creator." may be confusing and looks like it is creator of Modrinth itself. I think "Creator on Modrinth." describes it better