### PR TITLE
feat(frontend): Add filter query and download hash to the url during donwload modal use

### DIFF
--- a/apps/frontend/src/pages/[type]/[id].vue
+++ b/apps/frontend/src/pages/[type]/[id].vue
@@ -1247,17 +1247,21 @@ if (!route.name.startsWith("type-id-settings")) {
 
 const onUserCollectProject = useClientTry(userCollectProject);
 
+const {version, loader} = route.query;
+if (version !== undefined && project.value.game_versions.includes(version)) {
+  userSelectedGameVersion.value = version;
+}
+if (loader !== undefined && project.value.loaders.includes(loader)) {
+  userSelectedPlatform.value = loader;
+}
+
 watch(downloadModal, (modal) => {
   if (!modal) return;
 
-  const {version, loader} = route.query;
-  if (!version && !loader) return;
-  if (version && !project.value.game_versions.includes(version)) return;
-  if (loader && !project.value.loaders.includes(loader)) return;
-
-  if (version) userSelectedGameVersion.value = version;
-  if (loader) userSelectedPlatform.value = loader;
-  modal.show();
+  // route.hash returns everything in the hash string, including the # itself
+  if (route.hash === "#download") {
+    modal.show();
+  }
 })
 
 async function setProcessing() {

--- a/apps/frontend/src/pages/[type]/[id].vue
+++ b/apps/frontend/src/pages/[type]/[id].vue
@@ -1247,6 +1247,19 @@ if (!route.name.startsWith("type-id-settings")) {
 
 const onUserCollectProject = useClientTry(userCollectProject);
 
+watch(downloadModal, (modal) => {
+  if (!modal) return;
+
+  const {version, loader} = route.query;
+  if (!version && !loader) return;
+  if (version && !project.value.game_versions.includes(version)) return;
+  if (loader && !project.value.loaders.includes(loader)) return;
+
+  if (version) userSelectedGameVersion.value = version;
+  if (loader) userSelectedPlatform.value = loader;
+  modal.show();
+})
+
 async function setProcessing() {
   startLoading();
 

--- a/apps/frontend/src/pages/[type]/[id].vue
+++ b/apps/frontend/src/pages/[type]/[id].vue
@@ -184,7 +184,19 @@
         </div>
       </div>
     </div>
-    <NewModal ref="downloadModal">
+    <NewModal
+      ref="downloadModal"
+      @on-show="
+        () => {
+          navigateTo({ query: route.query, hash: '#download' });
+        }
+      "
+      @on-hide="
+        () => {
+          navigateTo({ query: route.query, hash: '' });
+        }
+      "
+    >
       <template #title>
         <Avatar :src="project.icon_url" :alt="project.title" class="icon" size="32px" />
         <div class="truncate text-lg font-extrabold text-contrast">
@@ -299,10 +311,20 @@
                     @click="
                       () => {
                         userSelectedGameVersion = version;
+
                         gameVersionAccordion.close();
                         if (!currentPlatform && platformAccordion) {
                           platformAccordion.open();
                         }
+
+                        navigateTo({
+                          query: {
+                            ...route.query,
+                            ...(userSelectedGameVersion && { version: userSelectedGameVersion }),
+                            ...(userSelectedPlatform && { loader: userSelectedPlatform }),
+                          },
+                          hash: route.hash,
+                        });
                       }
                     "
                   >
@@ -379,6 +401,15 @@
                         if (!currentGameVersion && gameVersionAccordion) {
                           gameVersionAccordion.open();
                         }
+
+                        navigateTo({
+                          query: {
+                            ...route.query,
+                            ...(userSelectedGameVersion && { version: userSelectedGameVersion }),
+                            ...(userSelectedPlatform && { loader: userSelectedPlatform }),
+                          },
+                          hash: route.hash,
+                        });
                       }
                     "
                   >
@@ -827,6 +858,7 @@ import {
   ProjectBackgroundGradient,
 } from "@modrinth/ui";
 import { formatCategory, isRejected, isStaff, isUnderReview, renderString } from "@modrinth/utils";
+import { navigateTo } from "#app";
 import dayjs from "dayjs";
 import VersionSummary from "@modrinth/ui/src/components/version/VersionSummary.vue";
 import Badge from "~/components/ui/Badge.vue";
@@ -1247,7 +1279,7 @@ if (!route.name.startsWith("type-id-settings")) {
 
 const onUserCollectProject = useClientTry(userCollectProject);
 
-const {version, loader} = route.query;
+const { version, loader } = route.query;
 if (version !== undefined && project.value.game_versions.includes(version)) {
   userSelectedGameVersion.value = version;
 }
@@ -1262,7 +1294,7 @@ watch(downloadModal, (modal) => {
   if (route.hash === "#download") {
     modal.show();
   }
-})
+});
 
 async function setProcessing() {
   startLoading();

--- a/packages/ui/src/components/modal/NewModal.vue
+++ b/packages/ui/src/components/modal/NewModal.vue
@@ -60,8 +60,6 @@ const props = withDefaults(
     closeOnClickOutside?: boolean
     warnOnClose?: boolean
     header?: string
-    onHide?: () => void
-    onShow?: () => void
   }>(),
   {
     type: true,
@@ -70,11 +68,11 @@ const props = withDefaults(
     closeOnClickOutside: true,
     closeOnEsc: true,
     warnOnClose: false,
-    header: null,
-    onHide: () => {},
-    onShow: () => {},
+    header: undefined
   },
 )
+
+const emit = defineEmits(["onShow", "onHide"]);
 
 const open = ref(false)
 const visible = ref(false)
@@ -90,7 +88,7 @@ function addBodyPadding() {
 }
 
 function show(event?: MouseEvent) {
-  props.onShow()
+  emit("onShow")
   open.value = true
 
   addBodyPadding()
@@ -109,7 +107,7 @@ function show(event?: MouseEvent) {
 }
 
 function hide() {
-  props.onHide()
+  emit("onHide");
   visible.value = false
   document.body.style.overflow = ''
   document.body.style.paddingRight = ''


### PR DESCRIPTION
This is a followup to #3133, adding a feature that will update the URL on the browser to contain the query filters and the download modal hash added by the PR