### PR TITLE
fix(frontend): add correct styling class to button

### DIFF
--- a/apps/frontend/src/pages/[type]/[id]/version/[version].vue
+++ b/apps/frontend/src/pages/[type]/[id]/version/[version].vue
@@ -381,6 +381,7 @@
         />
         <ButtonStyled v-if="isEditing">
           <button
+            class="raised-button"
             :disabled="primaryFile.hashes.sha1 === file.hashes.sha1"
             @click="
               () => {


### PR DESCRIPTION
This PR fixes a missing class on a button in the edit version page, it then ensures that the styling alings with the rest of the file containers.

## Media

### After
<img width="805" alt="image" src="https://github.com/user-attachments/assets/9a282781-f8dc-42f0-a23e-cbb6866fcaf6" />


### Before
<img width="814" alt="image" src="https://github.com/user-attachments/assets/6bf2baf2-2db0-401c-8306-d873b7598fe7" />
