### PR TITLE
Fix Modrinth App version GitHub issue text

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-app-bug.yml
+++ b/.github/ISSUE_TEMPLATE/1-app-bug.yml
@@ -16,7 +16,7 @@ body:
     id: version
     attributes:
       label: What version of the Modrinth App are you using?
-      description: Find this in ⚙️ Settings (bottom right) -> About -> App version.
+      description: Find this in ⚙️ Settings (bottom right) -> After Modrinth App (bottom left)
     validations:
       required: true
   - type: dropdown


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/991d70d9-0e8a-4510-980e-26853755f1a3)

Where you can find Modrinth App version has changed place, and the about doesn't exist anymore