### PR TITLE
Fix HTTP Headers

### DIFF
--- a/apps/app/src/api/ads.rs
+++ b/apps/app/src/api/ads.rs
@@ -111,8 +111,14 @@ pub async fn init_ads_window<R: Runtime>(
                 )
                     .initialization_script(LINK_SCRIPT)
                     // .initialization_script_for_main_only(LINK_SCRIPT, false)
-                    .user_agent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36")
-                    .zoom_hotkeys_enabled(false)
+                .user_agent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36 Modrinth")
+                .with_request_interceptor(|request| {
+                    request.headers_mut().insert(
+                        "Accept-Encoding",
+                        HeaderValue::from_static("gzip, deflate, br"),
+                    );
+                })    
+                .zoom_hotkeys_enabled(false)
                     .transparent(true),
                 if state.shown {
                     position


### PR DESCRIPTION
Append "Modrinth" to the default user agent string to clarify our identity rather than spoofing browser UAs and update the Accept-Encoding header to include spaces after commas, correcting the formatting issue in the default Tauri configuration.
Decreases the chance being flagged as a bot.