### PR TITLE
Introduce DevContainers

### DIFF
--- a/.devcontainer/app-local/Dockerfile
+++ b/.devcontainer/app-local/Dockerfile
@@ -1,0 +1,14 @@
+FROM mcr.microsoft.com/devcontainers/base:1-bookworm
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends libwebkit2gtk-4.1-dev \
+    build-essential \
+    curl \
+    wget \
+    file \
+    libxdo-dev \
+    libssl-dev \
+    libayatana-appindicator3-dev \
+    librsvg2-dev \
+    luakit \
+    xdg-utils

--- a/.devcontainer/app-local/devcontainer.json
+++ b/.devcontainer/app-local/devcontainer.json
@@ -1,0 +1,54 @@
+{
+  "name": "Modrinth (app, local)",
+
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+
+  "hostRequirements": {
+    "memory": "12gb"
+  },
+
+  "features": {
+    "ghcr.io/devcontainers/features/node": {
+      "version": "20",
+      "installYarnUsingApt": false,
+      "pnpmVersion": "none"
+    },
+    "ghcr.io/devcontainers/features/rust:1": {}
+  },
+
+  "containerEnv": {
+    "BROWSER_BASE_URL": "https://api.modrinth.com/v2/",
+    "DATABASE_URL": "sqlite://${containerWorkspaceFolder}/apps/app/.data/database.db"
+  },
+
+  "onCreateCommand": "${containerWorkspaceFolder}/.devcontainer/app-shared/setup.sh",
+  "updateContentCommand": "pnpm install --ignore-scripts && (cd apps/app && cargo fetch) && (cd apps/app-playground && cargo fetch)",
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "Vue.volar",
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "EditorConfig.EditorConfig",
+        "tauri-apps.tauri-vscode",
+        "-tamasfe.even-better-toml",
+        "tombi-toml.tombi"
+      ],
+      "settings": {
+        "extensions.ignoreRecommendations": true,
+        "rust-analyzer.files.exclude": ["apps/daedalus_client", "apps/labrinth"]
+      }
+    }
+  },
+
+  "mounts": [
+    {
+      "source": "devcontainer-cargo-cache-modrinth",
+      "target": "/usr/local/cargo",
+      "type": "volume"
+    }
+  ]
+}

--- a/.devcontainer/app-shared/setup.sh
+++ b/.devcontainer/app-shared/setup.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+
+npm i -g corepack
+
+corepack enable
+
+COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack install
+
+cargo install --git https://github.com/launchbadge/sqlx sqlx-cli \
+  --no-default-features --features sqlite,rustls
+
+mkdir -p "$(dirname "${DATABASE_URL#sqlite://}")"
+
+(cd packages/app-lib && cargo sqlx database setup)

--- a/.devcontainer/app/Dockerfile
+++ b/.devcontainer/app/Dockerfile
@@ -1,0 +1,14 @@
+FROM mcr.microsoft.com/devcontainers/base:1-bookworm
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends libwebkit2gtk-4.1-dev \
+    build-essential \
+    curl \
+    wget \
+    file \
+    libxdo-dev \
+    libssl-dev \
+    libayatana-appindicator3-dev \
+    librsvg2-dev \
+    luakit \
+    xdg-utils

--- a/.devcontainer/app/devcontainer.json
+++ b/.devcontainer/app/devcontainer.json
@@ -1,0 +1,66 @@
+{
+  "name": "Modrinth (app, remote)",
+
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+
+  "hostRequirements": {
+    "memory": "12gb"
+  },
+
+  "features": {
+    "ghcr.io/devcontainers/features/desktop-lite:1": {},
+    "ghcr.io/devcontainers/features/node": {
+      "version": "20",
+      "installYarnUsingApt": false,
+      "pnpmVersion": "none"
+    },
+    "ghcr.io/devcontainers/features/rust:1": {}
+  },
+
+  "containerEnv": {
+    "VNC_RESOLUTION": "1600x1000",
+    "BROWSER_BASE_URL": "https://api.modrinth.com/v2/",
+    "DATABASE_URL": "sqlite://${containerWorkspaceFolder}/apps/app/.data/database.db"
+  },
+
+  "onCreateCommand": "${containerWorkspaceFolder}/.devcontainer/app-shared/setup.sh",
+  "updateContentCommand": "pnpm install --ignore-scripts && (cd apps/app && cargo fetch) && (cd apps/app-playground && cargo fetch)",
+
+  "forwardPorts": [6080, 5901],
+  "portsAttributes": {
+    "6080": {
+      "label": "desktop"
+    },
+    "5901": {
+      "label": "vnc"
+    }
+  },
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "Vue.volar",
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "EditorConfig.EditorConfig",
+        "tauri-apps.tauri-vscode",
+        "-tamasfe.even-better-toml",
+        "tombi-toml.tombi"
+      ],
+      "settings": {
+        "extensions.ignoreRecommendations": true,
+        "rust-analyzer.files.exclude": ["apps/daedalus_client", "apps/labrinth"]
+      }
+    }
+  },
+
+  "mounts": [
+    {
+      "source": "devcontainer-cargo-cache-modrinth",
+      "target": "/usr/local/cargo",
+      "type": "volume"
+    }
+  ]
+}

