### PR TITLE
Fix Labrinth container SIGTERM handling

### DIFF
--- a/apps/labrinth/Dockerfile
+++ b/apps/labrinth/Dockerfile
@@ -15,9 +15,9 @@ LABEL org.opencontainers.image.description="Modrinth API"
 LABEL org.opencontainers.image.licenses=AGPL-3.0
 
 RUN apt-get update \
- && apt-get install -y --no-install-recommends ca-certificates openssl \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/*
+  && apt-get install -y --no-install-recommends ca-certificates openssl dumb-init \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
 RUN update-ca-certificates
 
@@ -26,4 +26,5 @@ COPY --from=build /usr/src/labrinth/apps/labrinth/migrations/* /labrinth/migrati
 COPY --from=build /usr/src/labrinth/apps/labrinth/assets /labrinth/assets
 WORKDIR /labrinth
 
-CMD /labrinth/labrinth
+ENTRYPOINT ["dumb-init", "--"]
+CMD ["/labrinth/labrinth"]


### PR DESCRIPTION
Currently, if Kubernetes sends SIGTERM to gracefully shutdown the pod, it will not do anything and wait for the graceful period seconds to forcefully kill the pod instead. dumb-init should fix this by handling signals for us.

Additionally, see https://github.com/Yelp/dumb-init#why-you-need-an-init-system