### PR TITLE
Commonize and distinguish a lot of struct names in `labrinth::database::models`

### DIFF
--- a/apps/labrinth/src/auth/checks.rs
+++ b/apps/labrinth/src/auth/checks.rs
@@ -1,9 +1,9 @@
 use crate::database;
-use crate::database::models::Collection;
-use crate::database::models::project_item::QueryProject;
-use crate::database::models::version_item::QueryVersion;
+use crate::database::models::DBCollection;
+use crate::database::models::project_item::ProjectQueryResult;
+use crate::database::models::version_item::VersionQueryResult;
 use crate::database::redis::RedisPool;
-use crate::database::{Project, Version, models};
+use crate::database::{DBProject, DBVersion, models};
 use crate::models::users::User;
 use crate::routes::ApiError;
 use itertools::Itertools;
@@ -38,7 +38,7 @@ where
 }
 
 pub async fn is_visible_project(
-    project_data: &Project,
+    project_data: &DBProject,
     user_option: &Option<User>,
     pool: &PgPool,
     hide_unlisted: bool,
@@ -54,7 +54,7 @@ pub async fn is_visible_project(
 }
 
 pub async fn is_team_member_project(
-    project_data: &Project,
+    project_data: &DBProject,
     user_option: &Option<User>,
     pool: &PgPool,
 ) -> Result<bool, ApiError> {
@@ -64,7 +64,7 @@ pub async fn is_team_member_project(
 }
 
 pub async fn filter_visible_projects(
-    mut projects: Vec<QueryProject>,
+    mut projects: Vec<ProjectQueryResult>,
     user_option: &Option<User>,
     pool: &PgPool,
     hide_unlisted: bool,
@@ -86,7 +86,7 @@ pub async fn filter_visible_projects(
 // - the user is a mod
 // This is essentially whether you can know of the project's existence
 pub async fn filter_visible_project_ids(
-    projects: Vec<&Project>,
+    projects: Vec<&DBProject>,
     user_option: &Option<User>,
     pool: &PgPool,
     hide_unlisted: bool,
@@ -126,7 +126,7 @@ pub async fn filter_visible_project_ids(
 // These are projects we have internal access to and can potentially see even if they are hidden
 // This is useful for getting visibility of versions, or seeing analytics or sensitive team-restricted data of a project
 pub async fn filter_enlisted_projects_ids(
-    projects: Vec<&Project>,
+    projects: Vec<&DBProject>,
     user_option: &Option<User>,
     pool: &PgPool,
 ) -> Result<Vec<crate::database::models::DBProjectId>, ApiError> {
@@ -173,7 +173,7 @@ pub async fn filter_enlisted_projects_ids(
 }
 
 pub async fn is_visible_version(
-    version_data: &Version,
+    version_data: &DBVersion,
     user_option: &Option<User>,
     pool: &PgPool,
     redis: &RedisPool,
@@ -184,7 +184,7 @@ pub async fn is_visible_version(
 }
 
 pub async fn is_team_member_version(
-    version_data: &Version,
+    version_data: &DBVersion,
     user_option: &Option<User>,
     pool: &PgPool,
     redis: &RedisPool,
@@ -195,7 +195,7 @@ pub async fn is_team_member_version(
 }
 
 pub async fn filter_visible_versions(
-    mut versions: Vec<QueryVersion>,
+    mut versions: Vec<VersionQueryResult>,
     user_option: &Option<User>,
     pool: &PgPool,
     redis: &RedisPool,
@@ -211,7 +211,7 @@ pub async fn filter_visible_versions(
     Ok(versions.into_iter().map(|x| x.into()).collect())
 }
 
-impl ValidateAuthorized for models::OAuthClient {
+impl ValidateAuthorized for models::DBOAuthClient {
     fn validate_authorized(
         &self,
         user_option: Option<&User>,
@@ -232,7 +232,7 @@ impl ValidateAuthorized for models::OAuthClient {
 }
 
 pub async fn filter_visible_version_ids(
-    versions: Vec<&Version>,
+    versions: Vec<&DBVersion>,
     user_option: &Option<User>,
     pool: &PgPool,
     redis: &RedisPool,
@@ -247,7 +247,7 @@ pub async fn filter_visible_version_ids(
 
     // Get visible projects- ones we are allowed to see public versions for.
     let visible_project_ids = filter_visible_project_ids(
-        Project::get_many_ids(&project_ids, pool, redis)
+        DBProject::get_many_ids(&project_ids, pool, redis)
             .await?
             .iter()
             .map(|x| &x.inner)
@@ -287,7 +287,7 @@ pub async fn filter_visible_version_ids(
 }
 
 pub async fn filter_enlisted_version_ids(
-    versions: Vec<&Version>,
+    versions: Vec<&DBVersion>,
     user_option: &Option<User>,
     pool: &PgPool,
     redis: &RedisPool,
@@ -299,7 +299,7 @@ pub async fn filter_enlisted_version_ids(
 
     // Get enlisted projects- ones we are allowed to see hidden versions for.
     let authorized_project_ids = filter_enlisted_projects_ids(
-        Project::get_many_ids(&project_ids, pool, redis)
+        DBProject::get_many_ids(&project_ids, pool, redis)
             .await?
             .iter()
             .map(|x| &x.inner)
@@ -325,7 +325,7 @@ pub async fn filter_enlisted_version_ids(
 }
 
 pub async fn is_visible_collection(
-    collection_data: &Collection,
+    collection_data: &DBCollection,
     user_option: &Option<User>,
 ) -> Result<bool, ApiError> {
     let mut authorized = !collection_data.status.is_hidden()
@@ -341,7 +341,7 @@ pub async fn is_visible_collection(
 }
 
 pub async fn filter_visible_collections(
-    collections: Vec<Collection>,
+    collections: Vec<DBCollection>,
     user_option: &Option<User>,
 ) -> Result<Vec<crate::models::collections::Collection>, ApiError> {
     let mut return_collections = Vec::new();

--- a/apps/labrinth/src/auth/oauth/mod.rs
+++ b/apps/labrinth/src/auth/oauth/mod.rs
@@ -1,10 +1,10 @@
 use crate::auth::get_user_from_headers;
 use crate::auth::oauth::uris::{OAuthRedirectUris, ValidatedRedirectUri};
 use crate::auth::validate::extract_authorization_header;
-use crate::database::models::flow_item::Flow;
-use crate::database::models::oauth_client_authorization_item::OAuthClientAuthorization;
-use crate::database::models::oauth_client_item::OAuthClient as DBOAuthClient;
-use crate::database::models::oauth_token_item::OAuthAccessToken;
+use crate::database::models::flow_item::DBFlow;
+use crate::database::models::oauth_client_authorization_item::DBOAuthClientAuthorization;
+use crate::database::models::oauth_client_item::DBOAuthClient;
+use crate::database::models::oauth_token_item::DBOAuthAccessToken;
 use crate::database::models::{
     DBOAuthClientAuthorizationId, generate_oauth_access_token_id,
     generate_oauth_client_authorization_id,
@@ -106,7 +106,7 @@ pub async fn init_oauth(
         }
 
         let existing_authorization =
-            OAuthClientAuthorization::get(client.id, user.id.into(), &**pool)
+            DBOAuthClientAuthorization::get(client.id, user.id.into(), &**pool)
                 .await
                 .map_err(|e| {
                     OAuthError::redirect(e, &oauth_info.state, &redirect_uri)
@@ -131,7 +131,7 @@ pub async fn init_oauth(
                 .await
             }
             _ => {
-                let flow_id = Flow::InitOAuthAppApproval {
+                let flow_id = DBFlow::InitOAuthAppApproval {
                     user_id: user.id.into(),
                     client_id: client.id,
                     existing_authorization_id: existing_authorization
@@ -231,13 +231,13 @@ pub async fn request_token(
 
         // Ensure auth code is single use
         // per IETF RFC6749 Section 10.5 (https://datatracker.ietf.org/doc/html/rfc6749#section-10.5)
-        let flow = Flow::take_if(
+        let flow = DBFlow::take_if(
             &req_params.code,
-            |f| matches!(f, Flow::OAuthAuthorizationCodeSupplied { .. }),
+            |f| matches!(f, DBFlow::OAuthAuthorizationCodeSupplied { .. }),
             &redis,
         )
         .await?;
-        if let Some(Flow::OAuthAuthorizationCodeSupplied {
+        if let Some(DBFlow::OAuthAuthorizationCodeSupplied {
             user_id,
             client_id,
             authorization_id,
@@ -274,8 +274,8 @@ pub async fn request_token(
             let token_id =
                 generate_oauth_access_token_id(&mut transaction).await?;
             let token = generate_access_token();
-            let token_hash = OAuthAccessToken::hash_token(&token);
-            let time_until_expiration = OAuthAccessToken {
+            let token_hash = DBOAuthAccessToken::hash_token(&token);
+            let time_until_expiration = DBOAuthAccessToken {
                 id: token_id,
                 authorization_id,
                 token_hash,
@@ -328,13 +328,13 @@ pub async fn accept_or_reject_client_scopes(
     .await?
     .1;
 
-    let flow = Flow::take_if(
+    let flow = DBFlow::take_if(
         &body.flow,
-        |f| matches!(f, Flow::InitOAuthAppApproval { .. }),
+        |f| matches!(f, DBFlow::InitOAuthAppApproval { .. }),
         &redis,
     )
     .await?;
-    if let Some(Flow::InitOAuthAppApproval {
+    if let Some(DBFlow::InitOAuthAppApproval {
         user_id,
         client_id,
         existing_authorization_id,
@@ -359,7 +359,7 @@ pub async fn accept_or_reject_client_scopes(
                         .await?
                 }
             };
-            OAuthClientAuthorization::upsert(
+            DBOAuthClientAuthorization::upsert(
                 auth_id,
                 client_id,
                 user_id,
@@ -425,7 +425,7 @@ async fn init_oauth_code_flow(
     state: Option<String>,
     redis: &RedisPool,
 ) -> Result<HttpResponse, OAuthError> {
-    let code = Flow::OAuthAuthorizationCodeSupplied {
+    let code = DBFlow::OAuthAuthorizationCodeSupplied {
         user_id,
         client_id: client_id.into(),
         authorization_id,

--- a/apps/labrinth/src/auth/validate.rs
+++ b/apps/labrinth/src/auth/validate.rs
@@ -50,7 +50,7 @@ pub async fn get_user_record_from_bearer_token<'a, 'b, E>(
     executor: E,
     redis: &RedisPool,
     session_queue: &AuthQueue,
-) -> Result<Option<(Scopes, user_item::User)>, AuthenticationError>
+) -> Result<Option<(Scopes, user_item::DBUser)>, AuthenticationError>
 where
     E: sqlx::Executor<'a, Database = sqlx::Postgres> + Copy,
 {
@@ -63,7 +63,7 @@ where
     let possible_user = match token.split_once('_') {
         Some(("mrp", _)) => {
             let pat =
-                crate::database::models::pat_item::PersonalAccessToken::get(
+                crate::database::models::pat_item::DBPersonalAccessToken::get(
                     token, executor, redis,
                 )
                 .await?
@@ -74,25 +74,26 @@ where
             }
 
             let user =
-                user_item::User::get_id(pat.user_id, executor, redis).await?;
+                user_item::DBUser::get_id(pat.user_id, executor, redis).await?;
 
             session_queue.add_pat(pat.id).await;
 
             user.map(|x| (pat.scopes, x))
         }
         Some(("mra", _)) => {
-            let session = crate::database::models::session_item::Session::get(
-                token, executor, redis,
-            )
-            .await?
-            .ok_or_else(|| AuthenticationError::InvalidCredentials)?;
+            let session =
+                crate::database::models::session_item::DBSession::get(
+                    token, executor, redis,
+                )
+                .await?
+                .ok_or_else(|| AuthenticationError::InvalidCredentials)?;
 
             if session.expires < Utc::now() {
                 return Err(AuthenticationError::InvalidCredentials);
             }
 
             let user =
-                user_item::User::get_id(session.user_id, executor, redis)
+                user_item::DBUser::get_id(session.user_id, executor, redis)
                     .await?;
 
             let rate_limit_ignore = dotenvy::var("RATE_LIMIT_IGNORE_KEY")?;
@@ -110,11 +111,11 @@ where
             user.map(|x| (Scopes::all(), x))
         }
         Some(("mro", _)) => {
-            use crate::database::models::oauth_token_item::OAuthAccessToken;
+            use crate::database::models::oauth_token_item::DBOAuthAccessToken;
 
-            let hash = OAuthAccessToken::hash_token(token);
+            let hash = DBOAuthAccessToken::hash_token(token);
             let access_token =
-                crate::database::models::oauth_token_item::OAuthAccessToken::get(hash, executor)
+                crate::database::models::oauth_token_item::DBOAuthAccessToken::get(hash, executor)
                     .await?
                     .ok_or(AuthenticationError::InvalidCredentials)?;
 
@@ -122,9 +123,12 @@ where
                 return Err(AuthenticationError::InvalidCredentials);
             }
 
-            let user =
-                user_item::User::get_id(access_token.user_id, executor, redis)
-                    .await?;
+            let user = user_item::DBUser::get_id(
+                access_token.user_id,
+                executor,
+                redis,
+            )
+            .await?;
 
             session_queue.add_oauth_access_token(access_token.id).await;
 
@@ -135,7 +139,7 @@ where
             let id =
                 AuthProvider::GitHub.get_user_id(&user.id, executor).await?;
 
-            let user = user_item::User::get_id(
+            let user = user_item::DBUser::get_id(
                 id.ok_or_else(|| AuthenticationError::InvalidCredentials)?,
                 executor,
                 redis,

--- a/apps/labrinth/src/database/mod.rs
+++ b/apps/labrinth/src/database/mod.rs
@@ -1,9 +1,9 @@
 pub mod models;
 mod postgres_database;
 pub mod redis;
-pub use models::Image;
-pub use models::Project;
-pub use models::Version;
+pub use models::DBImage;
+pub use models::DBProject;
+pub use models::DBVersion;
 pub use postgres_database::check_for_migrations;
 pub use postgres_database::connect;
 pub use postgres_database::register_and_set_metrics;

--- a/apps/labrinth/src/database/models/flow_item.rs
+++ b/apps/labrinth/src/database/models/flow_item.rs
@@ -15,7 +15,7 @@ const FLOWS_NAMESPACE: &str = "flows";
 
 #[derive(Deserialize, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
-pub enum Flow {
+pub enum DBFlow {
     OAuth {
         user_id: Option<DBUserId>,
         url: String,
@@ -53,7 +53,7 @@ pub enum Flow {
     },
 }
 
-impl Flow {
+impl DBFlow {
     pub async fn insert(
         &self,
         expires: Duration,
@@ -81,7 +81,7 @@ impl Flow {
     pub async fn get(
         id: &str,
         redis: &RedisPool,
-    ) -> Result<Option<Flow>, DatabaseError> {
+    ) -> Result<Option<DBFlow>, DatabaseError> {
         let mut redis = redis.connect().await?;
 
         redis.get_deserialized_from_json(FLOWS_NAMESPACE, id).await
@@ -91,9 +91,9 @@ impl Flow {
     /// The predicate should validate that the flow being removed is the correct one, as a security measure
     pub async fn take_if(
         id: &str,
-        predicate: impl FnOnce(&Flow) -> bool,
+        predicate: impl FnOnce(&DBFlow) -> bool,
         redis: &RedisPool,
-    ) -> Result<Option<Flow>, DatabaseError> {
+    ) -> Result<Option<DBFlow>, DatabaseError> {
         let flow = Self::get(id, redis).await?;
         if let Some(flow) = flow.as_ref() {
             if predicate(flow) {

--- a/apps/labrinth/src/database/models/friend_item.rs
+++ b/apps/labrinth/src/database/models/friend_item.rs
@@ -1,14 +1,14 @@
 use crate::database::models::DBUserId;
 use chrono::{DateTime, Utc};
 
-pub struct FriendItem {
+pub struct DBFriend {
     pub user_id: DBUserId,
     pub friend_id: DBUserId,
     pub created: DateTime<Utc>,
     pub accepted: bool,
 }
 
-impl FriendItem {
+impl DBFriend {
     pub async fn insert(
         &self,
         transaction: &mut sqlx::Transaction<'_, sqlx::Postgres>,
@@ -33,7 +33,7 @@ impl FriendItem {
         user_id: DBUserId,
         friend_id: DBUserId,
         exec: E,
-    ) -> Result<Option<FriendItem>, sqlx::Error>
+    ) -> Result<Option<DBFriend>, sqlx::Error>
     where
         E: sqlx::Executor<'a, Database = sqlx::Postgres>,
     {
@@ -48,7 +48,7 @@ impl FriendItem {
         )
         .fetch_optional(exec)
         .await?
-            .map(|row| FriendItem {
+            .map(|row| DBFriend {
                 user_id: DBUserId(row.user_id),
                 friend_id: DBUserId(row.friend_id),
                 created: row.created,
@@ -84,7 +84,7 @@ impl FriendItem {
         user_id: DBUserId,
         accepted: Option<bool>,
         exec: E,
-    ) -> Result<Vec<FriendItem>, sqlx::Error>
+    ) -> Result<Vec<DBFriend>, sqlx::Error>
     where
         E: sqlx::Executor<'a, Database = sqlx::Postgres>,
     {
@@ -99,7 +99,7 @@ impl FriendItem {
         .fetch_all(exec)
         .await?
         .into_iter()
-        .map(|row| FriendItem {
+        .map(|row| DBFriend {
             user_id: DBUserId(row.user_id),
             friend_id: DBUserId(row.friend_id),
             created: row.created,

--- a/apps/labrinth/src/database/models/mod.rs
+++ b/apps/labrinth/src/database/models/mod.rs
@@ -26,17 +26,17 @@ pub mod user_item;
 pub mod user_subscription_item;
 pub mod version_item;
 
-pub use collection_item::Collection;
+pub use collection_item::DBCollection;
 pub use ids::*;
-pub use image_item::Image;
-pub use oauth_client_item::OAuthClient;
-pub use organization_item::Organization;
-pub use project_item::Project;
-pub use team_item::Team;
-pub use team_item::TeamMember;
-pub use thread_item::{Thread, ThreadMessage};
-pub use user_item::User;
-pub use version_item::Version;
+pub use image_item::DBImage;
+pub use oauth_client_item::DBOAuthClient;
+pub use organization_item::DBOrganization;
+pub use project_item::DBProject;
+pub use team_item::DBTeam;
+pub use team_item::DBTeamMember;
+pub use thread_item::{DBThread, DBThreadMessage};
+pub use user_item::DBUser;
+pub use version_item::DBVersion;
 
 #[derive(Error, Debug)]
 pub enum DatabaseError {

--- a/apps/labrinth/src/database/models/oauth_client_authorization_item.rs
+++ b/apps/labrinth/src/database/models/oauth_client_authorization_item.rs
@@ -9,7 +9,7 @@ use super::{
 };
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
-pub struct OAuthClientAuthorization {
+pub struct DBOAuthClientAuthorization {
     pub id: DBOAuthClientAuthorizationId,
     pub client_id: DBOAuthClientId,
     pub user_id: DBUserId,
@@ -17,7 +17,7 @@ pub struct OAuthClientAuthorization {
     pub created: DateTime<Utc>,
 }
 
-struct AuthorizationQueryResult {
+struct DBAuthClientAuthorizationQueryResult {
     id: i64,
     client_id: i64,
     user_id: i64,
@@ -25,9 +25,9 @@ struct AuthorizationQueryResult {
     created: DateTime<Utc>,
 }
 
-impl From<AuthorizationQueryResult> for OAuthClientAuthorization {
-    fn from(value: AuthorizationQueryResult) -> Self {
-        OAuthClientAuthorization {
+impl From<DBAuthClientAuthorizationQueryResult> for DBOAuthClientAuthorization {
+    fn from(value: DBAuthClientAuthorizationQueryResult) -> Self {
+        DBOAuthClientAuthorization {
             id: DBOAuthClientAuthorizationId(value.id),
             client_id: DBOAuthClientId(value.client_id),
             user_id: DBUserId(value.user_id),
@@ -37,14 +37,14 @@ impl From<AuthorizationQueryResult> for OAuthClientAuthorization {
     }
 }
 
-impl OAuthClientAuthorization {
+impl DBOAuthClientAuthorization {
     pub async fn get(
         client_id: DBOAuthClientId,
         user_id: DBUserId,
         exec: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
-    ) -> Result<Option<OAuthClientAuthorization>, DatabaseError> {
+    ) -> Result<Option<DBOAuthClientAuthorization>, DatabaseError> {
         let value = sqlx::query_as!(
-            AuthorizationQueryResult,
+            DBAuthClientAuthorizationQueryResult,
             "
             SELECT id, client_id, user_id, scopes, created
             FROM oauth_client_authorizations
@@ -62,9 +62,9 @@ impl OAuthClientAuthorization {
     pub async fn get_all_for_user(
         user_id: DBUserId,
         exec: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
-    ) -> Result<Vec<OAuthClientAuthorization>, DatabaseError> {
+    ) -> Result<Vec<DBOAuthClientAuthorization>, DatabaseError> {
         let results = sqlx::query_as!(
-            AuthorizationQueryResult,
+            DBAuthClientAuthorizationQueryResult,
             "
             SELECT id, client_id, user_id, scopes, created
             FROM oauth_client_authorizations

--- a/apps/labrinth/src/database/models/oauth_client_item.rs
+++ b/apps/labrinth/src/database/models/oauth_client_item.rs
@@ -7,28 +7,28 @@ use super::{DBOAuthClientId, DBOAuthRedirectUriId, DBUserId, DatabaseError};
 use crate::models::pats::Scopes;
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
-pub struct OAuthRedirectUri {
+pub struct DBOAuthRedirectUri {
     pub id: DBOAuthRedirectUriId,
     pub client_id: DBOAuthClientId,
     pub uri: String,
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
-pub struct OAuthClient {
+pub struct DBOAuthClient {
     pub id: DBOAuthClientId,
     pub name: String,
     pub icon_url: Option<String>,
     pub raw_icon_url: Option<String>,
     pub max_scopes: Scopes,
     pub secret_hash: String,
-    pub redirect_uris: Vec<OAuthRedirectUri>,
+    pub redirect_uris: Vec<DBOAuthRedirectUri>,
     pub created: DateTime<Utc>,
     pub created_by: DBUserId,
     pub url: Option<String>,
     pub description: Option<String>,
 }
 
-struct ClientQueryResult {
+struct OAuthClientQueryResult {
     id: i64,
     name: String,
     icon_url: Option<String>,
@@ -49,7 +49,7 @@ macro_rules! select_clients_with_predicate {
         // the combination of the JOIN and filter using ANY makes sqlx think all columns are nullable
         // https://docs.rs/sqlx/latest/sqlx/macro.query.html#force-nullable
         sqlx::query_as!(
-            ClientQueryResult,
+            OAuthClientQueryResult,
             r#"
             SELECT
                 clients.id as "id!",
@@ -77,18 +77,18 @@ macro_rules! select_clients_with_predicate {
     };
 }
 
-impl OAuthClient {
+impl DBOAuthClient {
     pub async fn get(
         id: DBOAuthClientId,
         exec: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
-    ) -> Result<Option<OAuthClient>, DatabaseError> {
+    ) -> Result<Option<DBOAuthClient>, DatabaseError> {
         Ok(Self::get_many(&[id], exec).await?.into_iter().next())
     }
 
     pub async fn get_many(
         ids: &[DBOAuthClientId],
         exec: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
-    ) -> Result<Vec<OAuthClient>, DatabaseError> {
+    ) -> Result<Vec<DBOAuthClient>, DatabaseError> {
         let ids = ids.iter().map(|id| id.0).collect_vec();
         let ids_ref: &[i64] = &ids;
         let results = select_clients_with_predicate!(
@@ -104,7 +104,7 @@ impl OAuthClient {
     pub async fn get_all_user_clients(
         user_id: DBUserId,
         exec: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
-    ) -> Result<Vec<OAuthClient>, DatabaseError> {
+    ) -> Result<Vec<DBOAuthClient>, DatabaseError> {
         let user_id_param = user_id.0;
         let clients = select_clients_with_predicate!(
             "WHERE created_by = $1",
@@ -208,7 +208,7 @@ impl OAuthClient {
     }
 
     pub async fn insert_redirect_uris(
-        uris: &[OAuthRedirectUri],
+        uris: &[DBOAuthRedirectUri],
         exec: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
     ) -> Result<(), DatabaseError> {
         let (ids, client_ids, uris): (Vec<_>, Vec<_>, Vec<_>) = uris
@@ -235,14 +235,14 @@ impl OAuthClient {
     }
 }
 
-impl From<ClientQueryResult> for OAuthClient {
-    fn from(r: ClientQueryResult) -> Self {
+impl From<OAuthClientQueryResult> for DBOAuthClient {
+    fn from(r: OAuthClientQueryResult) -> Self {
         let redirects = if let (Some(ids), Some(uris)) =
             (r.uri_ids.as_ref(), r.uri_vals.as_ref())
         {
             ids.iter()
                 .zip(uris.iter())
-                .map(|(id, uri)| OAuthRedirectUri {
+                .map(|(id, uri)| DBOAuthRedirectUri {
                     id: DBOAuthRedirectUriId(*id),
                     client_id: DBOAuthClientId(r.id),
                     uri: uri.to_string(),
@@ -252,7 +252,7 @@ impl From<ClientQueryResult> for OAuthClient {
             vec![]
         };
 
-        OAuthClient {
+        DBOAuthClient {
             id: DBOAuthClientId(r.id),
             name: r.name,
             icon_url: r.icon_url,

--- a/apps/labrinth/src/database/models/oauth_token_item.rs
+++ b/apps/labrinth/src/database/models/oauth_token_item.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use sha2::Digest;
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
-pub struct OAuthAccessToken {
+pub struct DBOAuthAccessToken {
     pub id: DBOAuthAccessTokenId,
     pub authorization_id: DBOAuthClientAuthorizationId,
     pub token_hash: String,
@@ -22,11 +22,11 @@ pub struct OAuthAccessToken {
     pub user_id: DBUserId,
 }
 
-impl OAuthAccessToken {
+impl DBOAuthAccessToken {
     pub async fn get(
         token_hash: String,
         exec: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
-    ) -> Result<Option<OAuthAccessToken>, DatabaseError> {
+    ) -> Result<Option<DBOAuthAccessToken>, DatabaseError> {
         let value = sqlx::query!(
             "
             SELECT
@@ -49,7 +49,7 @@ impl OAuthAccessToken {
         .fetch_optional(exec)
         .await?;
 
-        Ok(value.map(|r| OAuthAccessToken {
+        Ok(value.map(|r| DBOAuthAccessToken {
             id: DBOAuthAccessTokenId(r.id),
             authorization_id: DBOAuthClientAuthorizationId(r.authorization_id),
             token_hash: r.token_hash,

--- a/apps/labrinth/src/database/models/pat_item.rs
+++ b/apps/labrinth/src/database/models/pat_item.rs
@@ -15,7 +15,7 @@ const PATS_TOKENS_NAMESPACE: &str = "pats_tokens";
 const PATS_USERS_NAMESPACE: &str = "pats_users";
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
-pub struct PersonalAccessToken {
+pub struct DBPersonalAccessToken {
     pub id: DBPatId,
     pub name: String,
     pub access_token: String,
@@ -26,7 +26,7 @@ pub struct PersonalAccessToken {
     pub last_used: Option<DateTime<Utc>>,
 }
 
-impl PersonalAccessToken {
+impl DBPersonalAccessToken {
     pub async fn insert(
         &self,
         transaction: &mut sqlx::Transaction<'_, sqlx::Postgres>,
@@ -63,7 +63,7 @@ impl PersonalAccessToken {
         id: T,
         exec: E,
         redis: &RedisPool,
-    ) -> Result<Option<PersonalAccessToken>, DatabaseError>
+    ) -> Result<Option<DBPersonalAccessToken>, DatabaseError>
     where
         E: sqlx::Executor<'a, Database = sqlx::Postgres>,
     {
@@ -76,7 +76,7 @@ impl PersonalAccessToken {
         pat_ids: &[DBPatId],
         exec: E,
         redis: &RedisPool,
-    ) -> Result<Vec<PersonalAccessToken>, DatabaseError>
+    ) -> Result<Vec<DBPersonalAccessToken>, DatabaseError>
     where
         E: sqlx::Executor<'a, Database = sqlx::Postgres>,
     {
@@ -84,7 +84,7 @@ impl PersonalAccessToken {
             .iter()
             .map(|x| crate::models::ids::PatId::from(*x))
             .collect::<Vec<_>>();
-        PersonalAccessToken::get_many(&ids, exec, redis).await
+        DBPersonalAccessToken::get_many(&ids, exec, redis).await
     }
 
     pub async fn get_many<
@@ -95,7 +95,7 @@ impl PersonalAccessToken {
         pat_strings: &[T],
         exec: E,
         redis: &RedisPool,
-    ) -> Result<Vec<PersonalAccessToken>, DatabaseError>
+    ) -> Result<Vec<DBPersonalAccessToken>, DatabaseError>
     where
         E: sqlx::Executor<'a, Database = sqlx::Postgres>,
     {
@@ -125,7 +125,7 @@ impl PersonalAccessToken {
                     )
                     .fetch(exec)
                     .try_fold(DashMap::new(), |acc, x| {
-                        let pat = PersonalAccessToken {
+                        let pat = DBPersonalAccessToken {
                             id: DBPatId(x.id),
                             name: x.name,
                             access_token: x.access_token.clone(),

--- a/apps/labrinth/src/database/models/payout_item.rs
+++ b/apps/labrinth/src/database/models/payout_item.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use super::{DBPayoutId, DBUserId, DatabaseError};
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
-pub struct Payout {
+pub struct DBPayout {
     pub id: DBPayoutId,
     pub user_id: DBUserId,
     pub created: DateTime<Utc>,
@@ -19,7 +19,7 @@ pub struct Payout {
     pub platform_id: Option<String>,
 }
 
-impl Payout {
+impl DBPayout {
     pub async fn insert(
         &self,
         transaction: &mut sqlx::Transaction<'_, sqlx::Postgres>,
@@ -51,11 +51,11 @@ impl Payout {
     pub async fn get<'a, 'b, E>(
         id: DBPayoutId,
         executor: E,
-    ) -> Result<Option<Payout>, DatabaseError>
+    ) -> Result<Option<DBPayout>, DatabaseError>
     where
         E: sqlx::Executor<'a, Database = sqlx::Postgres>,
     {
-        Payout::get_many(&[id], executor)
+        DBPayout::get_many(&[id], executor)
             .await
             .map(|x| x.into_iter().next())
     }
@@ -63,7 +63,7 @@ impl Payout {
     pub async fn get_many<'a, E>(
         payout_ids: &[DBPayoutId],
         exec: E,
-    ) -> Result<Vec<Payout>, DatabaseError>
+    ) -> Result<Vec<DBPayout>, DatabaseError>
     where
         E: sqlx::Executor<'a, Database = sqlx::Postgres>,
     {
@@ -78,7 +78,7 @@ impl Payout {
             &payout_ids.into_iter().map(|x| x.0).collect::<Vec<_>>()
         )
         .fetch(exec)
-        .map_ok(|r| Payout {
+        .map_ok(|r| DBPayout {
             id: DBPayoutId(r.id),
             user_id: DBUserId(r.user_id),
             created: r.created,
@@ -89,7 +89,7 @@ impl Payout {
             platform_id: r.platform_id,
             fee: r.fee,
         })
-        .try_collect::<Vec<Payout>>()
+        .try_collect::<Vec<DBPayout>>()
         .await?;
 
         Ok(results)

--- a/apps/labrinth/src/database/models/report_item.rs
+++ b/apps/labrinth/src/database/models/report_item.rs
@@ -1,7 +1,7 @@
 use super::ids::*;
 use chrono::{DateTime, Utc};
 
-pub struct Report {
+pub struct DBReport {
     pub id: DBReportId,
     pub report_type_id: ReportTypeId,
     pub project_id: Option<DBProjectId>,
@@ -13,7 +13,7 @@ pub struct Report {
     pub closed: bool,
 }
 
-pub struct QueryReport {
+pub struct ReportQueryResult {
     pub id: DBReportId,
     pub report_type: String,
     pub project_id: Option<DBProjectId>,
@@ -26,7 +26,7 @@ pub struct QueryReport {
     pub thread_id: DBThreadId,
 }
 
-impl Report {
+impl DBReport {
     pub async fn insert(
         &self,
         transaction: &mut sqlx::Transaction<'_, sqlx::Postgres>,
@@ -59,7 +59,7 @@ impl Report {
     pub async fn get<'a, E>(
         id: DBReportId,
         exec: E,
-    ) -> Result<Option<QueryReport>, sqlx::Error>
+    ) -> Result<Option<ReportQueryResult>, sqlx::Error>
     where
         E: sqlx::Executor<'a, Database = sqlx::Postgres>,
     {
@@ -71,7 +71,7 @@ impl Report {
     pub async fn get_many<'a, E>(
         report_ids: &[DBReportId],
         exec: E,
-    ) -> Result<Vec<QueryReport>, sqlx::Error>
+    ) -> Result<Vec<ReportQueryResult>, sqlx::Error>
     where
         E: sqlx::Executor<'a, Database = sqlx::Postgres>,
     {
@@ -91,7 +91,7 @@ impl Report {
             &report_ids_parsed
         )
         .fetch(exec)
-        .map_ok(|x| QueryReport {
+        .map_ok(|x| ReportQueryResult {
             id: DBReportId(x.id),
             report_type: x.name,
             project_id: x.mod_id.map(DBProjectId),
@@ -103,7 +103,7 @@ impl Report {
             closed: x.closed,
             thread_id: DBThreadId(x.thread_id)
         })
-        .try_collect::<Vec<QueryReport>>()
+        .try_collect::<Vec<ReportQueryResult>>()
         .await?;
 
         Ok(reports)
@@ -137,7 +137,7 @@ impl Report {
         .await?;
 
         if let Some(thread_id) = thread_id {
-            crate::database::models::Thread::remove_full(
+            crate::database::models::DBThread::remove_full(
                 DBThreadId(thread_id.id),
                 transaction,
             )

--- a/apps/labrinth/src/database/models/session_item.rs
+++ b/apps/labrinth/src/database/models/session_item.rs
@@ -62,7 +62,7 @@ impl SessionBuilder {
 }
 
 #[derive(Deserialize, Serialize)]
-pub struct Session {
+pub struct DBSession {
     pub id: DBSessionId,
     pub session: String,
     pub user_id: DBUserId,
@@ -81,7 +81,7 @@ pub struct Session {
     pub ip: String,
 }
 
-impl Session {
+impl DBSession {
     pub async fn get<
         'a,
         E,
@@ -90,7 +90,7 @@ impl Session {
         id: T,
         exec: E,
         redis: &RedisPool,
-    ) -> Result<Option<Session>, DatabaseError>
+    ) -> Result<Option<DBSession>, DatabaseError>
     where
         E: sqlx::Executor<'a, Database = sqlx::Postgres>,
     {
@@ -103,11 +103,11 @@ impl Session {
         id: DBSessionId,
         executor: E,
         redis: &RedisPool,
-    ) -> Result<Option<Session>, DatabaseError>
+    ) -> Result<Option<DBSession>, DatabaseError>
     where
         E: sqlx::Executor<'a, Database = sqlx::Postgres>,
     {
-        Session::get_many(
+        DBSession::get_many(
             &[crate::models::ids::SessionId::from(id)],
             executor,
             redis,
@@ -120,7 +120,7 @@ impl Session {
         session_ids: &[DBSessionId],
         exec: E,
         redis: &RedisPool,
-    ) -> Result<Vec<Session>, DatabaseError>
+    ) -> Result<Vec<DBSession>, DatabaseError>
     where
         E: sqlx::Executor<'a, Database = sqlx::Postgres>,
     {
@@ -128,7 +128,7 @@ impl Session {
             .iter()
             .map(|x| crate::models::ids::SessionId::from(*x))
             .collect::<Vec<_>>();
-        Session::get_many(&ids, exec, redis).await
+        DBSession::get_many(&ids, exec, redis).await
     }
 
     pub async fn get_many<
@@ -139,7 +139,7 @@ impl Session {
         session_strings: &[T],
         exec: E,
         redis: &RedisPool,
-    ) -> Result<Vec<Session>, DatabaseError>
+    ) -> Result<Vec<DBSession>, DatabaseError>
     where
         E: sqlx::Executor<'a, Database = sqlx::Postgres>,
     {
@@ -173,7 +173,7 @@ impl Session {
                 )
                     .fetch(exec)
                     .try_fold(DashMap::new(), |acc, x| {
-                        let session = Session {
+                        let session = DBSession {
                             id: DBSessionId(x.id),
                             session: x.session.clone(),
                             user_id: DBUserId(x.user_id),

--- a/apps/labrinth/src/database/models/user_subscription_item.rs
+++ b/apps/labrinth/src/database/models/user_subscription_item.rs
@@ -8,7 +8,7 @@ use chrono::{DateTime, Utc};
 use itertools::Itertools;
 use std::convert::{TryFrom, TryInto};
 
-pub struct UserSubscriptionItem {
+pub struct DBUserSubscription {
     pub id: DBUserSubscriptionId,
     pub user_id: DBUserId,
     pub price_id: DBProductPriceId,
@@ -18,7 +18,7 @@ pub struct UserSubscriptionItem {
     pub metadata: Option<SubscriptionMetadata>,
 }
 
-struct UserSubscriptionResult {
+struct UserSubscriptionQueryResult {
     id: i64,
     user_id: i64,
     price_id: i64,
@@ -31,7 +31,7 @@ struct UserSubscriptionResult {
 macro_rules! select_user_subscriptions_with_predicate {
     ($predicate:tt, $param:ident) => {
         sqlx::query_as!(
-            UserSubscriptionResult,
+            UserSubscriptionQueryResult,
             r#"
             SELECT
                 us.id, us.user_id, us.price_id, us.interval, us.created, us.status, us.metadata
@@ -43,11 +43,11 @@ macro_rules! select_user_subscriptions_with_predicate {
     };
 }
 
-impl TryFrom<UserSubscriptionResult> for UserSubscriptionItem {
+impl TryFrom<UserSubscriptionQueryResult> for DBUserSubscription {
     type Error = serde_json::Error;
 
-    fn try_from(r: UserSubscriptionResult) -> Result<Self, Self::Error> {
-        Ok(UserSubscriptionItem {
+    fn try_from(r: UserSubscriptionQueryResult) -> Result<Self, Self::Error> {
+        Ok(DBUserSubscription {
             id: DBUserSubscriptionId(r.id),
             user_id: DBUserId(r.user_id),
             price_id: DBProductPriceId(r.price_id),
@@ -59,18 +59,18 @@ impl TryFrom<UserSubscriptionResult> for UserSubscriptionItem {
     }
 }
 
-impl UserSubscriptionItem {
+impl DBUserSubscription {
     pub async fn get(
         id: DBUserSubscriptionId,
         exec: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
-    ) -> Result<Option<UserSubscriptionItem>, DatabaseError> {
+    ) -> Result<Option<DBUserSubscription>, DatabaseError> {
         Ok(Self::get_many(&[id], exec).await?.into_iter().next())
     }
 
     pub async fn get_many(
         ids: &[DBUserSubscriptionId],
         exec: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
-    ) -> Result<Vec<UserSubscriptionItem>, DatabaseError> {
+    ) -> Result<Vec<DBUserSubscription>, DatabaseError> {
         let ids = ids.iter().map(|id| id.0).collect_vec();
         let ids_ref: &[i64] = &ids;
         let results = select_user_subscriptions_with_predicate!(
@@ -89,7 +89,7 @@ impl UserSubscriptionItem {
     pub async fn get_all_user(
         user_id: DBUserId,
         exec: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
-    ) -> Result<Vec<UserSubscriptionItem>, DatabaseError> {
+    ) -> Result<Vec<DBUserSubscription>, DatabaseError> {
         let user_id = user_id.0;
         let results = select_user_subscriptions_with_predicate!(
             "WHERE us.user_id = $1",
@@ -107,7 +107,7 @@ impl UserSubscriptionItem {
     pub async fn get_all_servers(
         status: Option<SubscriptionStatus>,
         exec: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
-    ) -> Result<Vec<UserSubscriptionItem>, DatabaseError> {
+    ) -> Result<Vec<DBUserSubscription>, DatabaseError> {
         let status = status.map(|x| x.as_str());
 
         let results = select_user_subscriptions_with_predicate!(

--- a/apps/labrinth/src/models/v2/projects.rs
+++ b/apps/labrinth/src/models/v2/projects.rs
@@ -103,7 +103,7 @@ impl LegacyProject {
     // It's safe to use a db version_item for this as the only info is side types, game versions, and loader fields (for loaders), which used to be public on project anyway.
     pub fn from(
         data: Project,
-        versions_item: Option<version_item::QueryVersion>,
+        versions_item: Option<version_item::VersionQueryResult>,
     ) -> Self {
         let mut client_side = LegacySideType::Unknown;
         let mut server_side = LegacySideType::Unknown;
@@ -237,7 +237,8 @@ impl LegacyProject {
             .filter_map(|p| p.versions.first().map(|i| (*i).into()))
             .collect();
         let example_versions =
-            version_item::Version::get_many(&version_ids, exec, redis).await?;
+            version_item::DBVersion::get_many(&version_ids, exec, redis)
+                .await?;
         let mut legacy_projects = Vec::new();
         for project in data {
             let version_item = example_versions

--- a/apps/labrinth/src/models/v3/billing.rs
+++ b/apps/labrinth/src/models/v3/billing.rs
@@ -90,11 +90,11 @@ pub struct UserSubscription {
     pub metadata: Option<SubscriptionMetadata>,
 }
 
-impl From<crate::database::models::user_subscription_item::UserSubscriptionItem>
+impl From<crate::database::models::user_subscription_item::DBUserSubscription>
     for UserSubscription
 {
     fn from(
-        x: crate::database::models::user_subscription_item::UserSubscriptionItem,
+        x: crate::database::models::user_subscription_item::DBUserSubscription,
     ) -> Self {
         Self {
             id: x.id.into(),

--- a/apps/labrinth/src/models/v3/collections.rs
+++ b/apps/labrinth/src/models/v3/collections.rs
@@ -35,8 +35,8 @@ pub struct Collection {
     pub projects: Vec<ProjectId>,
 }
 
-impl From<database::models::Collection> for Collection {
-    fn from(c: database::models::Collection) -> Self {
+impl From<database::models::DBCollection> for Collection {
+    fn from(c: database::models::DBCollection) -> Self {
         Self {
             id: c.id.into(),
             user: c.user_id.into(),

--- a/apps/labrinth/src/models/v3/images.rs
+++ b/apps/labrinth/src/models/v3/images.rs
@@ -2,7 +2,7 @@ use super::{
     ids::{ProjectId, ThreadMessageId, VersionId},
     pats::Scopes,
 };
-use crate::database::models::image_item::Image as DBImage;
+use crate::database::models::image_item::DBImage;
 use crate::models::ids::{ImageId, ReportId};
 use ariadne::ids::UserId;
 use chrono::{DateTime, Utc};

--- a/apps/labrinth/src/models/v3/notifications.rs
+++ b/apps/labrinth/src/models/v3/notifications.rs
@@ -1,6 +1,6 @@
 use super::ids::OrganizationId;
-use crate::database::models::notification_item::Notification as DBNotification;
-use crate::database::models::notification_item::NotificationAction as DBNotificationAction;
+use crate::database::models::notification_item::DBNotification;
+use crate::database::models::notification_item::DBNotificationAction;
 use crate::models::ids::{
     NotificationId, ProjectId, ReportId, TeamId, ThreadId, ThreadMessageId,
     VersionId,

--- a/apps/labrinth/src/models/v3/oauth_clients.rs
+++ b/apps/labrinth/src/models/v3/oauth_clients.rs
@@ -1,7 +1,7 @@
 use super::pats::Scopes;
-use crate::database::models::oauth_client_authorization_item::OAuthClientAuthorization as DBOAuthClientAuthorization;
-use crate::database::models::oauth_client_item::OAuthClient as DBOAuthClient;
-use crate::database::models::oauth_client_item::OAuthRedirectUri as DBOAuthRedirectUri;
+use crate::database::models::oauth_client_authorization_item::DBOAuthClientAuthorization;
+use crate::database::models::oauth_client_item::DBOAuthClient;
+use crate::database::models::oauth_client_item::DBOAuthRedirectUri;
 use crate::models::ids::{
     OAuthClientAuthorizationId, OAuthClientId, OAuthRedirectUriId,
 };

--- a/apps/labrinth/src/models/v3/organizations.rs
+++ b/apps/labrinth/src/models/v3/organizations.rs
@@ -27,7 +27,7 @@ pub struct Organization {
 
 impl Organization {
     pub fn from(
-        data: crate::database::models::organization_item::Organization,
+        data: crate::database::models::organization_item::DBOrganization,
         team_members: Vec<TeamMember>,
     ) -> Self {
         Self {

--- a/apps/labrinth/src/models/v3/pats.rs
+++ b/apps/labrinth/src/models/v3/pats.rs
@@ -155,7 +155,7 @@ pub struct PersonalAccessToken {
 
 impl PersonalAccessToken {
     pub fn from(
-        data: crate::database::models::pat_item::PersonalAccessToken,
+        data: crate::database::models::pat_item::DBPersonalAccessToken,
         include_token: bool,
     ) -> Self {
         Self {

--- a/apps/labrinth/src/models/v3/payouts.rs
+++ b/apps/labrinth/src/models/v3/payouts.rs
@@ -22,7 +22,7 @@ pub struct Payout {
 }
 
 impl Payout {
-    pub fn from(data: crate::database::models::payout_item::Payout) -> Self {
+    pub fn from(data: crate::database::models::payout_item::DBPayout) -> Self {
         Self {
             id: data.id.into(),
             user_id: data.user_id.into(),

--- a/apps/labrinth/src/models/v3/projects.rs
+++ b/apps/labrinth/src/models/v3/projects.rs
@@ -1,8 +1,8 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::database::models::loader_fields::VersionField;
-use crate::database::models::project_item::{LinkUrl, QueryProject};
-use crate::database::models::version_item::QueryVersion;
+use crate::database::models::project_item::{LinkUrl, ProjectQueryResult};
+use crate::database::models::version_item::VersionQueryResult;
 use crate::models::ids::{
     OrganizationId, ProjectId, TeamId, ThreadId, VersionId,
 };
@@ -139,8 +139,8 @@ pub fn from_duplicate_version_fields(
     fields
 }
 
-impl From<QueryProject> for Project {
-    fn from(data: QueryProject) -> Self {
+impl From<ProjectQueryResult> for Project {
+    fn from(data: ProjectQueryResult) -> Self {
         let fields =
             from_duplicate_version_fields(data.aggregate_version_fields);
         let m = data.inner;
@@ -657,8 +657,8 @@ where
     Ok(map)
 }
 
-impl From<QueryVersion> for Version {
-    fn from(data: QueryVersion) -> Version {
+impl From<VersionQueryResult> for Version {
+    fn from(data: VersionQueryResult) -> Version {
         let v = data.inner;
         Version {
             id: v.id.into(),

--- a/apps/labrinth/src/models/v3/reports.rs
+++ b/apps/labrinth/src/models/v3/reports.rs
@@ -1,4 +1,4 @@
-use crate::database::models::report_item::QueryReport as DBReport;
+use crate::database::models::report_item::ReportQueryResult as DBReport;
 use crate::models::ids::{ProjectId, ReportId, ThreadId, VersionId};
 use ariadne::ids::UserId;
 use chrono::{DateTime, Utc};

--- a/apps/labrinth/src/models/v3/sessions.rs
+++ b/apps/labrinth/src/models/v3/sessions.rs
@@ -27,7 +27,7 @@ pub struct Session {
 
 impl Session {
     pub fn from(
-        data: crate::database::models::session_item::Session,
+        data: crate::database::models::session_item::DBSession,
         include_session: bool,
         current_session: Option<&str>,
     ) -> Self {

--- a/apps/labrinth/src/models/v3/teams.rs
+++ b/apps/labrinth/src/models/v3/teams.rs
@@ -42,8 +42,10 @@ impl Default for ProjectPermissions {
 impl ProjectPermissions {
     pub fn get_permissions_by_role(
         role: &crate::models::users::Role,
-        project_team_member: &Option<crate::database::models::TeamMember>, // team member of the user in the project
-        organization_team_member: &Option<crate::database::models::TeamMember>, // team member of the user in the organization
+        project_team_member: &Option<crate::database::models::DBTeamMember>, // team member of the user in the project
+        organization_team_member: &Option<
+            crate::database::models::DBTeamMember,
+        >, // team member of the user in the organization
     ) -> Option<Self> {
         if role.is_admin() {
             return Some(ProjectPermissions::all());
@@ -99,7 +101,7 @@ impl Default for OrganizationPermissions {
 impl OrganizationPermissions {
     pub fn get_permissions_by_role(
         role: &crate::models::users::Role,
-        team_member: &Option<crate::database::models::TeamMember>,
+        team_member: &Option<crate::database::models::DBTeamMember>,
     ) -> Option<Self> {
         if role.is_admin() {
             return Some(OrganizationPermissions::all());
@@ -154,8 +156,8 @@ pub struct TeamMember {
 
 impl TeamMember {
     pub fn from(
-        data: crate::database::models::team_item::TeamMember,
-        user: crate::database::models::User,
+        data: crate::database::models::team_item::DBTeamMember,
+        user: crate::database::models::DBUser,
         override_permissions: bool,
     ) -> Self {
         let user: User = user.into();
@@ -166,7 +168,7 @@ impl TeamMember {
     // if already available.
     // (Avoids a db query in some cases)
     pub fn from_model(
-        data: crate::database::models::team_item::TeamMember,
+        data: crate::database::models::team_item::DBTeamMember,
         user: crate::models::users::User,
         override_permissions: bool,
     ) -> Self {

--- a/apps/labrinth/src/models/v3/threads.rs
+++ b/apps/labrinth/src/models/v3/threads.rs
@@ -86,7 +86,7 @@ impl ThreadType {
 
 impl Thread {
     pub fn from(
-        data: crate::database::models::Thread,
+        data: crate::database::models::DBThread,
         users: Vec<User>,
         user: &User,
     ) -> Self {
@@ -119,7 +119,7 @@ impl Thread {
 
 impl ThreadMessage {
     pub fn from(
-        data: crate::database::models::ThreadMessage,
+        data: crate::database::models::DBThreadMessage,
         user: &User,
     ) -> Self {
         Self {

--- a/apps/labrinth/src/models/v3/users.rs
+++ b/apps/labrinth/src/models/v3/users.rs
@@ -63,7 +63,7 @@ pub struct UserPayoutData {
     pub balance: Decimal,
 }
 
-use crate::database::models::user_item::User as DBUser;
+use crate::database::models::user_item::DBUser;
 impl From<DBUser> for User {
     fn from(data: DBUser) -> Self {
         Self {
@@ -196,9 +196,7 @@ pub struct UserFriend {
 }
 
 impl UserFriend {
-    pub fn from(
-        data: crate::database::models::friend_item::FriendItem,
-    ) -> Self {
+    pub fn from(data: crate::database::models::friend_item::DBFriend) -> Self {
         Self {
             id: data.friend_id.into(),
             friend_id: data.user_id.into(),

--- a/apps/labrinth/src/queue/moderation.rs
+++ b/apps/labrinth/src/queue/moderation.rs
@@ -233,7 +233,7 @@ impl AutomatedModerationQueue {
             for project in projects {
                 async {
                     let project =
-                        database::Project::get_id((project).into(), &pool, &redis).await?;
+                        database::DBProject::get_id((project).into(), &pool, &redis).await?;
 
                     if let Some(project) = project {
                         let res = async {
@@ -261,7 +261,7 @@ impl AutomatedModerationQueue {
                             }
 
                             let versions =
-                                database::Version::get_many(&project.versions, &pool, &redis)
+                                database::DBVersion::get_many(&project.versions, &pool, &redis)
                                     .await?
                                     .into_iter()
                                     // we only support modpacks at this time
@@ -343,7 +343,7 @@ impl AutomatedModerationQueue {
                                         }
                                     }
 
-                                    let files = database::models::Version::get_files_from_hash(
+                                    let files = database::models::DBVersion::get_files_from_hash(
                                         "sha1".to_string(),
                                         &hashes.iter().map(|x| x.0.clone()).collect::<Vec<_>>(),
                                         &pool,
@@ -354,7 +354,7 @@ impl AutomatedModerationQueue {
                                     let version_ids =
                                         files.iter().map(|x| x.version_id).collect::<Vec<_>>();
                                     let versions_data = filter_visible_versions(
-                                        database::models::Version::get_many(
+                                        database::models::DBVersion::get_many(
                                             &version_ids,
                                             &pool,
                                             &redis,
@@ -621,7 +621,7 @@ impl AutomatedModerationQueue {
                             }
 
                             if !mod_messages.is_empty() {
-                                let first_time = database::models::Thread::get(project.thread_id, &pool).await?
+                                let first_time = database::models::DBThread::get(project.thread_id, &pool).await?
                                     .map(|x| x.messages.iter().all(|x| x.author_id == Some(database::models::DBUserId(AUTOMOD_ID)) || x.hide_identity))
                                     .unwrap_or(true);
 
@@ -640,7 +640,7 @@ impl AutomatedModerationQueue {
                                     .insert(&mut transaction)
                                     .await?;
 
-                                let members = database::models::TeamMember::get_from_team_full(
+                                let members = database::models::DBTeamMember::get_from_team_full(
                                     project.inner.team_id,
                                     &pool,
                                     &redis,
@@ -700,7 +700,7 @@ impl AutomatedModerationQueue {
                                         .execute(&pool)
                                         .await?;
 
-                                    database::models::Project::clear_cache(
+                                    database::models::DBProject::clear_cache(
                                         project.inner.id,
                                         project.inner.slug.clone(),
                                         None,

--- a/apps/labrinth/src/queue/session.rs
+++ b/apps/labrinth/src/queue/session.rs
@@ -1,5 +1,5 @@
-use crate::database::models::pat_item::PersonalAccessToken;
-use crate::database::models::session_item::Session;
+use crate::database::models::pat_item::DBPersonalAccessToken;
+use crate::database::models::session_item::DBSession;
 use crate::database::models::{
     DBOAuthAccessTokenId, DBPatId, DBSessionId, DBUserId, DatabaseError,
 };
@@ -123,10 +123,10 @@ impl AuthQueue {
                     Some(session),
                     Some(user_id),
                 ));
-                Session::remove(id, &mut transaction).await?;
+                DBSession::remove(id, &mut transaction).await?;
             }
 
-            Session::clear_cache(clear_cache_sessions, redis).await?;
+            DBSession::clear_cache(clear_cache_sessions, redis).await?;
 
             let ids = pat_queue.iter().map(|id| id.0).collect_vec();
             let clear_cache_pats = pat_queue
@@ -153,7 +153,7 @@ impl AuthQueue {
             .await?;
 
             transaction.commit().await?;
-            PersonalAccessToken::clear_cache(clear_cache_pats, redis).await?;
+            DBPersonalAccessToken::clear_cache(clear_cache_pats, redis).await?;
         }
 
         Ok(())

--- a/apps/labrinth/src/routes/analytics.rs
+++ b/apps/labrinth/src/routes/analytics.rs
@@ -130,7 +130,7 @@ pub async fn page_view_ingest(
             ];
 
             if PROJECT_TYPES.contains(&segments_vec[0]) {
-                let project = crate::database::models::Project::get(
+                let project = crate::database::models::DBProject::get(
                     segments_vec[1],
                     &**pool,
                     &redis,
@@ -189,7 +189,7 @@ pub async fn playtime_ingest(
         ));
     }
 
-    let versions = crate::database::models::Version::get_many(
+    let versions = crate::database::models::DBVersion::get_many(
         &playtimes.iter().map(|x| (*x.0).into()).collect::<Vec<_>>(),
         &**pool,
         &redis,

--- a/apps/labrinth/src/routes/internal/admin.rs
+++ b/apps/labrinth/src/routes/internal/admin.rs
@@ -204,7 +204,7 @@ pub async fn delphi_result_ingest(
 
     let webhook_url = dotenvy::var("DELPHI_SLACK_WEBHOOK")?;
 
-    let project = crate::database::models::Project::get_id(
+    let project = crate::database::models::DBProject::get_id(
         body.project_id.into(),
         &**pool,
         &redis,

--- a/apps/labrinth/src/routes/internal/gdpr.rs
+++ b/apps/labrinth/src/routes/internal/gdpr.rs
@@ -30,9 +30,9 @@ pub async fn export(
     let user_id = user.id.into();
 
     let collection_ids =
-        crate::database::models::User::get_collections(user_id, &**pool)
+        crate::database::models::DBUser::get_collections(user_id, &**pool)
             .await?;
-    let collections = crate::database::models::Collection::get_many(
+    let collections = crate::database::models::DBCollection::get_many(
         &collection_ids,
         &**pool,
         &redis,
@@ -42,24 +42,25 @@ pub async fn export(
     .map(crate::models::collections::Collection::from)
     .collect::<Vec<_>>();
 
-    let follows = crate::database::models::User::get_follows(user_id, &**pool)
-        .await?
-        .into_iter()
-        .map(crate::models::ids::ProjectId::from)
-        .collect::<Vec<_>>();
+    let follows =
+        crate::database::models::DBUser::get_follows(user_id, &**pool)
+            .await?
+            .into_iter()
+            .map(crate::models::ids::ProjectId::from)
+            .collect::<Vec<_>>();
 
     let projects =
-        crate::database::models::User::get_projects(user_id, &**pool, &redis)
+        crate::database::models::DBUser::get_projects(user_id, &**pool, &redis)
             .await?
             .into_iter()
             .map(crate::models::ids::ProjectId::from)
             .collect::<Vec<_>>();
 
     let org_ids =
-        crate::database::models::User::get_organizations(user_id, &**pool)
+        crate::database::models::DBUser::get_organizations(user_id, &**pool)
             .await?;
     let orgs =
-        crate::database::models::organization_item::Organization::get_many_ids(
+        crate::database::models::organization_item::DBOrganization::get_many_ids(
             &org_ids, &**pool, &redis,
         )
         .await?
@@ -68,7 +69,7 @@ pub async fn export(
         .map(|x| crate::models::organizations::Organization::from(x, vec![]))
         .collect::<Vec<_>>();
 
-    let notifs = crate::database::models::notification_item::Notification::get_many_user(
+    let notifs = crate::database::models::notification_item::DBNotification::get_many_user(
         user_id, &**pool, &redis,
     )
     .await?
@@ -77,7 +78,7 @@ pub async fn export(
     .collect::<Vec<_>>();
 
     let oauth_clients =
-        crate::database::models::oauth_client_item::OAuthClient::get_all_user_clients(
+        crate::database::models::oauth_client_item::DBOAuthClient::get_all_user_clients(
             user_id, &**pool,
         )
         .await?
@@ -85,7 +86,7 @@ pub async fn export(
         .map(crate::models::oauth_clients::OAuthClient::from)
         .collect::<Vec<_>>();
 
-    let oauth_authorizations = crate::database::models::oauth_client_authorization_item::OAuthClientAuthorization::get_all_for_user(
+    let oauth_authorizations = crate::database::models::oauth_client_authorization_item::DBOAuthClientAuthorization::get_all_for_user(
         user_id, &**pool,
     )
         .await?
@@ -94,12 +95,12 @@ pub async fn export(
         .collect::<Vec<_>>();
 
     let pat_ids =
-        crate::database::models::pat_item::PersonalAccessToken::get_user_pats(
+        crate::database::models::pat_item::DBPersonalAccessToken::get_user_pats(
             user_id, &**pool, &redis,
         )
         .await?;
     let pats =
-        crate::database::models::pat_item::PersonalAccessToken::get_many_ids(
+        crate::database::models::pat_item::DBPersonalAccessToken::get_many_ids(
             &pat_ids, &**pool, &redis,
         )
         .await?
@@ -108,12 +109,12 @@ pub async fn export(
         .collect::<Vec<_>>();
 
     let payout_ids =
-        crate::database::models::payout_item::Payout::get_all_for_user(
+        crate::database::models::payout_item::DBPayout::get_all_for_user(
             user_id, &**pool,
         )
         .await?;
 
-    let payouts = crate::database::models::payout_item::Payout::get_many(
+    let payouts = crate::database::models::payout_item::DBPayout::get_many(
         &payout_ids,
         &**pool,
     )
@@ -122,10 +123,11 @@ pub async fn export(
     .map(crate::models::payouts::Payout::from)
     .collect::<Vec<_>>();
 
-    let report_ids =
-        crate::database::models::user_item::User::get_reports(user_id, &**pool)
-            .await?;
-    let reports = crate::database::models::report_item::Report::get_many(
+    let report_ids = crate::database::models::user_item::DBUser::get_reports(
+        user_id, &**pool,
+    )
+    .await?;
+    let reports = crate::database::models::report_item::DBReport::get_many(
         &report_ids,
         &**pool,
     )
@@ -147,7 +149,7 @@ pub async fn export(
     .collect::<Vec<_>>();
 
     let messages =
-        crate::database::models::thread_item::ThreadMessage::get_many(
+        crate::database::models::thread_item::DBThreadMessage::get_many(
             &message_ids,
             &**pool,
         )
@@ -166,18 +168,19 @@ pub async fn export(
     .map(|x| crate::database::models::ids::DBImageId(x.id))
     .collect::<Vec<_>>();
 
-    let uploaded_images = crate::database::models::image_item::Image::get_many(
-        &uploaded_images_ids,
-        &**pool,
-        &redis,
-    )
-    .await?
-    .into_iter()
-    .map(crate::models::images::Image::from)
-    .collect::<Vec<_>>();
+    let uploaded_images =
+        crate::database::models::image_item::DBImage::get_many(
+            &uploaded_images_ids,
+            &**pool,
+            &redis,
+        )
+        .await?
+        .into_iter()
+        .map(crate::models::images::Image::from)
+        .collect::<Vec<_>>();
 
     let subscriptions =
-        crate::database::models::user_subscription_item::UserSubscriptionItem::get_all_user(
+        crate::database::models::user_subscription_item::DBUserSubscription::get_all_user(
             user_id, &**pool,
         )
         .await?

--- a/apps/labrinth/src/routes/internal/moderation.rs
+++ b/apps/labrinth/src/routes/internal/moderation.rs
@@ -61,7 +61,7 @@ pub async fn get_projects(
     .await?;
 
     let projects: Vec<_> =
-        database::Project::get_many_ids(&project_ids, &**pool, &redis)
+        database::DBProject::get_many_ids(&project_ids, &**pool, &redis)
             .await?
             .into_iter()
             .map(crate::models::projects::Project::from)
@@ -88,7 +88,7 @@ pub async fn get_project_meta(
 
     let project_id = info.into_inner().0;
     let project =
-        database::models::Project::get(&project_id, &**pool, &redis).await?;
+        database::models::DBProject::get(&project_id, &**pool, &redis).await?;
 
     if let Some(project) = project {
         let rows = sqlx::query!(

--- a/apps/labrinth/src/routes/internal/pats.rs
+++ b/apps/labrinth/src/routes/internal/pats.rs
@@ -45,13 +45,13 @@ pub async fn get_pats(
     .1;
 
     let pat_ids =
-        database::models::pat_item::PersonalAccessToken::get_user_pats(
+        database::models::pat_item::DBPersonalAccessToken::get_user_pats(
             user.id.into(),
             &**pool,
             &redis,
         )
         .await?;
-    let pats = database::models::pat_item::PersonalAccessToken::get_many_ids(
+    let pats = database::models::pat_item::DBPersonalAccessToken::get_many_ids(
         &pat_ids, &**pool, &redis,
     )
     .await?;
@@ -116,7 +116,7 @@ pub async fn create_pat(
     let token = format!("mrp_{token}");
 
     let name = info.name.clone();
-    database::models::pat_item::PersonalAccessToken {
+    database::models::pat_item::DBPersonalAccessToken {
         id,
         name: name.clone(),
         access_token: token.clone(),
@@ -130,7 +130,7 @@ pub async fn create_pat(
     .await?;
 
     transaction.commit().await?;
-    database::models::pat_item::PersonalAccessToken::clear_cache(
+    database::models::pat_item::DBPersonalAccessToken::clear_cache(
         vec![(None, None, Some(user.id.into()))],
         &redis,
     )
@@ -180,7 +180,7 @@ pub async fn edit_pat(
     .1;
 
     let id = id.into_inner().0;
-    let pat = database::models::pat_item::PersonalAccessToken::get(
+    let pat = database::models::pat_item::DBPersonalAccessToken::get(
         &id, &**pool, &redis,
     )
     .await?;
@@ -242,7 +242,7 @@ pub async fn edit_pat(
             }
 
             transaction.commit().await?;
-            database::models::pat_item::PersonalAccessToken::clear_cache(
+            database::models::pat_item::DBPersonalAccessToken::clear_cache(
                 vec![(Some(pat.id), Some(pat.access_token), Some(pat.user_id))],
                 &redis,
             )
@@ -271,7 +271,7 @@ pub async fn delete_pat(
     .await?
     .1;
     let id = id.into_inner().0;
-    let pat = database::models::pat_item::PersonalAccessToken::get(
+    let pat = database::models::pat_item::DBPersonalAccessToken::get(
         &id, &**pool, &redis,
     )
     .await?;
@@ -279,13 +279,13 @@ pub async fn delete_pat(
     if let Some(pat) = pat {
         if pat.user_id == user.id.into() {
             let mut transaction = pool.begin().await?;
-            database::models::pat_item::PersonalAccessToken::remove(
+            database::models::pat_item::DBPersonalAccessToken::remove(
                 pat.id,
                 &mut transaction,
             )
             .await?;
             transaction.commit().await?;
-            database::models::pat_item::PersonalAccessToken::clear_cache(
+            database::models::pat_item::DBPersonalAccessToken::clear_cache(
                 vec![(Some(pat.id), Some(pat.access_token), Some(pat.user_id))],
                 &redis,
             )

--- a/apps/labrinth/src/routes/internal/session.rs
+++ b/apps/labrinth/src/routes/internal/session.rs
@@ -1,6 +1,6 @@
 use crate::auth::{AuthenticationError, get_user_from_headers};
 use crate::database::models::DBUserId;
-use crate::database::models::session_item::Session as DBSession;
+use crate::database::models::session_item::DBSession;
 use crate::database::models::session_item::SessionBuilder;
 use crate::database::redis::RedisPool;
 use crate::models::pats::Scopes;

--- a/apps/labrinth/src/routes/internal/statuses.rs
+++ b/apps/labrinth/src/routes/internal/statuses.rs
@@ -1,6 +1,6 @@
 use crate::auth::AuthenticationError;
 use crate::auth::validate::get_user_record_from_bearer_token;
-use crate::database::models::friend_item::FriendItem;
+use crate::database::models::friend_item::DBFriend;
 use crate::database::redis::RedisPool;
 use crate::models::pats::Scopes;
 use crate::models::users::User;
@@ -85,8 +85,7 @@ pub async fn ws_init(
     };
 
     let friends =
-        FriendItem::get_user_friends(user.id.into(), Some(true), &**pool)
-            .await?;
+        DBFriend::get_user_friends(user.id.into(), Some(true), &**pool).await?;
 
     let friend_statuses = if !friends.is_empty() {
         let db = db.clone();
@@ -383,7 +382,7 @@ pub async fn broadcast_to_local_friends(
         user_id,
         message,
         sockets,
-        FriendItem::get_user_friends(user_id.into(), Some(true), pool).await?,
+        DBFriend::get_user_friends(user_id.into(), Some(true), pool).await?,
     )
     .await
 }
@@ -392,7 +391,7 @@ async fn broadcast_to_known_local_friends(
     user_id: UserId,
     message: ServerToClientMessage,
     sockets: &ActiveSockets,
-    friends: Vec<FriendItem>,
+    friends: Vec<DBFriend>,
 ) -> Result<(), crate::database::models::DatabaseError> {
     // FIXME Probably shouldn't be using database errors for this. Maybe ApiError?
 

--- a/apps/labrinth/src/routes/maven.rs
+++ b/apps/labrinth/src/routes/maven.rs
@@ -1,8 +1,10 @@
 use crate::auth::checks::{is_visible_project, is_visible_version};
 use crate::database::models::legacy_loader_fields::MinecraftGameVersion;
 use crate::database::models::loader_fields::Loader;
-use crate::database::models::project_item::QueryProject;
-use crate::database::models::version_item::{QueryFile, QueryVersion};
+use crate::database::models::project_item::ProjectQueryResult;
+use crate::database::models::version_item::{
+    FileQueryResult, VersionQueryResult,
+};
 use crate::database::redis::RedisPool;
 use crate::models::ids::{ProjectId, VersionId};
 use crate::models::pats::Scopes;
@@ -76,7 +78,7 @@ pub async fn maven_metadata(
 ) -> Result<HttpResponse, ApiError> {
     let project_id = params.into_inner().0;
     let Some(project) =
-        database::models::Project::get(&project_id, &**pool, &redis).await?
+        database::models::DBProject::get(&project_id, &**pool, &redis).await?
     else {
         return Err(ApiError::NotFound);
     };
@@ -159,17 +161,17 @@ pub async fn maven_metadata(
 }
 
 async fn find_version(
-    project: &QueryProject,
+    project: &ProjectQueryResult,
     vcoords: &String,
     pool: &PgPool,
     redis: &RedisPool,
-) -> Result<Option<QueryVersion>, ApiError> {
+) -> Result<Option<VersionQueryResult>, ApiError> {
     let id_option = ariadne::ids::base62_impl::parse_base62(vcoords)
         .ok()
         .map(|x| x as i64);
 
     let all_versions =
-        database::models::Version::get_many(&project.versions, pool, redis)
+        database::models::DBVersion::get_many(&project.versions, pool, redis)
             .await?;
 
     let exact_matches = all_versions
@@ -236,9 +238,9 @@ async fn find_version(
 fn find_file<'a>(
     project_id: &str,
     vcoords: &str,
-    version: &'a QueryVersion,
+    version: &'a VersionQueryResult,
     file: &str,
-) -> Option<&'a QueryFile> {
+) -> Option<&'a FileQueryResult> {
     if let Some(selected_file) =
         version.files.iter().find(|x| x.filename == file)
     {
@@ -282,7 +284,7 @@ pub async fn version_file(
 ) -> Result<HttpResponse, ApiError> {
     let (project_id, vnum, file) = params.into_inner();
     let Some(project) =
-        database::models::Project::get(&project_id, &**pool, &redis).await?
+        database::models::DBProject::get(&project_id, &**pool, &redis).await?
     else {
         return Err(ApiError::NotFound);
     };
@@ -348,7 +350,7 @@ pub async fn version_file_sha1(
 ) -> Result<HttpResponse, ApiError> {
     let (project_id, vnum, file) = params.into_inner();
     let Some(project) =
-        database::models::Project::get(&project_id, &**pool, &redis).await?
+        database::models::DBProject::get(&project_id, &**pool, &redis).await?
     else {
         return Err(ApiError::NotFound);
     };
@@ -393,7 +395,7 @@ pub async fn version_file_sha512(
 ) -> Result<HttpResponse, ApiError> {
     let (project_id, vnum, file) = params.into_inner();
     let Some(project) =
-        database::models::Project::get(&project_id, &**pool, &redis).await?
+        database::models::DBProject::get(&project_id, &**pool, &redis).await?
     else {
         return Err(ApiError::NotFound);
     };

--- a/apps/labrinth/src/routes/updates.rs
+++ b/apps/labrinth/src/routes/updates.rs
@@ -42,7 +42,7 @@ pub async fn forge_updates(
 
     let (id,) = info.into_inner();
 
-    let project = database::models::Project::get(&id, &**pool, &redis)
+    let project = database::models::DBProject::get(&id, &**pool, &redis)
         .await?
         .ok_or_else(|| ApiError::InvalidInput(ERROR.to_string()))?;
 
@@ -61,9 +61,12 @@ pub async fn forge_updates(
         return Err(ApiError::InvalidInput(ERROR.to_string()));
     }
 
-    let versions =
-        database::models::Version::get_many(&project.versions, &**pool, &redis)
-            .await?;
+    let versions = database::models::DBVersion::get_many(
+        &project.versions,
+        &**pool,
+        &redis,
+    )
+    .await?;
 
     let loaders = match &*neo.neoforge {
         "only" => |x: &String| *x == "neoforge",

--- a/apps/labrinth/src/routes/v2/project_creation.rs
+++ b/apps/labrinth/src/routes/v2/project_creation.rs
@@ -258,8 +258,12 @@ pub async fn project_create(
         Ok(project) => {
             let version_item = match project.versions.first() {
                 Some(vid) => {
-                    version_item::Version::get((*vid).into(), &**client, &redis)
-                        .await?
+                    version_item::DBVersion::get(
+                        (*vid).into(),
+                        &**client,
+                        &redis,
+                    )
+                    .await?
                 }
                 None => None,
             };

--- a/apps/labrinth/src/routes/v2/projects.rs
+++ b/apps/labrinth/src/routes/v2/projects.rs
@@ -229,7 +229,7 @@ pub async fn project_get(
         Ok(project) => {
             let version_item = match project.versions.first() {
                 Some(vid) => {
-                    version_item::Version::get((*vid).into(), &**pool, &redis)
+                    version_item::DBVersion::get((*vid).into(), &**pool, &redis)
                         .await?
                 }
                 None => None,
@@ -469,7 +469,7 @@ pub async fn project_edit(
     if let Some(donation_urls) = v2_new_project.donation_urls {
         // Fetch current donation links from project so we know what to delete
         let fetched_example_project =
-            project_item::Project::get(&info.0, &**pool, &redis).await?;
+            project_item::DBProject::get(&info.0, &**pool, &redis).await?;
         let donation_links = fetched_example_project
             .map(|x| {
                 x.urls
@@ -533,7 +533,7 @@ pub async fn project_edit(
     if response.status().is_success()
         && (client_side.is_some() || server_side.is_some())
     {
-        let project_item = project_item::Project::get(
+        let project_item = project_item::DBProject::get(
             &new_slug.unwrap_or(project_id),
             &**pool,
             &redis,
@@ -541,7 +541,7 @@ pub async fn project_edit(
         .await?;
         let version_ids = project_item.map(|x| x.versions).unwrap_or_default();
         let versions =
-            version_item::Version::get_many(&version_ids, &**pool, &redis)
+            version_item::DBVersion::get_many(&version_ids, &**pool, &redis)
                 .await?;
         for version in versions {
             let version = Version::from(version);

--- a/apps/labrinth/src/routes/v2/version_creation.rs
+++ b/apps/labrinth/src/routes/v2/version_creation.rs
@@ -288,17 +288,20 @@ async fn get_example_version_fields(
         None => return Ok(None),
     };
 
-    let vid =
-        match project_item::Project::get_id(project_id.into(), &**pool, redis)
-            .await?
-            .and_then(|p| p.versions.first().cloned())
-        {
-            Some(vid) => vid,
-            None => return Ok(None),
-        };
+    let vid = match project_item::DBProject::get_id(
+        project_id.into(),
+        &**pool,
+        redis,
+    )
+    .await?
+    .and_then(|p| p.versions.first().cloned())
+    {
+        Some(vid) => vid,
+        None => return Ok(None),
+    };
 
     let example_version =
-        match version_item::Version::get(vid, &**pool, redis).await? {
+        match version_item::DBVersion::get(vid, &**pool, redis).await? {
             Some(version) => version,
             None => return Ok(None),
         };

--- a/apps/labrinth/src/routes/v3/analytics_get.rs
+++ b/apps/labrinth/src/routes/v3/analytics_get.rs
@@ -578,7 +578,7 @@ async fn filter_allowed_ids(
     // If no project_ids or version_ids are provided, we default to all projects the user has *public* access to
     if project_ids.is_none() && !remove_defaults.unwrap_or(false) {
         project_ids = Some(
-            user_item::User::get_projects(user.id.into(), &***pool, redis)
+            user_item::DBUser::get_projects(user.id.into(), &***pool, redis)
                 .await?
                 .into_iter()
                 .map(|x| ProjectId::from(x).to_string())
@@ -589,7 +589,7 @@ async fn filter_allowed_ids(
     // Convert String list to list of ProjectIds or VersionIds
     // - Filter out unauthorized projects/versions
     let project_ids = if let Some(project_strings) = project_ids {
-        let projects_data = database::models::Project::get_many(
+        let projects_data = database::models::DBProject::get_many(
             &project_strings,
             &***pool,
             redis,
@@ -601,7 +601,7 @@ async fn filter_allowed_ids(
             .map(|x| x.inner.team_id)
             .collect::<Vec<database::models::DBTeamId>>();
         let team_members =
-            database::models::TeamMember::get_from_team_full_many(
+            database::models::DBTeamMember::get_from_team_full_many(
                 &team_ids, &***pool, redis,
             )
             .await?;
@@ -610,7 +610,7 @@ async fn filter_allowed_ids(
             .iter()
             .filter_map(|x| x.inner.organization_id)
             .collect::<Vec<database::models::DBOrganizationId>>();
-        let organizations = database::models::Organization::get_many_ids(
+        let organizations = database::models::DBOrganization::get_many_ids(
             &organization_ids,
             &***pool,
             redis,
@@ -622,7 +622,7 @@ async fn filter_allowed_ids(
             .map(|x| x.team_id)
             .collect::<Vec<database::models::DBTeamId>>();
         let organization_team_members =
-            database::models::TeamMember::get_from_team_full_many(
+            database::models::DBTeamMember::get_from_team_full_many(
                 &organization_team_ids,
                 &***pool,
                 redis,

--- a/apps/labrinth/src/routes/v3/friends.rs
+++ b/apps/labrinth/src/routes/v3/friends.rs
@@ -43,13 +43,13 @@ pub async fn add_friend(
 
     let string = info.into_inner().0;
     let friend =
-        crate::database::models::User::get(&string, &**pool, &redis).await?;
+        crate::database::models::DBUser::get(&string, &**pool, &redis).await?;
 
     if let Some(friend) = friend {
         let mut transaction = pool.begin().await?;
 
         if let Some(friend) =
-            crate::database::models::friend_item::FriendItem::get_friend(
+            crate::database::models::friend_item::DBFriend::get_friend(
                 user.id.into(),
                 friend.id,
                 &**pool,
@@ -68,7 +68,7 @@ pub async fn add_friend(
                 ));
             }
 
-            crate::database::models::friend_item::FriendItem::update_friend(
+            crate::database::models::friend_item::DBFriend::update_friend(
                 friend.user_id,
                 friend.friend_id,
                 true,
@@ -115,7 +115,7 @@ pub async fn add_friend(
                 ));
             }
 
-            crate::database::models::friend_item::FriendItem {
+            crate::database::models::friend_item::DBFriend {
                 user_id: user.id.into(),
                 friend_id: friend.id,
                 created: Utc::now(),
@@ -161,12 +161,12 @@ pub async fn remove_friend(
 
     let string = info.into_inner().0;
     let friend =
-        crate::database::models::User::get(&string, &**pool, &redis).await?;
+        crate::database::models::DBUser::get(&string, &**pool, &redis).await?;
 
     if let Some(friend) = friend {
         let mut transaction = pool.begin().await?;
 
-        crate::database::models::friend_item::FriendItem::remove(
+        crate::database::models::friend_item::DBFriend::remove(
             user.id.into(),
             friend.id,
             &mut transaction,
@@ -206,7 +206,7 @@ pub async fn friends(
     .1;
 
     let friends =
-        crate::database::models::friend_item::FriendItem::get_user_friends(
+        crate::database::models::friend_item::DBFriend::get_user_friends(
             user.id.into(),
             None,
             &**pool,

--- a/apps/labrinth/src/routes/v3/images.rs
+++ b/apps/labrinth/src/routes/v3/images.rs
@@ -67,7 +67,7 @@ pub async fn images_add(
         ImageContext::Project { project_id } => {
             if let Some(id) = data.project_id {
                 let project =
-                    project_item::Project::get(&id, &**pool, &redis).await?;
+                    project_item::DBProject::get(&id, &**pool, &redis).await?;
                 if let Some(project) = project {
                     if is_team_member_project(
                         &project.inner,
@@ -92,7 +92,7 @@ pub async fn images_add(
         ImageContext::Version { version_id } => {
             if let Some(id) = data.version_id {
                 let version =
-                    version_item::Version::get(id.into(), &**pool, &redis)
+                    version_item::DBVersion::get(id.into(), &**pool, &redis)
                         .await?;
                 if let Some(version) = version {
                     if is_team_member_version(
@@ -119,7 +119,7 @@ pub async fn images_add(
         ImageContext::ThreadMessage { thread_message_id } => {
             if let Some(id) = data.thread_message_id {
                 let thread_message =
-                    thread_item::ThreadMessage::get(id.into(), &**pool)
+                    thread_item::DBThreadMessage::get(id.into(), &**pool)
                         .await?
                         .ok_or_else(|| {
                             ApiError::InvalidInput(
@@ -127,7 +127,7 @@ pub async fn images_add(
                                     .to_string(),
                             )
                         })?;
-                let thread = thread_item::Thread::get(thread_message.thread_id, &**pool)
+                let thread = thread_item::DBThread::get(thread_message.thread_id, &**pool)
                     .await?
                     .ok_or_else(|| {
                         ApiError::InvalidInput(
@@ -147,14 +147,14 @@ pub async fn images_add(
         }
         ImageContext::Report { report_id } => {
             if let Some(id) = data.report_id {
-                let report = report_item::Report::get(id.into(), &**pool)
+                let report = report_item::DBReport::get(id.into(), &**pool)
                     .await?
                     .ok_or_else(|| {
                         ApiError::InvalidInput(
                             "The report could not be found.".to_string(),
                         )
                     })?;
-                let thread = thread_item::Thread::get(report.thread_id, &**pool)
+                let thread = thread_item::DBThread::get(report.thread_id, &**pool)
                     .await?
                     .ok_or_else(|| {
                         ApiError::InvalidInput(
@@ -198,7 +198,7 @@ pub async fn images_add(
 
     let mut transaction = pool.begin().await?;
 
-    let db_image: database::models::Image = database::models::Image {
+    let db_image: database::models::DBImage = database::models::DBImage {
         id: database::models::generate_image_id(&mut transaction).await?,
         url: upload_result.url,
         raw_url: upload_result.raw_url,

--- a/apps/labrinth/src/routes/v3/notifications.rs
+++ b/apps/labrinth/src/routes/v3/notifications.rs
@@ -46,7 +46,7 @@ pub async fn notifications_get(
     .1;
 
     use database::models::DBNotificationId;
-    use database::models::notification_item::Notification as DBNotification;
+    use database::models::notification_item::DBNotification;
 
     let notification_ids: Vec<DBNotificationId> =
         serde_json::from_str::<Vec<NotificationId>>(ids.ids.as_str())?
@@ -55,7 +55,7 @@ pub async fn notifications_get(
             .collect();
 
     let notifications_data: Vec<DBNotification> =
-        database::models::notification_item::Notification::get_many(
+        database::models::notification_item::DBNotification::get_many(
             &notification_ids,
             &**pool,
         )
@@ -90,7 +90,7 @@ pub async fn notification_get(
     let id = info.into_inner().0;
 
     let notification_data =
-        database::models::notification_item::Notification::get(
+        database::models::notification_item::DBNotification::get(
             id.into(),
             &**pool,
         )
@@ -127,7 +127,7 @@ pub async fn notification_read(
     let id = info.into_inner().0;
 
     let notification_data =
-        database::models::notification_item::Notification::get(
+        database::models::notification_item::DBNotification::get(
             id.into(),
             &**pool,
         )
@@ -137,7 +137,7 @@ pub async fn notification_read(
         if data.user_id == user.id.into() || user.role.is_admin() {
             let mut transaction = pool.begin().await?;
 
-            database::models::notification_item::Notification::read(
+            database::models::notification_item::DBNotification::read(
                 id.into(),
                 &mut transaction,
                 &redis,
@@ -177,7 +177,7 @@ pub async fn notification_delete(
     let id = info.into_inner().0;
 
     let notification_data =
-        database::models::notification_item::Notification::get(
+        database::models::notification_item::DBNotification::get(
             id.into(),
             &**pool,
         )
@@ -187,7 +187,7 @@ pub async fn notification_delete(
         if data.user_id == user.id.into() || user.role.is_admin() {
             let mut transaction = pool.begin().await?;
 
-            database::models::notification_item::Notification::remove(
+            database::models::notification_item::DBNotification::remove(
                 id.into(),
                 &mut transaction,
                 &redis,
@@ -234,7 +234,7 @@ pub async fn notifications_read(
     let mut transaction = pool.begin().await?;
 
     let notifications_data =
-        database::models::notification_item::Notification::get_many(
+        database::models::notification_item::DBNotification::get_many(
             &notification_ids,
             &**pool,
         )
@@ -249,7 +249,7 @@ pub async fn notifications_read(
         }
     }
 
-    database::models::notification_item::Notification::read_many(
+    database::models::notification_item::DBNotification::read_many(
         &notifications,
         &mut transaction,
         &redis,
@@ -287,7 +287,7 @@ pub async fn notifications_delete(
     let mut transaction = pool.begin().await?;
 
     let notifications_data =
-        database::models::notification_item::Notification::get_many(
+        database::models::notification_item::DBNotification::get_many(
             &notification_ids,
             &**pool,
         )
@@ -302,7 +302,7 @@ pub async fn notifications_delete(
         }
     }
 
-    database::models::notification_item::Notification::remove_many(
+    database::models::notification_item::DBNotification::remove_many(
         &notifications,
         &mut transaction,
         &redis,

--- a/apps/labrinth/src/routes/v3/organizations.rs
+++ b/apps/labrinth/src/routes/v3/organizations.rs
@@ -3,9 +3,9 @@ use std::sync::Arc;
 
 use super::ApiError;
 use crate::auth::{filter_visible_projects, get_user_from_headers};
-use crate::database::models::team_item::TeamMember;
+use crate::database::models::team_item::DBTeamMember;
 use crate::database::models::{
-    Organization, generate_organization_id, team_item,
+    DBOrganization, generate_organization_id, team_item,
 };
 use crate::database::redis::RedisPool;
 use crate::file_hosting::FileHost;
@@ -69,7 +69,7 @@ pub async fn organization_projects_get(
     .map(|x| x.1)
     .ok();
 
-    let organization_data = Organization::get(&id, &**pool, &redis).await?;
+    let organization_data = DBOrganization::get(&id, &**pool, &redis).await?;
     if let Some(organization) = organization_data {
         let project_ids = sqlx::query!(
             "
@@ -84,7 +84,7 @@ pub async fn organization_projects_get(
         .try_collect::<Vec<_>>()
         .await?;
 
-        let projects_data = crate::database::models::Project::get_many_ids(
+        let projects_data = crate::database::models::DBProject::get_many_ids(
             &project_ids,
             &**pool,
             &redis,
@@ -146,7 +146,7 @@ pub async fn organization_create(
         organization_strings.push(name_organization_id.to_string());
     }
     organization_strings.push(new_organization.slug.clone());
-    let results = Organization::get_many(
+    let results = DBOrganization::get_many(
         &organization_strings,
         &mut *transaction,
         &redis,
@@ -174,7 +174,7 @@ pub async fn organization_create(
     let team_id = team.insert(&mut transaction).await?;
 
     // Create organization
-    let organization = Organization {
+    let organization = DBOrganization {
         id: organization_id,
         slug: new_organization.slug.clone(),
         name: new_organization.name.clone(),
@@ -188,10 +188,11 @@ pub async fn organization_create(
     transaction.commit().await?;
 
     // Only member is the owner, the logged in one
-    let member_data = TeamMember::get_from_team_full(team_id, &**pool, &redis)
-        .await?
-        .into_iter()
-        .next();
+    let member_data =
+        DBTeamMember::get_from_team_full(team_id, &**pool, &redis)
+            .await?
+            .into_iter()
+            .next();
     let members_data = if let Some(member_data) = member_data {
         vec![crate::models::teams::TeamMember::from_model(
             member_data,
@@ -230,13 +231,13 @@ pub async fn organization_get(
     .ok();
     let user_id = current_user.as_ref().map(|x| x.id.into());
 
-    let organization_data = Organization::get(&id, &**pool, &redis).await?;
+    let organization_data = DBOrganization::get(&id, &**pool, &redis).await?;
     if let Some(data) = organization_data {
         let members_data =
-            TeamMember::get_from_team_full(data.team_id, &**pool, &redis)
+            DBTeamMember::get_from_team_full(data.team_id, &**pool, &redis)
                 .await?;
 
-        let users = crate::database::models::User::get_many_ids(
+        let users = crate::database::models::DBUser::get_many_ids(
             &members_data.iter().map(|x| x.user_id).collect::<Vec<_>>(),
             &**pool,
             &redis,
@@ -293,15 +294,16 @@ pub async fn organizations_get(
 ) -> Result<HttpResponse, ApiError> {
     let ids = serde_json::from_str::<Vec<&str>>(&ids.ids)?;
     let organizations_data =
-        Organization::get_many(&ids, &**pool, &redis).await?;
+        DBOrganization::get_many(&ids, &**pool, &redis).await?;
     let team_ids = organizations_data
         .iter()
         .map(|x| x.team_id)
         .collect::<Vec<_>>();
 
     let teams_data =
-        TeamMember::get_from_team_full_many(&team_ids, &**pool, &redis).await?;
-    let users = crate::database::models::User::get_many_ids(
+        DBTeamMember::get_from_team_full_many(&team_ids, &**pool, &redis)
+            .await?;
+    let users = crate::database::models::DBUser::get_many_ids(
         &teams_data.iter().map(|x| x.user_id).collect::<Vec<_>>(),
         &**pool,
         &redis,
@@ -405,11 +407,11 @@ pub async fn organizations_edit(
 
     let string = info.into_inner().0;
     let result =
-        database::models::Organization::get(&string, &**pool, &redis).await?;
+        database::models::DBOrganization::get(&string, &**pool, &redis).await?;
     if let Some(organization_item) = result {
         let id = organization_item.id;
 
-        let team_member = database::models::TeamMember::get_from_user_id(
+        let team_member = database::models::DBTeamMember::get_from_user_id(
             organization_item.team_id,
             user.id.into(),
             &**pool,
@@ -526,7 +528,7 @@ pub async fn organizations_edit(
             }
 
             transaction.commit().await?;
-            database::models::Organization::clear_cache(
+            database::models::DBOrganization::clear_cache(
                 organization_item.id,
                 Some(organization_item.slug),
                 &redis,
@@ -564,7 +566,7 @@ pub async fn organization_delete(
     let string = info.into_inner().0;
 
     let organization =
-        database::models::Organization::get(&string, &**pool, &redis)
+        database::models::DBOrganization::get(&string, &**pool, &redis)
             .await?
             .ok_or_else(|| {
                 ApiError::InvalidInput(
@@ -574,7 +576,7 @@ pub async fn organization_delete(
 
     if !user.role.is_admin() {
         let team_member =
-            database::models::TeamMember::get_from_user_id_organization(
+            database::models::DBTeamMember::get_from_user_id_organization(
                 organization.id,
                 user.id.into(),
                 false,
@@ -638,7 +640,7 @@ pub async fn organization_delete(
             &mut transaction,
         )
         .await?;
-        let member = TeamMember {
+        let member = DBTeamMember {
             id: new_id,
             team_id: *organization_project_team,
             user_id: owner_id,
@@ -653,7 +655,7 @@ pub async fn organization_delete(
         member.insert(&mut transaction).await?;
     }
     // Safely remove the organization
-    let result = database::models::Organization::remove(
+    let result = database::models::DBOrganization::remove(
         organization.id,
         &mut transaction,
         &redis,
@@ -662,7 +664,7 @@ pub async fn organization_delete(
 
     transaction.commit().await?;
 
-    database::models::Organization::clear_cache(
+    database::models::DBOrganization::clear_cache(
         organization.id,
         Some(organization.slug),
         &redis,
@@ -670,7 +672,7 @@ pub async fn organization_delete(
     .await?;
 
     for team_id in organization_project_teams {
-        database::models::TeamMember::clear_cache(team_id, &redis).await?;
+        database::models::DBTeamMember::clear_cache(team_id, &redis).await?;
     }
 
     if result.is_some() {
@@ -704,7 +706,7 @@ pub async fn organization_projects_add(
     .1;
 
     let organization =
-        database::models::Organization::get(&info, &**pool, &redis)
+        database::models::DBOrganization::get(&info, &**pool, &redis)
             .await?
             .ok_or_else(|| {
                 ApiError::InvalidInput(
@@ -712,7 +714,7 @@ pub async fn organization_projects_add(
                 )
             })?;
 
-    let project_item = database::models::Project::get(
+    let project_item = database::models::DBProject::get(
         &project_info.project_id,
         &**pool,
         &redis,
@@ -731,7 +733,7 @@ pub async fn organization_projects_add(
     }
 
     let project_team_member =
-        database::models::TeamMember::get_from_user_id_project(
+        database::models::DBTeamMember::get_from_user_id_project(
             project_item.inner.id,
             current_user.id.into(),
             false,
@@ -744,7 +746,7 @@ pub async fn organization_projects_add(
             )
         })?;
     let organization_team_member =
-        database::models::TeamMember::get_from_user_id_organization(
+        database::models::DBTeamMember::get_from_user_id_organization(
             organization.id,
             current_user.id.into(),
             false,
@@ -814,17 +816,17 @@ pub async fn organization_projects_add(
 
         transaction.commit().await?;
 
-        database::models::User::clear_project_cache(
+        database::models::DBUser::clear_project_cache(
             &[current_user.id.into()],
             &redis,
         )
         .await?;
-        database::models::TeamMember::clear_cache(
+        database::models::DBTeamMember::clear_cache(
             project_item.inner.team_id,
             &redis,
         )
         .await?;
-        database::models::Project::clear_cache(
+        database::models::DBProject::clear_cache(
             project_item.inner.id,
             project_item.inner.slug,
             None,
@@ -866,17 +868,20 @@ pub async fn organization_projects_remove(
     .await?
     .1;
 
-    let organization =
-        database::models::Organization::get(&organization_id, &**pool, &redis)
-            .await?
-            .ok_or_else(|| {
-                ApiError::InvalidInput(
-                    "The specified organization does not exist!".to_string(),
-                )
-            })?;
+    let organization = database::models::DBOrganization::get(
+        &organization_id,
+        &**pool,
+        &redis,
+    )
+    .await?
+    .ok_or_else(|| {
+        ApiError::InvalidInput(
+            "The specified organization does not exist!".to_string(),
+        )
+    })?;
 
     let project_item =
-        database::models::Project::get(&project_id, &**pool, &redis)
+        database::models::DBProject::get(&project_id, &**pool, &redis)
             .await?
             .ok_or_else(|| {
                 ApiError::InvalidInput(
@@ -896,7 +901,7 @@ pub async fn organization_projects_remove(
     }
 
     let organization_team_member =
-        database::models::TeamMember::get_from_user_id_organization(
+        database::models::DBTeamMember::get_from_user_id_organization(
             organization.id,
             current_user.id.into(),
             false,
@@ -916,7 +921,7 @@ pub async fn organization_projects_remove(
     .unwrap_or_default();
     if permissions.contains(OrganizationPermissions::REMOVE_PROJECT) {
         // Now that permissions are confirmed, we confirm the veracity of the new user as an org member
-        database::models::TeamMember::get_from_user_id_organization(
+        database::models::DBTeamMember::get_from_user_id_organization(
             organization.id,
             data.new_owner.into(),
             false,
@@ -932,13 +937,14 @@ pub async fn organization_projects_remove(
 
         // Then, we get the team member of the project and that user (if it exists)
         // We use the team member get directly
-        let new_owner = database::models::TeamMember::get_from_user_id_project(
-            project_item.inner.id,
-            data.new_owner.into(),
-            true,
-            &**pool,
-        )
-        .await?;
+        let new_owner =
+            database::models::DBTeamMember::get_from_user_id_project(
+                project_item.inner.id,
+                data.new_owner.into(),
+                true,
+                &**pool,
+            )
+            .await?;
 
         let mut transaction = pool.begin().await?;
 
@@ -951,7 +957,7 @@ pub async fn organization_projects_remove(
                         &mut transaction,
                     )
                     .await?;
-                let member = TeamMember {
+                let member = DBTeamMember {
                     id: new_id,
                     team_id: project_item.inner.team_id,
                     user_id: data.new_owner.into(),
@@ -998,17 +1004,17 @@ pub async fn organization_projects_remove(
         .await?;
 
         transaction.commit().await?;
-        database::models::User::clear_project_cache(
+        database::models::DBUser::clear_project_cache(
             &[current_user.id.into()],
             &redis,
         )
         .await?;
-        database::models::TeamMember::clear_cache(
+        database::models::DBTeamMember::clear_cache(
             project_item.inner.team_id,
             &redis,
         )
         .await?;
-        database::models::Project::clear_cache(
+        database::models::DBProject::clear_cache(
             project_item.inner.id,
             project_item.inner.slug,
             None,
@@ -1052,7 +1058,7 @@ pub async fn organization_icon_edit(
     let string = info.into_inner().0;
 
     let organization_item =
-        database::models::Organization::get(&string, &**pool, &redis)
+        database::models::DBOrganization::get(&string, &**pool, &redis)
             .await?
             .ok_or_else(|| {
                 ApiError::InvalidInput(
@@ -1061,7 +1067,7 @@ pub async fn organization_icon_edit(
             })?;
 
     if !user.role.is_mod() {
-        let team_member = database::models::TeamMember::get_from_user_id(
+        let team_member = database::models::DBTeamMember::get_from_user_id(
             organization_item.team_id,
             user.id.into(),
             &**pool,
@@ -1125,7 +1131,7 @@ pub async fn organization_icon_edit(
     .await?;
 
     transaction.commit().await?;
-    database::models::Organization::clear_cache(
+    database::models::DBOrganization::clear_cache(
         organization_item.id,
         Some(organization_item.slug),
         &redis,
@@ -1155,7 +1161,7 @@ pub async fn delete_organization_icon(
     let string = info.into_inner().0;
 
     let organization_item =
-        database::models::Organization::get(&string, &**pool, &redis)
+        database::models::DBOrganization::get(&string, &**pool, &redis)
             .await?
             .ok_or_else(|| {
                 ApiError::InvalidInput(
@@ -1164,7 +1170,7 @@ pub async fn delete_organization_icon(
             })?;
 
     if !user.role.is_mod() {
-        let team_member = database::models::TeamMember::get_from_user_id(
+        let team_member = database::models::DBTeamMember::get_from_user_id(
             organization_item.team_id,
             user.id.into(),
             &**pool,
@@ -1208,7 +1214,7 @@ pub async fn delete_organization_icon(
 
     transaction.commit().await?;
 
-    database::models::Organization::clear_cache(
+    database::models::DBOrganization::clear_cache(
         organization_item.id,
         Some(organization_item.slug),
         &redis,

--- a/apps/labrinth/src/routes/v3/payouts.rs
+++ b/apps/labrinth/src/routes/v3/payouts.rs
@@ -160,7 +160,7 @@ pub async fn paypal_webhook(
 
                 transaction.commit().await?;
 
-                crate::database::models::user_item::User::clear_caches(
+                crate::database::models::user_item::DBUser::clear_caches(
                     &[(
                         crate::database::models::DBUserId(result.user_id),
                         None,
@@ -270,7 +270,7 @@ pub async fn tremendous_webhook(
 
                 transaction.commit().await?;
 
-                crate::database::models::user_item::User::clear_caches(
+                crate::database::models::user_item::DBUser::clear_caches(
                     &[(
                         crate::database::models::DBUserId(result.user_id),
                         None,
@@ -319,12 +319,12 @@ pub async fn user_payouts(
     .1;
 
     let payout_ids =
-        crate::database::models::payout_item::Payout::get_all_for_user(
+        crate::database::models::payout_item::DBPayout::get_all_for_user(
             user.id.into(),
             &**pool,
         )
         .await?;
-    let payouts = crate::database::models::payout_item::Payout::get_many(
+    let payouts = crate::database::models::payout_item::DBPayout::get_many(
         &payout_ids,
         &**pool,
     )
@@ -477,7 +477,7 @@ pub async fn create_payout(
             }
 
             let mut payout_item =
-                crate::database::models::payout_item::Payout {
+                crate::database::models::payout_item::DBPayout {
                     id: payout_id,
                     user_id: user.id,
                     created: Utc::now(),
@@ -550,7 +550,7 @@ pub async fn create_payout(
             if let Some(email) = user.email {
                 if user.email_verified {
                     let mut payout_item =
-                        crate::database::models::payout_item::Payout {
+                        crate::database::models::payout_item::DBPayout {
                             id: payout_id,
                             user_id: user.id,
                             created: Utc::now(),
@@ -633,7 +633,7 @@ pub async fn create_payout(
     payout_item.insert(&mut transaction).await?;
 
     transaction.commit().await?;
-    crate::database::models::User::clear_caches(&[(user.id, None)], &redis)
+    crate::database::models::DBUser::clear_caches(&[(user.id, None)], &redis)
         .await?;
 
     Ok(HttpResponse::NoContent().finish())
@@ -660,7 +660,7 @@ pub async fn cancel_payout(
 
     let id = info.into_inner().0;
     let payout =
-        crate::database::models::payout_item::Payout::get(id.into(), &**pool)
+        crate::database::models::payout_item::DBPayout::get(id.into(), &**pool)
             .await?;
 
     if let Some(payout) = payout {

--- a/apps/labrinth/src/routes/v3/teams.rs
+++ b/apps/labrinth/src/routes/v3/teams.rs
@@ -1,9 +1,9 @@
 use crate::auth::checks::is_visible_project;
 use crate::auth::get_user_from_headers;
-use crate::database::Project;
+use crate::database::DBProject;
 use crate::database::models::notification_item::NotificationBuilder;
 use crate::database::models::team_item::TeamAssociationId;
-use crate::database::models::{Organization, Team, TeamMember, User};
+use crate::database::models::{DBOrganization, DBTeam, DBTeamMember, DBUser};
 use crate::database::redis::RedisPool;
 use crate::models::ids::TeamId;
 use crate::models::notifications::NotificationBody;
@@ -48,7 +48,8 @@ pub async fn team_members_get_project(
 ) -> Result<HttpResponse, ApiError> {
     let string = info.into_inner().0;
     let project_data =
-        crate::database::models::Project::get(&string, &**pool, &redis).await?;
+        crate::database::models::DBProject::get(&string, &**pool, &redis)
+            .await?;
 
     if let Some(project) = project_data {
         let current_user = get_user_from_headers(
@@ -67,13 +68,13 @@ pub async fn team_members_get_project(
         {
             return Err(ApiError::NotFound);
         }
-        let members_data = TeamMember::get_from_team_full(
+        let members_data = DBTeamMember::get_from_team_full(
             project.inner.team_id,
             &**pool,
             &redis,
         )
         .await?;
-        let users = User::get_many_ids(
+        let users = DBUser::get_many_ids(
             &members_data.iter().map(|x| x.user_id).collect::<Vec<_>>(),
             &**pool,
             &redis,
@@ -83,7 +84,7 @@ pub async fn team_members_get_project(
         let user_id = current_user.as_ref().map(|x| x.id.into());
         let logged_in = if let Some(user_id) = user_id {
             let (team_member, organization_team_member) =
-                TeamMember::get_for_project_permissions(
+                DBTeamMember::get_for_project_permissions(
                     &project.inner,
                     user_id,
                     &**pool,
@@ -132,7 +133,7 @@ pub async fn team_members_get_organization(
 ) -> Result<HttpResponse, ApiError> {
     let string = info.into_inner().0;
     let organization_data =
-        crate::database::models::Organization::get(&string, &**pool, &redis)
+        crate::database::models::DBOrganization::get(&string, &**pool, &redis)
             .await?;
 
     if let Some(organization) = organization_data {
@@ -147,13 +148,13 @@ pub async fn team_members_get_organization(
         .map(|x| x.1)
         .ok();
 
-        let members_data = TeamMember::get_from_team_full(
+        let members_data = DBTeamMember::get_from_team_full(
             organization.team_id,
             &**pool,
             &redis,
         )
         .await?;
-        let users = crate::database::models::User::get_many_ids(
+        let users = crate::database::models::DBUser::get_many_ids(
             &members_data.iter().map(|x| x.user_id).collect::<Vec<_>>(),
             &**pool,
             &redis,
@@ -208,8 +209,8 @@ pub async fn team_members_get(
 ) -> Result<HttpResponse, ApiError> {
     let id = info.into_inner().0;
     let members_data =
-        TeamMember::get_from_team_full(id.into(), &**pool, &redis).await?;
-    let users = crate::database::models::User::get_many_ids(
+        DBTeamMember::get_from_team_full(id.into(), &**pool, &redis).await?;
+    let users = crate::database::models::DBUser::get_many_ids(
         &members_data.iter().map(|x| x.user_id).collect::<Vec<_>>(),
         &**pool,
         &redis,
@@ -279,8 +280,9 @@ pub async fn teams_get(
         .collect::<Vec<crate::database::models::ids::DBTeamId>>();
 
     let teams_data =
-        TeamMember::get_from_team_full_many(&team_ids, &**pool, &redis).await?;
-    let users = crate::database::models::User::get_many_ids(
+        DBTeamMember::get_from_team_full_many(&team_ids, &**pool, &redis)
+            .await?;
+    let users = crate::database::models::DBUser::get_many_ids(
         &teams_data.iter().map(|x| x.user_id).collect::<Vec<_>>(),
         &**pool,
         &redis,
@@ -351,7 +353,7 @@ pub async fn join_team(
     .await?
     .1;
 
-    let member = TeamMember::get_from_user_id_pending(
+    let member = DBTeamMember::get_from_user_id_pending(
         team_id,
         current_user.id.into(),
         &**pool,
@@ -367,7 +369,7 @@ pub async fn join_team(
         let mut transaction = pool.begin().await?;
 
         // Edit Team Member to set Accepted to True
-        TeamMember::edit_team_member(
+        DBTeamMember::edit_team_member(
             team_id,
             current_user.id.into(),
             None,
@@ -383,8 +385,8 @@ pub async fn join_team(
 
         transaction.commit().await?;
 
-        User::clear_project_cache(&[current_user.id.into()], &redis).await?;
-        TeamMember::clear_cache(team_id, &redis).await?;
+        DBUser::clear_project_cache(&[current_user.id.into()], &redis).await?;
+        DBTeamMember::clear_cache(team_id, &redis).await?;
     } else {
         return Err(ApiError::InvalidInput(
             "There is no pending request from this team".to_string(),
@@ -439,27 +441,30 @@ pub async fn add_team_member(
     )
     .await?
     .1;
-    let team_association = Team::get_association(team_id, &**pool)
+    let team_association = DBTeam::get_association(team_id, &**pool)
         .await?
         .ok_or_else(|| {
             ApiError::InvalidInput(
                 "The team specified does not exist".to_string(),
             )
         })?;
-    let member =
-        TeamMember::get_from_user_id(team_id, current_user.id.into(), &**pool)
-            .await?;
+    let member = DBTeamMember::get_from_user_id(
+        team_id,
+        current_user.id.into(),
+        &**pool,
+    )
+    .await?;
     match team_association {
         // If team is associated with a project, check if they have permissions to invite users to that project
         TeamAssociationId::Project(pid) => {
             let organization =
-                Organization::get_associated_organization_project_id(
+                DBOrganization::get_associated_organization_project_id(
                     pid, &**pool,
                 )
                 .await?;
             let organization_team_member =
                 if let Some(organization) = &organization {
-                    TeamMember::get_from_user_id(
+                    DBTeamMember::get_from_user_id(
                         organization.team_id,
                         current_user.id.into(),
                         &**pool,
@@ -537,7 +542,7 @@ pub async fn add_team_member(
         ));
     }
 
-    let request = TeamMember::get_from_user_id_pending(
+    let request = DBTeamMember::get_from_user_id_pending(
         team_id,
         new_member.user_id.into(),
         &**pool,
@@ -556,7 +561,7 @@ pub async fn add_team_member(
             ));
         }
     }
-    let new_user = crate::database::models::User::get_id(
+    let new_user = crate::database::models::DBUser::get_id(
         new_member.user_id.into(),
         &**pool,
         &redis,
@@ -570,11 +575,13 @@ pub async fn add_team_member(
     if let TeamAssociationId::Project(pid) = team_association {
         // We cannot add the owner to a project team in their own org
         let organization =
-            Organization::get_associated_organization_project_id(pid, &**pool)
-                .await?;
+            DBOrganization::get_associated_organization_project_id(
+                pid, &**pool,
+            )
+            .await?;
         let new_user_organization_team_member =
             if let Some(organization) = &organization {
-                TeamMember::get_from_user_id(
+                DBTeamMember::get_from_user_id(
                     organization.team_id,
                     new_user.id,
                     &**pool,
@@ -607,7 +614,7 @@ pub async fn add_team_member(
     let new_id =
         crate::database::models::ids::generate_team_member_id(&mut transaction)
             .await?;
-    TeamMember {
+    DBTeamMember {
         id: new_id,
         team_id,
         user_id: new_member.user_id.into(),
@@ -653,8 +660,8 @@ pub async fn add_team_member(
     }
 
     transaction.commit().await?;
-    TeamMember::clear_cache(team_id, &redis).await?;
-    User::clear_project_cache(&[new_member.user_id.into()], &redis).await?;
+    DBTeamMember::clear_cache(team_id, &redis).await?;
+    DBUser::clear_project_cache(&[new_member.user_id.into()], &redis).await?;
 
     Ok(HttpResponse::NoContent().body(""))
 }
@@ -691,16 +698,16 @@ pub async fn edit_team_member(
     .1;
 
     let team_association =
-        Team::get_association(id, &**pool).await?.ok_or_else(|| {
+        DBTeam::get_association(id, &**pool).await?.ok_or_else(|| {
             ApiError::InvalidInput(
                 "The team specified does not exist".to_string(),
             )
         })?;
     let member =
-        TeamMember::get_from_user_id(id, current_user.id.into(), &**pool)
+        DBTeamMember::get_from_user_id(id, current_user.id.into(), &**pool)
             .await?;
     let edit_member_db =
-        TeamMember::get_from_user_id_pending(id, user_id, &**pool)
+        DBTeamMember::get_from_user_id_pending(id, user_id, &**pool)
             .await?
             .ok_or_else(|| {
                 ApiError::CustomAuthentication(
@@ -723,13 +730,13 @@ pub async fn edit_team_member(
     match team_association {
         TeamAssociationId::Project(project_id) => {
             let organization =
-                Organization::get_associated_organization_project_id(
+                DBOrganization::get_associated_organization_project_id(
                     project_id, &**pool,
                 )
                 .await?;
             let organization_team_member =
                 if let Some(organization) = &organization {
-                    TeamMember::get_from_user_id(
+                    DBTeamMember::get_from_user_id(
                         organization.team_id,
                         current_user.id.into(),
                         &**pool,
@@ -831,7 +838,7 @@ pub async fn edit_team_member(
         }
     }
 
-    TeamMember::edit_team_member(
+    DBTeamMember::edit_team_member(
         id,
         user_id,
         edit_member.permissions,
@@ -846,7 +853,7 @@ pub async fn edit_team_member(
     .await?;
 
     transaction.commit().await?;
-    TeamMember::clear_cache(id, &redis).await?;
+    DBTeamMember::clear_cache(id, &redis).await?;
 
     Ok(HttpResponse::NoContent().body(""))
 }
@@ -879,9 +886,10 @@ pub async fn transfer_ownership(
     // Forbid transferring ownership of a project team that is owned by an organization
     // These are owned by the organization owner, and must be removed from the organization first
     // There shouldnt be an ownr on these projects in these cases, but just in case.
-    let team_association_id = Team::get_association(id.into(), &**pool).await?;
+    let team_association_id =
+        DBTeam::get_association(id.into(), &**pool).await?;
     if let Some(TeamAssociationId::Project(pid)) = team_association_id {
-        let result = Project::get_id(pid, &**pool, &redis).await?;
+        let result = DBProject::get_id(pid, &**pool, &redis).await?;
         if let Some(project_item) = result {
             if project_item.inner.organization_id.is_some() {
                 return Err(ApiError::InvalidInput(
@@ -893,7 +901,7 @@ pub async fn transfer_ownership(
     }
 
     if !current_user.role.is_admin() {
-        let member = TeamMember::get_from_user_id(
+        let member = DBTeamMember::get_from_user_id(
             id.into(),
             current_user.id.into(),
             &**pool,
@@ -914,7 +922,7 @@ pub async fn transfer_ownership(
         }
     }
 
-    let new_member = TeamMember::get_from_user_id(
+    let new_member = DBTeamMember::get_from_user_id(
         id.into(),
         new_owner.user_id.into(),
         &**pool,
@@ -936,12 +944,12 @@ pub async fn transfer_ownership(
 
     // The following are the only places new_is_owner is modified.
     if let Some(former_owner) =
-        TeamMember::get_from_team_full(id.into(), &**pool, &redis)
+        DBTeamMember::get_from_team_full(id.into(), &**pool, &redis)
             .await?
             .into_iter()
             .find(|x| x.is_owner)
     {
-        TeamMember::edit_team_member(
+        DBTeamMember::edit_team_member(
             id.into(),
             former_owner.user_id,
             None,
@@ -956,7 +964,7 @@ pub async fn transfer_ownership(
         .await?;
     }
 
-    TeamMember::edit_team_member(
+    DBTeamMember::edit_team_member(
         id.into(),
         new_owner.user_id.into(),
         Some(ProjectPermissions::all()),
@@ -1004,7 +1012,7 @@ pub async fn transfer_ownership(
 
             // If the owner of the organization is a member of the project, remove them
             for team_id in team_ids.iter() {
-                TeamMember::delete(
+                DBTeamMember::delete(
                     *team_id,
                     new_owner.user_id.into(),
                     &mut transaction,
@@ -1018,9 +1026,9 @@ pub async fn transfer_ownership(
         };
 
     transaction.commit().await?;
-    TeamMember::clear_cache(id.into(), &redis).await?;
+    DBTeamMember::clear_cache(id.into(), &redis).await?;
     for team_id in project_teams_edited {
-        TeamMember::clear_cache(team_id, &redis).await?;
+        DBTeamMember::clear_cache(team_id, &redis).await?;
     }
 
     Ok(HttpResponse::NoContent().body(""))
@@ -1048,17 +1056,17 @@ pub async fn remove_team_member(
     .1;
 
     let team_association =
-        Team::get_association(id, &**pool).await?.ok_or_else(|| {
+        DBTeam::get_association(id, &**pool).await?.ok_or_else(|| {
             ApiError::InvalidInput(
                 "The team specified does not exist".to_string(),
             )
         })?;
     let member =
-        TeamMember::get_from_user_id(id, current_user.id.into(), &**pool)
+        DBTeamMember::get_from_user_id(id, current_user.id.into(), &**pool)
             .await?;
 
     let delete_member =
-        TeamMember::get_from_user_id_pending(id, user_id, &**pool).await?;
+        DBTeamMember::get_from_user_id_pending(id, user_id, &**pool).await?;
 
     if let Some(delete_member) = delete_member {
         if delete_member.is_owner {
@@ -1074,13 +1082,13 @@ pub async fn remove_team_member(
         match team_association {
             TeamAssociationId::Project(pid) => {
                 let organization =
-                    Organization::get_associated_organization_project_id(
+                    DBOrganization::get_associated_organization_project_id(
                         pid, &**pool,
                     )
                     .await?;
                 let organization_team_member =
                     if let Some(organization) = &organization {
-                        TeamMember::get_from_user_id(
+                        DBTeamMember::get_from_user_id(
                             organization.team_id,
                             current_user.id.into(),
                             &**pool,
@@ -1105,7 +1113,7 @@ pub async fn remove_team_member(
                             .contains(ProjectPermissions::REMOVE_MEMBER)
                     // true as if the permission exists, but the member does not, they are part of an org
                     {
-                        TeamMember::delete(id, user_id, &mut transaction)
+                        DBTeamMember::delete(id, user_id, &mut transaction)
                             .await?;
                     } else {
                         return Err(ApiError::CustomAuthentication(
@@ -1121,7 +1129,7 @@ pub async fn remove_team_member(
                     // This is a pending invite rather than a member, so the
                     // user being invited or team members with the MANAGE_INVITES
                     // permission can remove it.
-                    TeamMember::delete(id, user_id, &mut transaction).await?;
+                    DBTeamMember::delete(id, user_id, &mut transaction).await?;
                 } else {
                     return Err(ApiError::CustomAuthentication(
                         "You do not have permission to cancel a team invite"
@@ -1144,7 +1152,7 @@ pub async fn remove_team_member(
                         || organization_permissions
                             .contains(OrganizationPermissions::REMOVE_MEMBER)
                     {
-                        TeamMember::delete(id, user_id, &mut transaction)
+                        DBTeamMember::delete(id, user_id, &mut transaction)
                             .await?;
                     } else {
                         return Err(ApiError::CustomAuthentication(
@@ -1160,7 +1168,7 @@ pub async fn remove_team_member(
                     // This is a pending invite rather than a member, so the
                     // user being invited or team members with the MANAGE_INVITES
                     // permission can remove it.
-                    TeamMember::delete(id, user_id, &mut transaction).await?;
+                    DBTeamMember::delete(id, user_id, &mut transaction).await?;
                 } else {
                     return Err(ApiError::CustomAuthentication(
                         "You do not have permission to cancel an organization invite".to_string(),
@@ -1171,8 +1179,8 @@ pub async fn remove_team_member(
 
         transaction.commit().await?;
 
-        TeamMember::clear_cache(id, &redis).await?;
-        User::clear_project_cache(&[delete_member.user_id], &redis).await?;
+        DBTeamMember::clear_cache(id, &redis).await?;
+        DBUser::clear_project_cache(&[delete_member.user_id], &redis).await?;
 
         Ok(HttpResponse::NoContent().body(""))
     } else {

--- a/apps/labrinth/src/routes/v3/users.rs
+++ b/apps/labrinth/src/routes/v3/users.rs
@@ -4,7 +4,7 @@ use super::{ApiError, oauth_clients::get_user_clients};
 use crate::util::img::delete_old_images;
 use crate::{
     auth::{filter_visible_projects, get_user_from_headers},
-    database::{models::User, redis::RedisPool},
+    database::{models::DBUser, redis::RedisPool},
     file_hosting::FileHost,
     models::{
         collections::{Collection, CollectionStatus},
@@ -88,7 +88,7 @@ pub async fn admin_user_email(
         )
     })?;
 
-    let user = User::get_id(
+    let user = DBUser::get_id(
         crate::database::models::DBUserId(user_id),
         &**pool,
         &redis,
@@ -120,12 +120,12 @@ pub async fn projects_list(
     .map(|x| x.1)
     .ok();
 
-    let id_option = User::get(&info.into_inner().0, &**pool, &redis).await?;
+    let id_option = DBUser::get(&info.into_inner().0, &**pool, &redis).await?;
 
     if let Some(id) = id_option.map(|x| x.id) {
-        let project_data = User::get_projects(id, &**pool, &redis).await?;
+        let project_data = DBUser::get_projects(id, &**pool, &redis).await?;
 
-        let projects: Vec<_> = crate::database::Project::get_many_ids(
+        let projects: Vec<_> = crate::database::DBProject::get_many_ids(
             &project_data,
             &**pool,
             &redis,
@@ -177,7 +177,7 @@ pub async fn users_get(
 ) -> Result<HttpResponse, ApiError> {
     let user_ids = serde_json::from_str::<Vec<String>>(&ids.ids)?;
 
-    let users_data = User::get_many(&user_ids, &**pool, &redis).await?;
+    let users_data = DBUser::get_many(&user_ids, &**pool, &redis).await?;
 
     let users: Vec<crate::models::users::User> =
         users_data.into_iter().map(From::from).collect();
@@ -192,7 +192,7 @@ pub async fn user_get(
     redis: web::Data<RedisPool>,
     session_queue: web::Data<AuthQueue>,
 ) -> Result<HttpResponse, ApiError> {
-    let user_data = User::get(&info.into_inner().0, &**pool, &redis).await?;
+    let user_data = DBUser::get(&info.into_inner().0, &**pool, &redis).await?;
 
     if let Some(data) = user_data {
         let auth_user = get_user_from_headers(
@@ -237,7 +237,7 @@ pub async fn collections_list(
     .map(|x| x.1)
     .ok();
 
-    let id_option = User::get(&info.into_inner().0, &**pool, &redis).await?;
+    let id_option = DBUser::get(&info.into_inner().0, &**pool, &redis).await?;
 
     if let Some(id) = id_option.map(|x| x.id) {
         let user_id: UserId = id.into();
@@ -246,9 +246,9 @@ pub async fn collections_list(
             .map(|y| y.role.is_mod() || y.id == user_id)
             .unwrap_or(false);
 
-        let project_data = User::get_collections(id, &**pool).await?;
+        let project_data = DBUser::get_collections(id, &**pool).await?;
 
-        let response: Vec<_> = crate::database::models::Collection::get_many(
+        let response: Vec<_> = crate::database::models::DBCollection::get_many(
             &project_data,
             &**pool,
             &redis,
@@ -285,13 +285,13 @@ pub async fn orgs_list(
     .map(|x| x.1)
     .ok();
 
-    let id_option = User::get(&info.into_inner().0, &**pool, &redis).await?;
+    let id_option = DBUser::get(&info.into_inner().0, &**pool, &redis).await?;
 
     if let Some(id) = id_option.map(|x| x.id) {
-        let org_data = User::get_organizations(id, &**pool).await?;
+        let org_data = DBUser::get_organizations(id, &**pool).await?;
 
         let organizations_data =
-            crate::database::models::organization_item::Organization::get_many_ids(
+            crate::database::models::organization_item::DBOrganization::get_many_ids(
                 &org_data, &**pool, &redis,
             )
             .await?;
@@ -302,11 +302,11 @@ pub async fn orgs_list(
             .collect::<Vec<_>>();
 
         let teams_data =
-            crate::database::models::TeamMember::get_from_team_full_many(
+            crate::database::models::DBTeamMember::get_from_team_full_many(
                 &team_ids, &**pool, &redis,
             )
             .await?;
-        let users = User::get_many_ids(
+        let users = DBUser::get_many_ids(
             &teams_data.iter().map(|x| x.user_id).collect::<Vec<_>>(),
             &**pool,
             &redis,
@@ -397,7 +397,7 @@ pub async fn user_edit(
         ApiError::Validation(validation_errors_to_string(err, None))
     })?;
 
-    let id_option = User::get(&info.into_inner().0, &**pool, &redis).await?;
+    let id_option = DBUser::get(&info.into_inner().0, &**pool, &redis).await?;
 
     if let Some(actual_user) = id_option {
         let id = actual_user.id;
@@ -408,7 +408,7 @@ pub async fn user_edit(
 
             if let Some(username) = &new_user.username {
                 let existing_user_id_option =
-                    User::get(username, &**pool, &redis).await?;
+                    DBUser::get(username, &**pool, &redis).await?;
 
                 if existing_user_id_option
                     .map(|x| UserId::from(x.id))
@@ -527,7 +527,7 @@ pub async fn user_edit(
             }
 
             transaction.commit().await?;
-            User::clear_caches(&[(id, Some(actual_user.username))], &redis)
+            DBUser::clear_caches(&[(id, Some(actual_user.username))], &redis)
                 .await?;
             Ok(HttpResponse::NoContent().body(""))
         } else {
@@ -565,7 +565,7 @@ pub async fn user_icon_edit(
     )
     .await?
     .1;
-    let id_option = User::get(&info.into_inner().0, &**pool, &redis).await?;
+    let id_option = DBUser::get(&info.into_inner().0, &**pool, &redis).await?;
 
     if let Some(actual_user) = id_option {
         if user.id != actual_user.id.into() && !user.role.is_mod() {
@@ -612,7 +612,7 @@ pub async fn user_icon_edit(
         )
         .execute(&**pool)
         .await?;
-        User::clear_caches(&[(actual_user.id, None)], &redis).await?;
+        DBUser::clear_caches(&[(actual_user.id, None)], &redis).await?;
 
         Ok(HttpResponse::NoContent().body(""))
     } else {
@@ -637,7 +637,7 @@ pub async fn user_icon_delete(
     )
     .await?
     .1;
-    let id_option = User::get(&info.into_inner().0, &**pool, &redis).await?;
+    let id_option = DBUser::get(&info.into_inner().0, &**pool, &redis).await?;
 
     if let Some(actual_user) = id_option {
         if user.id != actual_user.id.into() && !user.role.is_mod() {
@@ -665,7 +665,7 @@ pub async fn user_icon_delete(
         .execute(&**pool)
         .await?;
 
-        User::clear_caches(&[(actual_user.id, None)], &redis).await?;
+        DBUser::clear_caches(&[(actual_user.id, None)], &redis).await?;
 
         Ok(HttpResponse::NoContent().body(""))
     } else {
@@ -689,7 +689,7 @@ pub async fn user_delete(
     )
     .await?
     .1;
-    let id_option = User::get(&info.into_inner().0, &**pool, &redis).await?;
+    let id_option = DBUser::get(&info.into_inner().0, &**pool, &redis).await?;
 
     if let Some(id) = id_option.map(|x| x.id) {
         if !user.role.is_admin() && user.id != id.into() {
@@ -700,7 +700,7 @@ pub async fn user_delete(
 
         let mut transaction = pool.begin().await?;
 
-        let result = User::remove(id, &mut transaction, &redis).await?;
+        let result = DBUser::remove(id, &mut transaction, &redis).await?;
 
         transaction.commit().await?;
 
@@ -730,7 +730,7 @@ pub async fn user_follows(
     )
     .await?
     .1;
-    let id_option = User::get(&info.into_inner().0, &**pool, &redis).await?;
+    let id_option = DBUser::get(&info.into_inner().0, &**pool, &redis).await?;
 
     if let Some(id) = id_option.map(|x| x.id) {
         if !user.role.is_admin() && user.id != id.into() {
@@ -739,8 +739,8 @@ pub async fn user_follows(
             ));
         }
 
-        let project_ids = User::get_follows(id, &**pool).await?;
-        let projects: Vec<_> = crate::database::Project::get_many_ids(
+        let project_ids = DBUser::get_follows(id, &**pool).await?;
+        let projects: Vec<_> = crate::database::DBProject::get_many_ids(
             &project_ids,
             &**pool,
             &redis,
@@ -772,7 +772,7 @@ pub async fn user_notifications(
     )
     .await?
     .1;
-    let id_option = User::get(&info.into_inner().0, &**pool, &redis).await?;
+    let id_option = DBUser::get(&info.into_inner().0, &**pool, &redis).await?;
 
     if let Some(id) = id_option.map(|x| x.id) {
         if !user.role.is_admin() && user.id != id.into() {
@@ -782,7 +782,7 @@ pub async fn user_notifications(
         }
 
         let mut notifications: Vec<Notification> =
-            crate::database::models::notification_item::Notification::get_many_user(
+            crate::database::models::notification_item::DBNotification::get_many_user(
                 id, &**pool, &redis,
             )
             .await?

--- a/apps/labrinth/src/routes/v3/versions.rs
+++ b/apps/labrinth/src/routes/v3/versions.rs
@@ -9,8 +9,10 @@ use crate::database;
 use crate::database::models::loader_fields::{
     self, LoaderField, LoaderFieldEnumValue, VersionField,
 };
-use crate::database::models::version_item::{DependencyBuilder, LoaderVersion};
-use crate::database::models::{Organization, image_item};
+use crate::database::models::version_item::{
+    DBLoaderVersion, DependencyBuilder,
+};
+use crate::database::models::{DBOrganization, image_item};
 use crate::database::redis::RedisPool;
 use crate::models;
 use crate::models::ids::VersionId;
@@ -70,7 +72,8 @@ pub async fn version_project_get_helper(
     redis: web::Data<RedisPool>,
     session_queue: web::Data<AuthQueue>,
 ) -> Result<HttpResponse, ApiError> {
-    let result = database::models::Project::get(&id.0, &**pool, &redis).await?;
+    let result =
+        database::models::DBProject::get(&id.0, &**pool, &redis).await?;
 
     let user_option = get_user_from_headers(
         &req,
@@ -90,7 +93,7 @@ pub async fn version_project_get_helper(
             return Err(ApiError::NotFound);
         }
 
-        let versions = database::models::Version::get_many(
+        let versions = database::models::DBVersion::get_many(
             &project.versions,
             &**pool,
             &redis,
@@ -134,7 +137,7 @@ pub async fn versions_get(
             .map(|x| x.into())
             .collect::<Vec<database::models::DBVersionId>>();
     let versions_data =
-        database::models::Version::get_many(&version_ids, &**pool, &redis)
+        database::models::DBVersion::get_many(&version_ids, &**pool, &redis)
             .await?;
 
     let user_option = get_user_from_headers(
@@ -174,7 +177,7 @@ pub async fn version_get_helper(
     session_queue: web::Data<AuthQueue>,
 ) -> Result<HttpResponse, ApiError> {
     let version_data =
-        database::models::Version::get(id.into(), &**pool, &redis).await?;
+        database::models::DBVersion::get(id.into(), &**pool, &redis).await?;
 
     let user_option = get_user_from_headers(
         &req,
@@ -290,11 +293,11 @@ pub async fn version_edit_helper(
     let version_id = info.0.into();
 
     let result =
-        database::models::Version::get(version_id, &**pool, &redis).await?;
+        database::models::DBVersion::get(version_id, &**pool, &redis).await?;
 
     if let Some(version_item) = result {
         let team_member =
-            database::models::TeamMember::get_from_user_id_project(
+            database::models::DBTeamMember::get_from_user_id_project(
                 version_item.inner.project_id,
                 user.id.into(),
                 false,
@@ -303,7 +306,7 @@ pub async fn version_edit_helper(
             .await?;
 
         let organization =
-            Organization::get_associated_organization_project_id(
+            DBOrganization::get_associated_organization_project_id(
                 version_item.inner.project_id,
                 &**pool,
             )
@@ -311,7 +314,7 @@ pub async fn version_edit_helper(
 
         let organization_team_member = if let Some(organization) = &organization
         {
-            database::models::TeamMember::get_from_user_id(
+            database::models::DBTeamMember::get_from_user_id(
                 organization.team_id,
                 user.id.into(),
                 &**pool,
@@ -513,15 +516,15 @@ pub async fn version_edit_helper(
                                     .to_string(),
                             )
                         })?;
-                    loader_versions.push(LoaderVersion {
+                    loader_versions.push(DBLoaderVersion {
                         loader_id,
                         version_id,
                     });
                 }
-                LoaderVersion::insert_many(loader_versions, &mut transaction)
+                DBLoaderVersion::insert_many(loader_versions, &mut transaction)
                     .await?;
 
-                crate::database::models::Project::clear_cache(
+                crate::database::models::DBProject::clear_cache(
                     version_item.inner.project_id,
                     None,
                     None,
@@ -679,9 +682,9 @@ pub async fn version_edit_helper(
             .await?;
 
             transaction.commit().await?;
-            database::models::Version::clear_cache(&version_item, &redis)
+            database::models::DBVersion::clear_cache(&version_item, &redis)
                 .await?;
-            database::models::Project::clear_cache(
+            database::models::DBProject::clear_cache(
                 version_item.inner.project_id,
                 None,
                 Some(true),
@@ -726,7 +729,7 @@ pub async fn version_list(
     let string = info.into_inner().0;
 
     let result =
-        database::models::Project::get(&string, &**pool, &redis).await?;
+        database::models::DBProject::get(&string, &**pool, &redis).await?;
 
     let user_option = get_user_from_headers(
         &req,
@@ -753,7 +756,7 @@ pub async fn version_list(
         let loader_filters = filters.loaders.as_ref().map(|x| {
             serde_json::from_str::<Vec<String>>(x).unwrap_or_default()
         });
-        let mut versions = database::models::Version::get_many(
+        let mut versions = database::models::DBVersion::get_many(
             &project.versions,
             &**pool,
             &redis,
@@ -886,7 +889,7 @@ pub async fn version_delete(
     .1;
     let id = info.into_inner().0;
 
-    let version = database::models::Version::get(id.into(), &**pool, &redis)
+    let version = database::models::DBVersion::get(id.into(), &**pool, &redis)
         .await?
         .ok_or_else(|| {
             ApiError::InvalidInput(
@@ -896,7 +899,7 @@ pub async fn version_delete(
 
     if !user.role.is_admin() {
         let team_member =
-            database::models::TeamMember::get_from_user_id_project(
+            database::models::DBTeamMember::get_from_user_id_project(
                 version.inner.project_id,
                 user.id.into(),
                 false,
@@ -906,7 +909,7 @@ pub async fn version_delete(
             .map_err(ApiError::Database)?;
 
         let organization =
-            Organization::get_associated_organization_project_id(
+            DBOrganization::get_associated_organization_project_id(
                 version.inner.project_id,
                 &**pool,
             )
@@ -914,7 +917,7 @@ pub async fn version_delete(
 
         let organization_team_member = if let Some(organization) = &organization
         {
-            database::models::TeamMember::get_from_user_id(
+            database::models::DBTeamMember::get_from_user_id(
                 organization.team_id,
                 user.id.into(),
                 &**pool,
@@ -942,14 +945,16 @@ pub async fn version_delete(
     let context = ImageContext::Version {
         version_id: Some(version.inner.id.into()),
     };
-    let uploaded_images =
-        database::models::Image::get_many_contexted(context, &mut transaction)
-            .await?;
+    let uploaded_images = database::models::DBImage::get_many_contexted(
+        context,
+        &mut transaction,
+    )
+    .await?;
     for image in uploaded_images {
-        image_item::Image::remove(image.id, &mut transaction, &redis).await?;
+        image_item::DBImage::remove(image.id, &mut transaction, &redis).await?;
     }
 
-    let result = database::models::Version::remove_full(
+    let result = database::models::DBVersion::remove_full(
         version.inner.id,
         &redis,
         &mut transaction,
@@ -957,7 +962,7 @@ pub async fn version_delete(
     .await?;
     transaction.commit().await?;
     remove_documents(&[version.inner.id.into()], &search_config).await?;
-    database::models::Project::clear_cache(
+    database::models::DBProject::clear_cache(
         version.inner.project_id,
         None,
         Some(true),

--- a/apps/labrinth/src/util/img.rs
+++ b/apps/labrinth/src/util/img.rs
@@ -199,7 +199,7 @@ pub async fn delete_unused_images(
     redis: &RedisPool,
 ) -> Result<(), ApiError> {
     let uploaded_images =
-        database::models::Image::get_many_contexted(context, transaction)
+        database::models::DBImage::get_many_contexted(context, transaction)
             .await?;
 
     for image in uploaded_images {
@@ -212,8 +212,8 @@ pub async fn delete_unused_images(
         }
 
         if should_delete {
-            image_item::Image::remove(image.id, transaction, redis).await?;
-            image_item::Image::clear_cache(image.id, redis).await?;
+            image_item::DBImage::remove(image.id, transaction, redis).await?;
+            image_item::DBImage::clear_cache(image.id, redis).await?;
         }
     }
 

--- a/apps/labrinth/src/util/webhook.rs
+++ b/apps/labrinth/src/util/webhook.rs
@@ -47,7 +47,7 @@ async fn get_webhook_metadata(
     redis: &RedisPool,
     emoji: bool,
 ) -> Result<Option<WebhookMetadata>, ApiError> {
-    let project = crate::database::models::project_item::Project::get_id(
+    let project = crate::database::models::project_item::DBProject::get_id(
         project_id.into(),
         pool,
         redis,
@@ -58,7 +58,7 @@ async fn get_webhook_metadata(
         let mut owner = None;
 
         if let Some(organization_id) = project.inner.organization_id {
-            let organization = crate::database::models::organization_item::Organization::get_id(
+            let organization = crate::database::models::organization_item::DBOrganization::get_id(
                 organization_id,
                 pool,
                 redis,
@@ -77,7 +77,7 @@ async fn get_webhook_metadata(
                 });
             }
         } else {
-            let team = crate::database::models::team_item::TeamMember::get_from_team_full(
+            let team = crate::database::models::team_item::DBTeamMember::get_from_team_full(
                 project.inner.team_id,
                 pool,
                 redis,
@@ -85,7 +85,7 @@ async fn get_webhook_metadata(
             .await?;
 
             if let Some(member) = team.into_iter().find(|x| x.is_owner) {
-                let user = crate::database::models::user_item::User::get_id(
+                let user = crate::database::models::user_item::DBUser::get_id(
                     member.user_id,
                     pool,
                     redis,

--- a/apps/labrinth/tests/common/pats.rs
+++ b/apps/labrinth/tests/common/pats.rs
@@ -18,7 +18,7 @@ pub async fn create_test_pat(
 ) -> String {
     let mut transaction = db.pool.begin().await.unwrap();
     let id = generate_pat_id(&mut transaction).await.unwrap();
-    let pat = database::models::pat_item::PersonalAccessToken {
+    let pat = database::models::pat_item::DBPersonalAccessToken {
         id,
         name: format!("test_pat_{}", scopes.bits()),
         access_token: format!("mrp_{}", id.0),

--- a/packages/ariadne/src/ids.rs
+++ b/packages/ariadne/src/ids.rs
@@ -86,10 +86,6 @@ impl_base62_display!(Base62Id);
 #[macro_export]
 macro_rules! base62_id {
     ($struct:ident) => {
-        $crate::ids::base62_id!($struct, "ariadne::ids::Base62Id");
-    };
-
-    ($struct:ident, $base_type:expr) => {
         #[derive(
             Copy,
             Clone,
@@ -100,8 +96,8 @@ macro_rules! base62_id {
             Debug,
             Hash,
         )]
-        #[serde(from = $base_type)]
-        #[serde(into = $base_type)]
+        #[serde(from = "ariadne::ids::Base62Id")]
+        #[serde(into = "ariadne::ids::Base62Id")]
         pub struct $struct(pub u64);
 
         $crate::ids::impl_base62_display!($struct);
@@ -120,7 +116,8 @@ macro_rules! base62_id {
     };
 }
 
-base62_id!(UserId, "crate::ids::Base62Id");
+use crate as ariadne; // Hack because serde(from) and serde(into) don't work with $crate
+base62_id!(UserId);
 
 pub use {base62_id, impl_base62_display};
 


### PR DESCRIPTION
This prefixes many of the structs in `labrinth::database::models` with DB to match `labrinth::database::models::ids`, and also renames the structs passed to `sqlx::query_as!` to all be suffixed with `QueryResult`.