### PR TITLE
Fix blurry project icons

### DIFF
--- a/packages/ui/src/components/base/Avatar.vue
+++ b/packages/ui/src/components/base/Avatar.vue
@@ -8,7 +8,7 @@
       circle: circle,
       'no-shadow': noShadow,
       raised: raised,
-      pixelated: raised,
+      pixelated: pixelated,
     }"
     :src="src"
     :alt="alt"
@@ -96,7 +96,7 @@ const LEGACY_PRESETS = {
 const cssSize = computed(() => LEGACY_PRESETS[props.size] ?? props.size)
 
 function updatePixelated() {
-  if (img.value && img.value.naturalWidth && img.value.naturalWidth <= 96) {
+  if (img.value && img.value.naturalWidth && img.value.naturalWidth < 32) {
     pixelated.value = true
   } else {
     pixelated.value = false


### PR DESCRIPTION
This PR sets the image-rendering CSS property of all images smaller than 32 pixels to "pixelated" to avoid blurry images.
This is very noticeable with projects that use item textures as their icon as the browser will try to smoothen the pixel art.

Example: https://modrinth.com/mod/game-of-reborn