--- a/.devcontainer/backend/Dockerfile
+++ b/.devcontainer/backend/Dockerfile
@@ -1,0 +1,8 @@
+FROM mcr.microsoft.com/devcontainers/base:1-bookworm
+
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+        postgresql-client \
+        libssl-dev \
+        pkg-config \
+        liblzma-dev

--- a/.devcontainer/backend/devcontainer.json
+++ b/.devcontainer/backend/devcontainer.json
@@ -1,0 +1,36 @@
+{
+  "name": "Modrinth (backend)",
+
+  "dockerComposeFile": ["../../docker-compose.yml", "docker-compose.yml"],
+  "service": "labrinth",
+  "workspaceFolder": "/workspace",
+
+  "hostRequirements": {
+    "memory": "12gb"
+  },
+
+  "features": {
+    "ghcr.io/devcontainers/features/rust:1": {}
+  },
+
+  "onCreateCommand": "${containerWorkspaceFolder}/.devcontainer/backend/setup.sh",
+  "updateContentCommand": "(cd apps/labrinth && cargo fetch)",
+
+  "customizations": {
+    "vscode": {
+      "extensions": ["EditorConfig.EditorConfig", "-tamasfe.even-better-toml", "tombi-toml.tombi"],
+      "settings": {
+        "extensions.ignoreRecommendations": true,
+        "rust-analyzer.files.exclude": ["apps/app", "apps/app-playground", "packages/app-lib"]
+      }
+    }
+  },
+
+  "mounts": [
+    {
+      "source": "devcontainer-cargo-cache-modrinth",
+      "target": "/usr/local/cargo",
+      "type": "volume"
+    }
+  ]
+}

--- a/.devcontainer/backend/docker-compose.yml
+++ b/.devcontainer/backend/docker-compose.yml
@@ -1,0 +1,20 @@
+services:
+  labrinth:
+    build:
+      dockerfile: ./.devcontainer/backend/Dockerfile
+    command: sleep infinity
+    volumes:
+      - .:/workspace:cached
+    depends_on:
+      - postgres_db
+      - meilisearch
+      - redis
+      - clickhouse
+    environment:
+      DATABASE_URL: postgresql://labrinth:labrinth@postgres_db/labrinth
+      MEILISEARCH_ADDR: http://meilisearch:7700
+      REDIS_URL: redis://redis
+      CLICKHOUSE_URL: http://clickhouse:8123
+  clickhouse:
+    environment:
+      - CLICKHOUSE_SKIP_USER_SETUP=1

--- a/.devcontainer/backend/setup.sh
+++ b/.devcontainer/backend/setup.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -euo pipefail
+
+cargo install --git https://github.com/launchbadge/sqlx sqlx-cli \
+  --no-default-features --features postgres,rustls
+
+(cd apps/labrinth && sqlx database setup)
+
+psql "$DATABASE_URL" <<EOF
+INSERT INTO loaders VALUES (0, 'placeholder_loader');
+INSERT INTO loaders_project_types VALUES (0, 1); -- modloader id, supported type id
+INSERT INTO categories VALUES (0, 'placeholder_category', 1); -- category id, category, project type id
+EOF

