### PR TITLE
License UI redesign + composition API

### DIFF
--- a/apps/frontend/src/pages/[type]/[id]/settings/license.vue
+++ b/apps/frontend/src/pages/[type]/[id]/settings/license.vue
@@ -26,7 +26,7 @@
           </span>
         </label>
 
-        <div class="input-stack w-1/2">
+        <div class="w-1/2">
           <DropdownSelect
             v-model="license"
             name="License selector"
@@ -34,15 +34,27 @@
             :display-name="(chosen: BuiltinLicense) => chosen.friendly"
             placeholder="Select license..."
           />
-
-          <Checkbox
-            v-model="allowOrLater"
-            :disabled="!hasPermission || !license?.requiresOnlyOrLater"
-            description="Allow later editions of this license"
-          >
-            Allow later editions of this license
-          </Checkbox>
         </div>
+      </div>
+
+      <div class="adjacent-input" v-if="license.requiresOnlyOrLater">
+        <label for="or-later-checkbox">
+          <span class="label__title">Later editions</span>
+          <span class="label__description">
+            The license you selected has an "or later" clause. If you check this box, users may use
+            your project under later editions of the license.
+          </span>
+        </label>
+
+        <Checkbox
+          id="or-later-checkbox"
+          v-model="allowOrLater"
+          :disabled="!hasPermission"
+          description="Allow later editions"
+          class="w-1/2"
+        >
+          Allow later editions
+        </Checkbox>
       </div>
 
       <div class="adjacent-input">

--- a/apps/frontend/src/pages/[type]/[id]/settings/license.vue
+++ b/apps/frontend/src/pages/[type]/[id]/settings/license.vue
@@ -7,7 +7,12 @@
         {{ formatProjectType(project.project_type).toLowerCase() }}. You may choose one from our
         list or provide a custom license. You may also provide a custom URL to your chosen license;
         otherwise, the license text will be displayed. See our
-        <a href="https://blog.modrinth.com/licensing-guide/" target="_blank" rel="noopener" class="text-link">
+        <a
+          href="https://blog.modrinth.com/licensing-guide/"
+          target="_blank"
+          rel="noopener"
+          class="text-link"
+        >
           licensing guide
         </a>
         for more information.
@@ -22,12 +27,22 @@
         </label>
 
         <div class="input-stack w-1/2">
-          <DropdownSelect v-model="license" name="License selector" :options="builtinLicenses"
-            :display-name="(option: BuiltinLicense) => builtinLicenses.find((license) => license.short === option.short)?.friendly"
-            placeholder="Select license..." />
+          <DropdownSelect
+            v-model="license"
+            name="License selector"
+            :options="builtinLicenses"
+            :display-name="
+              (option: BuiltinLicense) =>
+                builtinLicenses.find((license) => license.short === option.short)?.friendly
+            "
+            placeholder="Select license..."
+          />
 
-          <Checkbox v-model="allowOrLater" :disabled="!hasPermission || !license?.requiresOnlyOrLater"
-            description="Allow later editions of this license">
+          <Checkbox
+            v-model="allowOrLater"
+            :disabled="!hasPermission || !license?.requiresOnlyOrLater"
+            description="Allow later editions of this license"
+          >
             Allow later editions of this license
           </Checkbox>
         </div>
@@ -47,9 +62,15 @@
         </label>
 
         <div class="w-1/2">
-          <input id="license-url" v-model="licenseUrl" type="url" maxlength="2048"
+          <input
+            id="license-url"
+            v-model="licenseUrl"
+            type="url"
+            maxlength="2048"
             :placeholder="license?.friendly !== 'Custom' ? `License URL (optional)` : `License URL`"
-            :disabled="!hasPermission || licenseId === 'LicenseRef-Unknown'" class="w-full" />
+            :disabled="!hasPermission || licenseId === 'LicenseRef-Unknown'"
+            class="w-full"
+          />
         </div>
       </div>
 
@@ -59,32 +80,58 @@
           <span class="label__description">
             If your license does not have an offical
             <a href="https://spdx.org/licenses/" target="_blank" rel="noopener" class="text-link">
-              SPDX license identifier</a>, check the box and enter the name of the license instead.
+              SPDX license identifier</a
+            >, check the box and enter the name of the license instead.
           </span>
         </label>
         <label for="license-name" v-else>
           <span class="label__title">License name</span>
