### PR TITLE
Fix MessageBanner padding

### DIFF
--- a/apps/frontend/src/pages/[type]/[id].vue
+++ b/apps/frontend/src/pages/[type]/[id].vue
@@ -674,7 +674,7 @@
           :auth="auth"
           :tags="tags"
         />
-        <MessageBanner v-if="project.status === 'archived'" message-type="warning" class="mb-4">
+        <MessageBanner v-if="project.status === 'archived'" message-type="warning" class="my-4">
           {{ project.title }} has been archived. {{ project.title }} will not receive any further
           updates unless the author decides to unarchive the project.
         </MessageBanner>


### PR DESCRIPTION
The MessageBanner padding that appears when a project is archived only has padding on the bottom and not the top. This means that there is no visual gap and it does follow the visual style of the rest of the website. I have fixed it.

![image](https://github.com/user-attachments/assets/cde2460f-ecbf-40e3-aa5b-3071927126ae)
