### PR TITLE
fix(frontend): hide resubmit nag for draft projects

### DIFF
--- a/apps/frontend/src/components/ui/ProjectMemberHeader.vue
+++ b/apps/frontend/src/components/ui/ProjectMemberHeader.vue
@@ -336,6 +336,7 @@ const nags = computed(() => [
     },
   },
   {
+    hide: props.project.stats === "draft",
     condition: props.tags.rejectedStatuses.includes(props.project.status),
     title: "Resubmit for review",
     id: "resubmit-for-review",


### PR DESCRIPTION
Currently, the "Resubmit for review" nag in the publishing checklist is visible for draft projects (since this nag only differentiates whether the project is rejected). 
This works fine for any other status since usually this part of the page isn't visible. However, for draft projects this may lead to unnecessary confusion as to why it is visible and why it's already checked as well (it is because "draft" isn't a rejected status).

![image](https://github.com/user-attachments/assets/9957a4dc-4a21-4ef0-98fd-dcaf28ab6a9d)
The image displays this issue on a draft project (indicated by the unchecked "submit" nag)

Note: Due to the size of the codebase this change has not been tested.

