### PR TITLE
feat(frontend): Automatically open download modal when filter queries are present (on the main mod page)

### DIFF
--- a/apps/frontend/src/pages/[type]/[id].vue
+++ b/apps/frontend/src/pages/[type]/[id].vue
@@ -1247,17 +1247,21 @@ if (!route.name.startsWith("type-id-settings")) {
 
 const onUserCollectProject = useClientTry(userCollectProject);
 
+const {version, loader} = route.query;
+if (version !== undefined && project.value.game_versions.includes(version)) {
+  userSelectedGameVersion.value = version;
+}
+if (loader !== undefined && project.value.loaders.includes(loader)) {
+  userSelectedPlatform.value = loader;
+}
+
 watch(downloadModal, (modal) => {
   if (!modal) return;
 
-  const {version, loader} = route.query;
-  if (!version && !loader) return;
-  if (version && !project.value.game_versions.includes(version)) return;
-  if (loader && !project.value.loaders.includes(loader)) return;
-
-  if (version) userSelectedGameVersion.value = version;
-  if (loader) userSelectedPlatform.value = loader;
-  modal.show();
+  // route.hash returns everything in the hash string, including the # itself
+  if (route.hash === "#download") {
+    modal.show();
+  }
 })
 
 async function setProcessing() {

--- a/apps/frontend/src/pages/[type]/[id].vue
+++ b/apps/frontend/src/pages/[type]/[id].vue
@@ -1247,6 +1247,19 @@ if (!route.name.startsWith("type-id-settings")) {
 
 const onUserCollectProject = useClientTry(userCollectProject);
 
+watch(downloadModal, (modal) => {
+  if (!modal) return;
+
+  const {version, loader} = route.query;
+  if (!version && !loader) return;
+  if (version && !project.value.game_versions.includes(version)) return;
+  if (loader && !project.value.loaders.includes(loader)) return;
+
+  if (version) userSelectedGameVersion.value = version;
+  if (loader) userSelectedPlatform.value = loader;
+  modal.show();
+})
+
 async function setProcessing() {
   startLoading();
 


### PR DESCRIPTION
Adds an option to open the download modal with a preselected version and loader.

This is a QoL, while `https://modrinth.com/[type]/[id]/version/latest?version=<game_version>&loader=<loader>`  exists, the download modal has a much more intuitive and friendlier UI, showing the latest release, beta and alpha separate and offering a link to the Modrinth App

The link format is similar to the existing alternative 
`https://modrinth.com/[type]/[id]?version=<game_version>&loader=<loader>`
* `version` is the game version
* `loader` is the platform
Both are optional, with at least one being required to open the modal on page load
If version or loader are not a valid option for the project the modal will not open