### PR TITLE
Changed image upload screen to fit preview on small screens.

### DIFF
--- a/packages/ui/src/components/base/MarkdownEditor.vue
+++ b/packages/ui/src/components/base/MarkdownEditor.vue
@@ -126,7 +126,7 @@
       </span>
       <div class="markdown-body-wrapper">
         <div
-          style="width: 100%"
+          style="width: 100%; max-height: 306px;"
           class="markdown-body"
           v-html="renderHighlightedString(imageMarkdown)"
         />


### PR DESCRIPTION
Added max-height of 306px to make large vertical images' preview not overflow on small screens (in the image upload screen).