### PR TITLE
Fix Labrinth not compiling on Windows due to jemalloc dependency

### DIFF
--- a/apps/labrinth/Cargo.toml
+++ b/apps/labrinth/Cargo.toml
@@ -125,15 +125,16 @@ lettre = "0.11.3"
 derive-new = "0.6.0"
 rust_iso3166 = "0.1.11"
 
-tikv-jemallocator = { version = "0.6.0", features = ["profiling", "unprefixed_malloc_on_supported_platforms"] }
-tikv-jemalloc-ctl = { version = "0.6.0", features = ["stats"] }
-jemalloc_pprof = { version = "0.7.0", features = ["flamegraph"] }
-
 async-stripe = { version = "0.39.1", features = ["runtime-tokio-hyper-rustls"] }
 rusty-money = "0.4.1"
 json-patch = "*"
 
 ariadne = { path = "../../packages/ariadne" }
+
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = { version = "0.6.0", features = ["profiling", "unprefixed_malloc_on_supported_platforms"] }
+tikv-jemalloc-ctl = { version = "0.6.0", features = ["stats"] }
+jemalloc_pprof = { version = "0.7.0", features = ["flamegraph"] }
 
 [dev-dependencies]
 actix-http = "3.4.0"

--- a/apps/labrinth/src/lib.rs
+++ b/apps/labrinth/src/lib.rs
@@ -352,7 +352,13 @@ pub fn app_config(
     .app_data(labrinth_config.active_sockets.clone())
     .app_data(labrinth_config.automated_moderation_queue.clone())
     .app_data(web::Data::new(labrinth_config.stripe_client.clone()))
-    .configure(routes::debug::config)
+    .configure(
+        #[allow(unused_variables)]
+        |cfg| {
+            #[cfg(not(target_env = "msvc"))]
+            routes::debug::config(cfg)
+        },
+    )
     .configure(routes::v2::config)
     .configure(routes::v3::config)
     .configure(routes::internal::config)

--- a/apps/labrinth/src/main.rs
+++ b/apps/labrinth/src/main.rs
@@ -110,6 +110,8 @@ async fn main() -> std::io::Result<()> {
         .register_and_set_metrics(&prometheus.registry)
         .await
         .expect("Failed to register redis metrics");
+
+    #[cfg(not(target_env = "msvc"))]
     labrinth::routes::debug::jemalloc_mmeory_stats(&prometheus.registry)
         .expect("Failed to register jemalloc metrics");
 

--- a/apps/labrinth/src/routes/mod.rs
+++ b/apps/labrinth/src/routes/mod.rs
@@ -12,6 +12,7 @@ pub mod internal;
 pub mod v2;
 pub mod v3;
 
+#[cfg(not(target_env = "msvc"))]
 pub mod debug;
 
 pub mod v2_reroute;


### PR DESCRIPTION
Jemalloc doesn't compile on Windows (or at least on MSVC), so I made the dependency only active when not on MSVC.