-          <span class="label__description">The full name of the license. If the license has a SPDX identifier, please
-            uncheck the
-            checkbox and use the identifier instead.</span>
+          <span class="label__description"
+            >The full name of the license. If the license has a SPDX identifier, please uncheck the
+            checkbox and use the identifier instead.</span
+          >
         </label>
 
         <div class="input-stack w-1/2">
-          <input v-if="!nonSpdxLicense" v-model="license.short" id="license-spdx" class="w-full" type="text"
-            maxlength="128" placeholder="SPDX identifier" :disabled="!hasPermission" />
-          <input v-else v-model="license.short" id="license-name" class="w-full" type="text" maxlength="128"
-            placeholder="License name" :disabled="!hasPermission" />
+          <input
+            v-if="!nonSpdxLicense"
+            v-model="license.short"
+            id="license-spdx"
+            class="w-full"
+            type="text"
+            maxlength="128"
+            placeholder="SPDX identifier"
+            :disabled="!hasPermission"
+          />
+          <input
+            v-else
+            v-model="license.short"
+            id="license-name"
+            class="w-full"
+            type="text"
+            maxlength="128"
+            placeholder="License name"
+            :disabled="!hasPermission"
+          />
 
-          <Checkbox v-if="license?.friendly === 'Custom'" v-model="nonSpdxLicense" :disabled="!hasPermission"
-            description="License does not have a SPDX identifier">
+          <Checkbox
+            v-if="license?.friendly === 'Custom'"
+            v-model="nonSpdxLicense"
+            :disabled="!hasPermission"
+            description="License does not have a SPDX identifier"
+          >
             License does not have a SPDX identifier
           </Checkbox>
         </div>
       </div>
 
       <div class="input-stack">
-        <button type="button" class="iconified-button brand-button" :disabled="!hasChanges || !license.friendly"
-          @click="saveChanges()">
+        <button
+          type="button"
+          class="iconified-button brand-button"
+          :disabled="!hasChanges || !license.friendly"
+          @click="saveChanges()"
+        >
           <SaveIcon />
           Save changes
         </button>
@@ -95,7 +142,14 @@
 
 <script setup lang="ts">
 import { Checkbox, DropdownSelect } from "@modrinth/ui";
-import { TeamMemberPermission, builtinLicenses, formatProjectType, type BuiltinLicense, type Project, type TeamMember } from "@modrinth/utils";
+import {
+  TeamMemberPermission,
+  builtinLicenses,
+  formatProjectType,
+  type BuiltinLicense,
+  type Project,
+  type TeamMember,
+} from "@modrinth/utils";
 import { computed, ref, shallowRef, type ShallowRef } from "vue";
 import SaveIcon from "~/assets/images/utils/save.svg?component";
 