--- a/.devcontainer/frontend/devcontainer.json
+++ b/.devcontainer/frontend/devcontainer.json
@@ -1,0 +1,38 @@
+{
+  "name": "Modrinth (frontend)",
+
+  "image": "mcr.microsoft.com/devcontainers/base:1-bookworm",
+
+  "features": {
+    "ghcr.io/devcontainers/features/node": {
+      "version": "20",
+      "installYarnUsingApt": false,
+      "pnpmVersion": "none"
+    }
+  },
+
+  "containerEnv": {
+    "BROWSER_BASE_URL": "https://api.modrinth.com/v2/"
+  },
+
+  "onCreateCommand": "npm i -g corepack && corepack enable && COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack install",
+  "updateContentCommand": "pnpm install --ignore-scripts && pnpm --filter=@modrinth/frontend postinstall",
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "Vue.volar",
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "EditorConfig.EditorConfig",
+        "Nuxtr.nuxtr-vscode",
+        "antfu.goto-alias"
+      ],
+      "settings": {
+        "extensions.ignoreRecommendations": true
+      }
+    }
+  },
+
+  "appPort": [3000]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,5 @@ app-playground-data/*
 apps/frontend/.env
 
 .astro
+
+.pnpm-store

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,21 @@
 {
-  "recommendations": ["esbenp.prettier-vscode", "Vue.volar", "rust-lang.rust-analyzer"]
+  "recommendations": [
+    // Code style enforcers
+    "EditorConfig.EditorConfig",
+    "esbenp.prettier-vscode",
+    "dbaeumer.vscode-eslint",
+    // Vue + Nuxt development
+    "Vue.volar",
+    "Nuxtr.nuxtr-vscode",
+    "antfu.goto-alias",
+    // Rust development
+    "rust-lang.rust-analyzer",
+    "tombi-toml.tombi",
+    "tauri-apps.tauri-vscode"
+  ],
+  "unwantedRecommendations": [
+    // Even Better TOML has a memory leak and is unmaintained.
+    // It is replaced by Tombi.
+    "tamasfe.even-better-toml"
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,52 @@
 {
-  "prettier.endOfLine": "lf",
   "editor.formatOnSave": true,
-  "eslint.validate": ["javascript", "javascriptreact", "typescript", "typescriptreact"],
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit"
+  },
+
+  "files.exclude": {
+    "**/.git": true,
+    "**/.svn": true,
+    "**/.hg": true,
+    "**/.DS_Store": true,
+    "**/Thumbs.db": true,
+    "**/.idea": true,
+    "**/.pnpm-store": true,
+    "**/.turbo": true,
+    "**/node_modules": true,
+    "**/target": true
+  },
+
+  "explorer.fileNesting.enabled": true,
+  "explorer.fileNesting.patterns": {
+    "*.ts": "${capture}.js",
+    "*.js": "${capture}.js.map, ${capture}.min.js, ${capture}.d.ts",
+    "*.jsx": "${capture}.js",
+    "*.tsx": "${capture}.ts",
+    "tsconfig.json": "tsconfig.*.json",
+    "package.json": "package-lock.json, yarn.lock, pnpm-lock.yaml, bun.lockb, bun.lock, pnpm-workspace.yaml",
+    "Cargo.toml": "Cargo.lock",
+    "README.md": "COPYING.md, LICENSE"
+  },
+
+  "prettier.endOfLine": "lf",
+
+  "eslint.validate": ["javascript", "javascriptreact", "typescript", "typescriptreact"],
+  "eslint.run": "onSave",
+
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[vue]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   }
 }


### PR DESCRIPTION
Development containers allow to develop projects in a virtualised environment, e.g. with Docker on desktop, or remotely with providers like GitHub Codespaces.

This makes it extremely easy for people to contribute to the project, since the environment is already set up for them.

The following development containers are introduced with this commit:

- `app` - for remote app development in the cloud.

  It includes a lightweight desktop environment and a VNC client to connect to the desktop remotely and interact with the running app.

- `app-local` - for local app development on Linux desktops.

  Unlike `app`, it does not include desktop environment and relies on desktop forwarding provided by Visual Studio Code. This is only suitable for Linux hosts.

- `backend` - for backend development.

  Features pre-configured database and other components required by Labrinth.

- `frontend` - for frontend development.

  Everything you need to work with Modrinth frontend - Vue, Nuxt and other niceties included.

Some Visual Studio Code settings were also revised to remove unmaintained or broken extension recommendations, recommend different useful extensions, as well as declutter the explorer.
