### PR TITLE
fix(labrinth): cors headers on ratelimited

### DIFF
--- a/apps/labrinth/src/util/cors.rs
+++ b/apps/labrinth/src/util/cors.rs
@@ -1,5 +1,6 @@
 use actix_cors::Cors;
 
+// Updating this? Remember to update the ratelimit CORS too!
 pub fn default_cors() -> Cors {
     Cors::default()
         .allow_any_origin()

--- a/apps/labrinth/src/util/ratelimit.rs
+++ b/apps/labrinth/src/util/ratelimit.rs
@@ -168,6 +168,15 @@ where
                         wait_time.as_secs().into(),
                     );
 
+                    // TODO: Sentralize CORS in the CORS util.
+                    headers.insert(
+                        actix_web::http::header::HeaderName::from_str(
+                            "Access-Control-Allow-Origin",
+                        )
+                        .unwrap(),
+                        "*".parse().unwrap(),
+                    );
+
                     Box::pin(async {
                         Ok(req.into_response(response.map_into_right_body()))
                     })


### PR DESCRIPTION
Annoyed that this has been unresolved for so long, so made a hotfix-ish. Can probably make a more clean solution if `actix-cors` exposes a function to get the headers. Hoping for a swift review 🚀 

Fixes #2591
Fixes #2529