### PR TITLE
Fixed spacing in ModalConfirm.vue

### DIFF
--- a/apps/frontend/src/components/ui/ModalConfirm.vue
+++ b/apps/frontend/src/components/ui/ModalConfirm.vue
@@ -5,7 +5,7 @@
       <label v-if="hasToType" for="confirmation" class="confirmation-label">
         <span>
           <strong>To verify, type</strong>
-          <em class="confirmation-text">{{ confirmationText }}</em>
+          <em class="confirmation-text"> {{ confirmationText }} </em>
           <strong>below:</strong>
         </span>
       </label>


### PR DESCRIPTION
Fixed the spacing around the confirmationText. For example when you want to delete an organization, there aren't any spaces between the "To verify, type" and the confirmation text, which is fixed here.