### PR TITLE
fix: changelog margins overlapping link

### DIFF
--- a/apps/frontend/src/pages/news/changelog/[product]/[date].vue
+++ b/apps/frontend/src/pages/news/changelog/[product]/[date].vue
@@ -39,13 +39,8 @@ if (!changelogEntry.value) {
     >
       <ChevronLeftIcon /> View full changelog
     </nuxt-link>
-    <Timeline fade-out-end :fade-out-start="!isFirst" :class="{ '-mt-8': !isFirst }">
-      <ChangelogEntry
-        :entry="changelogEntry"
-        :first="isFirst"
-        show-type
-        :class="{ 'mt-8': !isFirst }"
-      />
+    <Timeline fade-out-end :fade-out-start="!isFirst">
+      <ChangelogEntry :entry="changelogEntry" :first="isFirst" show-type />
     </Timeline>
   </div>
 </template>

--- a/packages/ui/src/components/base/Timeline.vue
+++ b/packages/ui/src/components/base/Timeline.vue
@@ -48,7 +48,7 @@ withDefaults(
     mask-image: linear-gradient(
       to bottom,
       transparent 0%,
-      black 8rem,
+      black,
       black calc(100% - 8rem),
       transparent 100%
     );


### PR DESCRIPTION
Removes the margin top negation and the margin top from the changelog entry as they just cancelled out each other and also caused the timeline div to overlap the "View full changelog" link making it impossible to click it, 