@@ -142,7 +196,7 @@ if (oldLicenseId === "LicenseRef-Unknown") {
 
 const hasPermission = computed(() => {
   return (props.currentMember?.permissions ?? 0) & TeamMemberPermission.EDIT_DETAILS;
-})
+});
 
 const licenseId = computed(() => {
   let id = "";
@@ -165,7 +219,7 @@ const licenseId = computed(() => {
   }
 
   return id;
-})
+});
 
 const patchRequestPayload = computed(() => {
   const payload: {
@@ -186,7 +240,7 @@ const patchRequestPayload = computed(() => {
 
 const hasChanges = computed(() => {
   return Object.keys(patchRequestPayload.value).length > 0;
-})
+});
 
 function saveChanges() {
   if (hasChanges.value) {

--- a/apps/frontend/src/pages/[type]/[id]/settings/license.vue
+++ b/apps/frontend/src/pages/[type]/[id]/settings/license.vue
@@ -55,9 +55,13 @@
       <div class="adjacent-input">
         <label for="license-url">
           <span class="label__title">License URL</span>
-          <span class="label__description">
+          <span class="label__description" v-if="license?.friendly !== 'Custom'">
             The web location of the full license text. If you don't provide a link, the license text
             will be displayed instead.
+          </span>
+          <span class="label__description" v-else>
+            The web location of the full license text. You have to provide a link since this is a
+            custom license.
           </span>
         </label>
 
@@ -67,7 +71,7 @@
             v-model="licenseUrl"
             type="url"
             maxlength="2048"
-            placeholder="License URL (optional)"
+            :placeholder="license?.friendly !== 'Custom' ? `License URL (optional)` : `License URL`"
             :disabled="!hasPermission || licenseId === 'LicenseRef-Unknown'"
             class="w-full"
           />

--- a/apps/frontend/src/pages/[type]/[id]/settings/license.vue
+++ b/apps/frontend/src/pages/[type]/[id]/settings/license.vue
@@ -1,38 +1,32 @@
 <template>
   <div>
     <section class="universal-card">
+      <h2 class="label__title size-card-header">License</h2>
+      <p class="label__description">
+        It is important to choose a proper license for your
+        {{ $formatProjectType(project.project_type).toLowerCase() }}. You may choose one from our
+        list or provide a custom license. You may also provide a custom URL to your chosen license;
+        otherwise, the license text will be displayed. See our
+        <a
+          href="https://blog.modrinth.com/licensing-guide/"
+          target="_blank"
+          rel="noopener"
+          class="text-link"
+        >
+          licensing guide
+        </a>
+        for more information.
+      </p>
+
       <div class="adjacent-input">
         <label for="license-multiselect">
-          <span class="label__title size-card-header">License</span>
+          <span class="label__title">Select a license</span>
           <span class="label__description">
-            It is very important to choose a proper license for your
-            {{ $formatProjectType(project.project_type).toLowerCase() }}. You may choose one from
-            our list or provide a custom license. You may also provide a custom URL to your chosen
-            license; otherwise, the license text will be displayed.
-            <span v-if="license && license.friendly === 'Custom'" class="label__subdescription">
-              Enter a valid
-              <a href="https://spdx.org/licenses/" target="_blank" rel="noopener" class="text-link">
-                SPDX license identifier</a
-              >
-              in the marked area. If your license does not have a SPDX identifier (for example, if
-              you created the license yourself or if the license is Minecraft-specific), simply
-              check the box and enter the name of the license instead.
-            </span>
-            <span class="label__subdescription">
-              Confused? See our
-              <a
-                href="https://blog.modrinth.com/licensing-guide/"
-                target="_blank"
-                rel="noopener"
-                class="text-link"
-              >
-                licensing guide</a
-              >
-              for more information.
-            </span>
+            How users are and aren't allowed to use your project.
           </span>
         </label>
-        <div class="input-stack">
+
+        <div class="input-stack w-1/2">
           <Multiselect
             id="license-multiselect"
             v-model="license"
@@ -49,13 +43,83 @@
             :disabled="!hasPermission"
           />
           <Checkbox
-            v-if="license?.requiresOnlyOrLater"
             v-model="allowOrLater"
-            :disabled="!hasPermission"
+            :disabled="!hasPermission || !license?.requiresOnlyOrLater"
             description="Allow later editions of this license"
           >
             Allow later editions of this license
           </Checkbox>
+        </div>
+      </div>
+
+      <div class="adjacent-input">
+        <label for="license-url">
+          <span class="label__title">License URL</span>
+          <span class="label__description">
+            The web location of the full license text. If you don't provide a link, the license text
+            will be displayed instead.
+          </span>
+        </label>
+
+        <div class="w-1/2">
+          <input
+            id="license-url"
+            v-model="licenseUrl"
+            type="url"
+            maxlength="2048"
+            placeholder="License URL (optional)"
+            :disabled="!hasPermission || licenseId === 'LicenseRef-Unknown'"
+            class="w-full"
+          />
+        </div>
+      </div>
+
+      <div class="adjacent-input" v-if="license?.friendly === 'Custom'">
+        <label for="license-spdx" v-if="!nonSpdxLicense">
+          <span class="label__title">SPDX identifier</span>
+          <span class="label__description">
+            If your license does not have an offical
+            <a href="https://spdx.org/licenses/" target="_blank" rel="noopener" class="text-link">
+              SPDX license identifier</a
+            >, check the box and enter the name of the license instead.
+          </span>
+        </label>
+        <label for="license-name" v-else>
+          <span class="label__title">License name</span>
+          <span class="label__description"
+            >The full name of the license. If the license has a SPDX identifier, please uncheck the
+            checkbox and use the identifier instead.</span
+          >
+        </label>
+
+        <div class="input-stack w-1/2">
+          <input
+            v-if="!nonSpdxLicense"
+            v-model="license.short"
+            id="license-spdx"
+            class="w-full"
+            type="text"
+            maxlength="128"
+            placeholder="SPDX identifier"
+            :class="{
+              'known-error': license.short === '' && showKnownErrors,
+            }"
+            :disabled="!hasPermission"
+          />
+          <input
+            v-else
+            v-model="license.short"
+            id="license-name"
+            class="w-full"
+            type="text"
+            maxlength="128"
+            placeholder="License name"
+            :class="{
+              'known-error': license.short === '' && showKnownErrors,
+            }"
+            :disabled="!hasPermission"
+          />
+
           <Checkbox
             v-if="license?.friendly === 'Custom'"
             v-model="nonSpdxLicense"
@@ -64,26 +128,9 @@
           >
             License does not have a SPDX identifier
           </Checkbox>
-          <input
-            v-if="license?.friendly === 'Custom'"
-            v-model="license.short"
-            type="text"
-            maxlength="2048"
-            :placeholder="nonSpdxLicense ? 'License name' : 'SPDX identifier'"
-            :class="{
-              'known-error': license.short === '' && showKnownErrors,
-            }"
-            :disabled="!hasPermission"
-          />
-          <input
-            v-model="licenseUrl"
-            type="url"
-            maxlength="2048"
-            placeholder="License URL (optional)"
-            :disabled="!hasPermission || licenseId === 'LicenseRef-Unknown'"
-          />
         </div>
       </div>
+
       <div class="input-stack">
         <button
           type="button"
@@ -101,8 +148,8 @@
 
 <script>
 import Multiselect from "vue-multiselect";
-import Checkbox from "~/components/ui/Checkbox";
 import SaveIcon from "~/assets/images/utils/save.svg?component";
+import Checkbox from "~/components/ui/Checkbox";
 
 export default defineNuxtComponent({
   components: {

--- a/apps/frontend/src/pages/[type]/[id]/settings/license.vue
+++ b/apps/frontend/src/pages/[type]/[id]/settings/license.vue
@@ -31,10 +31,7 @@
             v-model="license"
             name="License selector"
             :options="builtinLicenses"
-            :display-name="
-              (option: BuiltinLicense) =>
-                builtinLicenses.find((license) => license.short === option.short)?.friendly
-            "
+            :display-name="(chosen: BuiltinLicense) => chosen.friendly"
             placeholder="Select license..."
           />
 
@@ -129,7 +126,11 @@
         <button
           type="button"
           class="iconified-button brand-button"
-          :disabled="!hasChanges || !license.friendly"
+          :disabled="
+            !hasChanges ||
+            !hasPermission ||
+            (license.friendly === 'Custom' && (license.short === '' || licenseUrl === ''))
+          "
           @click="saveChanges()"
         >
           <SaveIcon />
@@ -150,7 +151,7 @@ import {
   type Project,
   type TeamMember,
 } from "@modrinth/utils";
-import { computed, ref, shallowRef, type ShallowRef } from "vue";
+import { computed, ref, type Ref } from "vue";
 import SaveIcon from "~/assets/images/utils/save.svg?component";
 
 const props = defineProps<{
@@ -160,11 +161,11 @@ const props = defineProps<{
 }>();
 
 const licenseUrl = ref(props.project.license.url);
-const license: ShallowRef<{
+const license: Ref<{
   friendly: string;
   short: string;
   requiresOnlyOrLater?: boolean;
-}> = shallowRef({
+}> = ref({
   friendly: "",
   short: "",
   requiresOnlyOrLater: false,
@@ -243,8 +244,6 @@ const hasChanges = computed(() => {
 });
 
 function saveChanges() {
-  if (hasChanges.value) {
-    props.patchProject(patchRequestPayload.value);
-  }
+  props.patchProject(patchRequestPayload.value);
 }
 </script>

--- a/packages/utils/index.ts
+++ b/packages/utils/index.ts
@@ -1,6 +1,6 @@
 export * from './billing'
 export * from './highlight'
-export * from "./licenses"
+export * from './licenses'
 export * from './parse'
 export * from './projects'
 export * from './types'

--- a/packages/utils/index.ts
+++ b/packages/utils/index.ts
@@ -1,8 +1,8 @@
+export * from './billing'
 export * from './highlight'
+export * from "./licenses"
 export * from './parse'
 export * from './projects'
+export * from './types'
 export * from './users'
 export * from './utils'
-export * from './billing'
-
-export * from './types'

--- a/packages/utils/licenses.ts
+++ b/packages/utils/licenses.ts
@@ -1,72 +1,76 @@
-export interface BuiltinLicense { friendly: string, short: string, requiresOnlyOrLater?: boolean }
+export interface BuiltinLicense {
+  friendly: string
+  short: string
+  requiresOnlyOrLater?: boolean
+}
 
 export const builtinLicenses: BuiltinLicense[] = [
-  { friendly: "Custom", short: "" },
+  { friendly: 'Custom', short: '' },
   {
-    friendly: "All Rights Reserved/No License",
-    short: "All-Rights-Reserved",
+    friendly: 'All Rights Reserved/No License',
+    short: 'All-Rights-Reserved',
   },
-  { friendly: "Apache License 2.0", short: "Apache-2.0" },
+  { friendly: 'Apache License 2.0', short: 'Apache-2.0' },
   {
     friendly: 'BSD 2-Clause "Simplified" License',
-    short: "BSD-2-Clause",
+    short: 'BSD-2-Clause',
   },
   {
     friendly: 'BSD 3-Clause "New" or "Revised" License',
-    short: "BSD-3-Clause",
+    short: 'BSD-3-Clause',
   },
   {
-    friendly: "CC Zero (Public Domain equivalent)",
-    short: "CC0-1.0",
+    friendly: 'CC Zero (Public Domain equivalent)',
+    short: 'CC0-1.0',
   },
-  { friendly: "CC-BY 4.0", short: "CC-BY-4.0" },
+  { friendly: 'CC-BY 4.0', short: 'CC-BY-4.0' },
   {
-    friendly: "CC-BY-SA 4.0",
-    short: "CC-BY-SA-4.0",
-  },
-  {
-    friendly: "CC-BY-NC 4.0",
-    short: "CC-BY-NC-4.0",
+    friendly: 'CC-BY-SA 4.0',
+    short: 'CC-BY-SA-4.0',
   },
   {
-    friendly: "CC-BY-NC-SA 4.0",
-    short: "CC-BY-NC-SA-4.0",
+    friendly: 'CC-BY-NC 4.0',
+    short: 'CC-BY-NC-4.0',
   },
   {
-    friendly: "CC-BY-ND 4.0",
-    short: "CC-BY-ND-4.0",
+    friendly: 'CC-BY-NC-SA 4.0',
+    short: 'CC-BY-NC-SA-4.0',
   },
   {
-    friendly: "CC-BY-NC-ND 4.0",
-    short: "CC-BY-NC-ND-4.0",
+    friendly: 'CC-BY-ND 4.0',
+    short: 'CC-BY-ND-4.0',
   },
   {
-    friendly: "GNU Affero General Public License v3",
-    short: "AGPL-3.0",
+    friendly: 'CC-BY-NC-ND 4.0',
+    short: 'CC-BY-NC-ND-4.0',
+  },
+  {
+    friendly: 'GNU Affero General Public License v3',
+    short: 'AGPL-3.0',
     requiresOnlyOrLater: true,
   },
   {
-    friendly: "GNU Lesser General Public License v2.1",
-    short: "LGPL-2.1",
+    friendly: 'GNU Lesser General Public License v2.1',
+    short: 'LGPL-2.1',
     requiresOnlyOrLater: true,
   },
   {
-    friendly: "GNU Lesser General Public License v3",
-    short: "LGPL-3.0",
+    friendly: 'GNU Lesser General Public License v3',
+    short: 'LGPL-3.0',
     requiresOnlyOrLater: true,
   },
   {
-    friendly: "GNU General Public License v2",
-    short: "GPL-2.0",
+    friendly: 'GNU General Public License v2',
+    short: 'GPL-2.0',
     requiresOnlyOrLater: true,
   },
   {
-    friendly: "GNU General Public License v3",
-    short: "GPL-3.0",
+    friendly: 'GNU General Public License v3',
+    short: 'GPL-3.0',
     requiresOnlyOrLater: true,
   },
-  { friendly: "ISC License", short: "ISC" },
-  { friendly: "MIT License", short: "MIT" },
-  { friendly: "Mozilla Public License 2.0", short: "MPL-2.0" },
-  { friendly: "zlib License", short: "Zlib" },
-] as const;
+  { friendly: 'ISC License', short: 'ISC' },
+  { friendly: 'MIT License', short: 'MIT' },
+  { friendly: 'Mozilla Public License 2.0', short: 'MPL-2.0' },
+  { friendly: 'zlib License', short: 'Zlib' },
+] as const

--- a/packages/utils/licenses.ts
+++ b/packages/utils/licenses.ts
@@ -1,0 +1,72 @@
+export interface BuiltinLicense { friendly: string, short: string, requiresOnlyOrLater?: boolean }
+
+export const builtinLicenses: BuiltinLicense[] = [
+  { friendly: "Custom", short: "" },
+  {
+    friendly: "All Rights Reserved/No License",
+    short: "All-Rights-Reserved",
+  },
+  { friendly: "Apache License 2.0", short: "Apache-2.0" },
+  {
+    friendly: 'BSD 2-Clause "Simplified" License',
+    short: "BSD-2-Clause",
+  },
+  {
+    friendly: 'BSD 3-Clause "New" or "Revised" License',
+    short: "BSD-3-Clause",
+  },
+  {
+    friendly: "CC Zero (Public Domain equivalent)",
+    short: "CC0-1.0",
+  },
+  { friendly: "CC-BY 4.0", short: "CC-BY-4.0" },
+  {
+    friendly: "CC-BY-SA 4.0",
+    short: "CC-BY-SA-4.0",
+  },
+  {
+    friendly: "CC-BY-NC 4.0",
+    short: "CC-BY-NC-4.0",
+  },
+  {
+    friendly: "CC-BY-NC-SA 4.0",
+    short: "CC-BY-NC-SA-4.0",
+  },
+  {
+    friendly: "CC-BY-ND 4.0",
+    short: "CC-BY-ND-4.0",
+  },
+  {
+    friendly: "CC-BY-NC-ND 4.0",
+    short: "CC-BY-NC-ND-4.0",
+  },
+  {
+    friendly: "GNU Affero General Public License v3",
+    short: "AGPL-3.0",
+    requiresOnlyOrLater: true,
+  },
+  {
+    friendly: "GNU Lesser General Public License v2.1",
+    short: "LGPL-2.1",
+    requiresOnlyOrLater: true,
+  },
+  {
+    friendly: "GNU Lesser General Public License v3",
+    short: "LGPL-3.0",
+    requiresOnlyOrLater: true,
+  },
+  {
+    friendly: "GNU General Public License v2",
+    short: "GPL-2.0",
+    requiresOnlyOrLater: true,
+  },
+  {
+    friendly: "GNU General Public License v3",
+    short: "GPL-3.0",
+    requiresOnlyOrLater: true,
+  },
+  { friendly: "ISC License", short: "ISC" },
+  { friendly: "MIT License", short: "MIT" },
+  { friendly: "Mozilla Public License 2.0", short: "MPL-2.0" },
+  { friendly: "zlib License", short: "Zlib" },
+] as const;

--- a/packages/utils/types.ts
+++ b/packages/utils/types.ts
@@ -87,8 +87,7 @@ export interface Project {
 
   license: {
     id: string
-    name
-    string
+    name: string
     url?: string
   }
 }


### PR DESCRIPTION
### Goals

- [x] Make fields not jump around
- [x] Make it easier to understand by separating fields and giving proper labels
- [x] Composition API
- [x] Typescript
- [x] Move away from vue-multiselect
- [x] Display an understandable default, such as "Select a license..." instead of the confusing "Unknown"
  - Possibly fixes the confusion in #3017


### Changes

- Add more understandable UI
  - Field titles
  - Field description
  - Give fields enough width to be readable
  - Rephrase some text
- Use more semantically correct elements
  - Make paragraph not a label
- Fields no longer jump around
- Split SPDX-identifier and license name into two separate fields
- Fmt, sort imports
- Encourage license URL when selecting custom license
- Move to Vue composition API
- Move to TypeScript
- Move away from vue-multiselect to the dropdown component
- Use `formatProjectType` function for typesafety
- Remove unused form error highlighting code
- Creating typings for built-in licenses
- Move standard licenses to licenses.ts util
  - There are other license-related utils I want to move there in the future
- Fix typo in Project license type definition

### Screenshots

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/3fbfbe6b-4260-4080-b808-09575de36683)  | **WIP** ![image](https://github.com/user-attachments/assets/ea327a61-563c-4633-9b98-c18204a3a1ec) |

### Issues

Closes #3017 