### PR TITLE
Fix to attached world data

### DIFF
--- a/apps/app-frontend/src/components/ui/world/modal/EditServerModal.vue
+++ b/apps/app-frontend/src/components/ui/world/modal/EditServerModal.vue
@@ -54,7 +54,7 @@ async function saveServer() {
       'server',
       address.value,
       newDisplayStatus.value,
-    )
+    ).catch(handleError)
   }
 
   emit('submit', {

--- a/apps/daedalus_client/src/error.rs
+++ b/apps/daedalus_client/src/error.rs
@@ -22,7 +22,7 @@ pub enum ErrorKind {
     Fetch { inner: reqwest::Error, item: String },
     #[error("Error while uploading file to S3: {file}")]
     S3 {
-        inner: s3::error::S3Error,
+        inner: Box<s3::error::S3Error>,
         file: String,
     },
     #[error("Error acquiring semaphore: {0}")]

--- a/apps/daedalus_client/src/util.rs
+++ b/apps/daedalus_client/src/util.rs
@@ -78,7 +78,7 @@ pub async fn upload_file_to_bucket(
             BUCKET.put_object(key.clone(), &bytes).await
         }
         .map_err(|err| ErrorKind::S3 {
-            inner: err,
+            inner: Box::new(err),
             file: path.clone(),
         });
 

--- a/packages/app-lib/.sqlx/query-1a979fbc58be7dde562b6f7c8fdcf9a4fc5a9817f4831c66bd56f2f4d0a00f82.json
+++ b/packages/app-lib/.sqlx/query-1a979fbc58be7dde562b6f7c8fdcf9a4fc5a9817f4831c66bd56f2f4d0a00f82.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            DELETE FROM attached_world_data\n            WHERE profile_path = $1 and world_type = $2 and world_id = $3\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 3
+    },
+    "nullable": []
+  },
+  "hash": "1a979fbc58be7dde562b6f7c8fdcf9a4fc5a9817f4831c66bd56f2f4d0a00f82"
+}

--- a/packages/app-lib/src/state/attached_world_data.rs
+++ b/packages/app-lib/src/state/attached_world_data.rs
@@ -62,6 +62,29 @@ impl AttachedWorldData {
             })
             .collect())
     }
+
+    pub async fn remove_for_world(
+        instance: &str,
+        world_type: WorldType,
+        world_id: &str,
+        exec: impl sqlx::Executor<'_, Database = sqlx::Sqlite>,
+    ) -> crate::Result<()> {
+        let world_type = world_type.as_str();
+
+        sqlx::query!(
+            "
+            DELETE FROM attached_world_data
+            WHERE profile_path = $1 and world_type = $2 and world_id = $3
+            ",
+            instance,
+            world_type,
+            world_id
+        )
+        .execute(exec)
+        .await?;
+
+        Ok(())
+    }
 }
 
 macro_rules! attached_data_setter {


### PR DESCRIPTION
This deletes the attached world data when a world is deleted. Also makes an enum smaller in order to make Clippy happy.