### PR TITLE
Minor Labrinth documentation and missing Sendy configuration handling tweaks

### DIFF
--- a/apps/docs/src/content/docs/contributing/labrinth.md
+++ b/apps/docs/src/content/docs/contributing/labrinth.md
@@ -53,7 +53,11 @@ If you would like 'placeholder_category' to be marked as supporting modpacks too
 INSERT INTO categories VALUES (0, 'placeholder_category', 2); -- modloader id, supported type id
 ```
 
+You can find more example SQL statements for seeding the database in the `apps/labrinth/tests/files/dummy_data.sql` file.
+
 The majority of configuration is done at runtime using [dotenvy](https://crates.io/crates/dotenvy) and the `.env` file. Each of the variables and what they do can be found in the dropdown below. Additionally, there are three command line options that can be used to specify to MeiliSearch what you want to do.
+
+During development, you might notice that changes made directly to entities in the PostgreSQL database do not seem to take effect. This is often because the Redis cache still holds outdated data. To ensure your updates are reflected, clear the cache by e.g. running `redis-cli FLUSHALL`, which will force Labrinth to fetch the latest data from the database the next time it is needed.
 
 <details>
 <summary>.env variables & command line options</summary>
@@ -73,6 +77,11 @@ The majority of configuration is done at runtime using [dotenvy](https://crates.
 `MEILISEARCH_KEY`: The name that MeiliSearch is given  
 `BIND_ADDR`: The bind address for the server. Supports both IPv4 and IPv6  
 `MOCK_FILE_PATH`: The path used to store uploaded files; this has no default value and will panic if unspecified
+`SMTP_USERNAME`: The username used to authenticate with the SMTP server
+`SMTP_PASSWORD`: The password associated with the `SMTP_USERNAME` for SMTP authentication
+`SMTP_HOST`: The hostname or IP address of the SMTP server
+`SMTP_PORT`: The port number on which the SMTP server is listening (commonly 25, 465, or 587)
+`SMTP_TLS`: The TLS mode to use for the SMTP connection, which can be one of the following: `none`, `opportunistic_start_tls`, `requires_start_tls`, `tls`
 
 #### CDN options
 

--- a/apps/labrinth/src/routes/internal/flows.rs
+++ b/apps/labrinth/src/routes/internal/flows.rs
@@ -1296,6 +1296,11 @@ pub async fn sign_up_sendy(email: &str) -> Result<(), AuthenticationError> {
     let api_key = dotenvy::var("SENDY_API_KEY")?;
     let site_url = dotenvy::var("SITE_URL")?;
 
+    if url.is_empty() || url == "none" {
+        tracing::info!("Sendy URL not set, skipping signup");
+        return Ok(());
+    }
+
     let mut form = HashMap::new();
 
     form.insert("api_key", &*api_key);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   postgres_db:
     image: postgres:alpine


### PR DESCRIPTION
This pull request tweaks the Labrinth documentation to mention the new SMTP variables, the `dummy_data.sql` as inspiration on how to seed a new database, and point towards potential Redis caching woes that may happen during development. Similarly, short-circuiting logic is added to skip Sendy signups when no Sendy API details are set up, easing deployment on development environments. Finally, the `docker-compose.yml` file had its deprecated version declaration removed, getting rid of warnings I got when doing `docker compose up`.