### PR TITLE
feat: git attributes to enforce LF endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
I noticed that the `.vscode` folder says LF endings should be used. However, I still regularily see CRLF. To fix this I've added a `.gitattributes` file which makes git convert endings to LF.