### PR TITLE
chore: add vscode setting to detect indentation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
   "prettier.endOfLine": "lf",
   "editor.formatOnSave": true,
   "eslint.validate": ["javascript", "javascriptreact", "typescript", "typescriptreact"],
+  "editor.detectIndentation": true,
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit"
   }


### PR DESCRIPTION
Tell vscode to detect the current file indentation overriding user indentation settings without screwing the current file on save and prevent to run any lint script for faster iteration or edit files keeping the format without installing deps