### PR TITLE
Use permalinks in moderation queue page

### DIFF
--- a/apps/frontend/src/pages/moderation/review.vue
+++ b/apps/frontend/src/pages/moderation/review.vue
@@ -52,10 +52,7 @@
     >
       <div class="project-title">
         <div class="mobile-row">
-          <nuxt-link
-            :to="`/${project.inferred_project_type}/${project.slug}`"
-            class="iconified-stacked-link"
-          >
+          <nuxt-link :to="`/project/${project.id}`" class="iconified-stacked-link">
             <Avatar :src="project.icon_url" size="xs" no-shadow raised />
             <span class="stacked">
               <span class="title">{{ project.name }}</span>
@@ -67,7 +64,7 @@
           by
           <nuxt-link
             v-if="project.owner"
-            :to="`/user/${project.owner.user.username}`"
+            :to="`/user/${project.owner.user.id}`"
             class="iconified-link"
           >
             <Avatar :src="project.owner.user.avatar_url" circle size="xxs" raised />
@@ -75,7 +72,7 @@
           </nuxt-link>
           <nuxt-link
             v-else-if="project.org"
-            :to="`/organization/${project.org.slug}`"
+            :to="`/organization/${project.org.id}`"
             class="iconified-link"
           >
             <Avatar :src="project.org.icon_url" circle size="xxs" raised />
@@ -88,10 +85,7 @@
         </div>
       </div>
       <div class="input-group">
-        <nuxt-link
-          :to="`/${project.inferred_project_type}/${project.slug}`"
-          class="iconified-button raised-button"
-        >
+        <nuxt-link :to="`/project/${project.id}`" class="iconified-button raised-button">
           <EyeIcon />
           View project
         </nuxt-link>


### PR DESCRIPTION
Moderation queue now uses "permalinks" when linking to projects, users, or organizations. It has the side effect of also fixing a bug where projects without versions would lead to a 404 page.