### PR TITLE
fix(frontend): Properly handle empty version list on `version/latest`

### DIFF
--- a/apps/frontend/src/pages/[type]/[id]/version/[version].vue
+++ b/apps/frontend/src/pages/[type]/[id]/version/[version].vue
@@ -821,6 +821,13 @@ export default defineNuxtComponent({
       if (route.query.version) {
         versionList = versionList.filter((x) => x.game_versions.includes(route.query.version));
       }
+      if (versionList.length === 0) {
+        throw createError({
+          fatal: true,
+          statusCode: 404,
+          message: "No version matches the filters",
+        });
+      }
       version = versionList.reduce((a, b) => (a.date_published > b.date_published ? a : b));
     } else {
       version = props.versions.find((x) => x.id === route.params.version);


### PR DESCRIPTION
When using `version/latest` with filters that lead to no mod version the page will result in an error page, due to an exception when trying to reduce an empty array, this adds a 404 page when no version is found matching the filters

Example: https://modrinth.com/mod/jei/version/latest?version=1.22&loader=fabric