### PR TITLE
feat(labrinth): rework v3 side types to a single `environment` field

### DIFF
--- a/apps/labrinth/migrations/20250523174544_project-versions-environments.sql
+++ b/apps/labrinth/migrations/20250523174544_project-versions-environments.sql
@@ -1,0 +1,114 @@
+DO LANGUAGE plpgsql $$
+DECLARE
+    VAR_env_field_id INT;
+    VAR_env_field_enum_id INT := 4; -- Known available ID for a new enum type
+BEGIN
+
+-- Define a new loader field for environment
+INSERT INTO loader_field_enums (id, enum_name, ordering, hidable)
+    VALUES (VAR_env_field_enum_id, 'environment', NULL, TRUE);
+
+INSERT INTO loader_field_enum_values (enum_id, value, ordering, created, metadata)
+    VALUES
+        -- Must be installed on both client and (integrated) server
+        (VAR_env_field_enum_id, 'client_and_server', NULL, NOW(), NULL),
+        -- Must be installed only on the client
+        (VAR_env_field_enum_id, 'client_only', NULL, NOW(), NULL),
+        -- Must be installed on the client, may be installed on a (integrated) server. To be displayed as a
+        -- client mod
+        (VAR_env_field_enum_id, 'client_only_server_optional', NULL, NOW(), NULL),
+        -- Must be installed only on the integrated singleplayer server. To be displayed as a server mod for
+        -- singleplayer exclusively
+        (VAR_env_field_enum_id, 'singleplayer_only', NULL, NOW(), NULL),
+        -- Must be installed only on a (integrated) server
+        (VAR_env_field_enum_id, 'server_only', NULL, NOW(), NULL),
+        -- Must be installed on the server, may be installed on the client. To be displayed as a
+        -- singleplayer-compatible server mod
+        (VAR_env_field_enum_id, 'server_only_client_optional', NULL, NOW(), NULL),
+        -- Must be installed only on a dedicated multiplayer server (not the integrated singleplayer server).
+        -- To be displayed as an server mod for multiplayer exclusively
+        (VAR_env_field_enum_id, 'dedicated_server_only', NULL, NOW(), NULL),
+        -- Can be installed on both client and server, with no strong preference for either. To be displayed
+        -- as both a client and server mod
+        (VAR_env_field_enum_id, 'client_or_server', NULL, NOW(), NULL),
+        -- Can be installed on both client and server, with a preference for being installed on both. To be
+        -- displayed as a client and server mod
+        (VAR_env_field_enum_id, 'client_or_server_prefers_both', NULL, NOW(), NULL),
+        (VAR_env_field_enum_id, 'unknown', NULL, NOW(), NULL);
+
+INSERT INTO loader_fields (field, field_type, enum_type, optional)
+    VALUES ('environment', 'enum', VAR_env_field_enum_id, FALSE)
+    RETURNING id INTO VAR_env_field_id;
+
+-- Update version_fields to have the new environment field, initializing it from the
+-- values of the previous fields
+INSERT INTO version_fields (version_id, field_id, enum_value)
+    SELECT vf.version_id, VAR_env_field_id, (
+        SELECT id
+        FROM loader_field_enum_values
+        WHERE enum_id = VAR_env_field_enum_id
+        AND value = (
+            CASE jsonb_object_agg(lf.field, vf.int_value)
+                WHEN '{ "server_only": 0, "singleplayer": 0, "client_and_server": 0, "client_only": 1 }'::jsonb THEN 'client_only'
+                WHEN '{ "server_only": 0, "singleplayer": 0, "client_and_server": 1, "client_only": 0 }'::jsonb THEN 'client_and_server'
+                WHEN '{ "server_only": 0, "singleplayer": 0, "client_and_server": 1, "client_only": 1 }'::jsonb THEN 'client_only_server_optional'
+                WHEN '{ "server_only": 0, "singleplayer": 1, "client_and_server": 0, "client_only": 0 }'::jsonb THEN 'singleplayer_only'
+                WHEN '{ "server_only": 0, "singleplayer": 1, "client_and_server": 0, "client_only": 1 }'::jsonb THEN 'client_only'
+                WHEN '{ "server_only": 0, "singleplayer": 1, "client_and_server": 1, "client_only": 0 }'::jsonb THEN 'client_and_server'
+                WHEN '{ "server_only": 0, "singleplayer": 1, "client_and_server": 1, "client_only": 1 }'::jsonb THEN 'client_only_server_optional'
+                WHEN '{ "server_only": 1, "singleplayer": 0, "client_and_server": 0, "client_only": 0 }'::jsonb THEN 'server_only'
+                WHEN '{ "server_only": 1, "singleplayer": 0, "client_and_server": 0, "client_only": 1 }'::jsonb THEN 'client_or_server'
+                WHEN '{ "server_only": 1, "singleplayer": 0, "client_and_server": 1, "client_only": 0 }'::jsonb THEN 'server_only_client_optional'
+                WHEN '{ "server_only": 1, "singleplayer": 0, "client_and_server": 1, "client_only": 1 }'::jsonb THEN 'client_or_server_prefers_both'
+                WHEN '{ "server_only": 1, "singleplayer": 1, "client_and_server": 0, "client_only": 0 }'::jsonb THEN 'server_only'
+                WHEN '{ "server_only": 1, "singleplayer": 1, "client_and_server": 0, "client_only": 1 }'::jsonb THEN 'client_or_server'
+                WHEN '{ "server_only": 1, "singleplayer": 1, "client_and_server": 1, "client_only": 0 }'::jsonb THEN 'server_only_client_optional'
+                WHEN '{ "server_only": 1, "singleplayer": 1, "client_and_server": 1, "client_only": 1 }'::jsonb THEN 'client_or_server_prefers_both'
+                ELSE 'unknown'
+            END
+        )
+    )
+    FROM version_fields vf
+    JOIN loader_fields lf ON vf.field_id = lf.id
+    WHERE lf.field IN ('server_only', 'singleplayer', 'client_and_server', 'client_only')
+    GROUP BY vf.version_id
+    HAVING COUNT(DISTINCT lf.field) = VAR_env_field_enum_id;
+
+-- Clean up old fields from the project versions
+DELETE FROM version_fields
+    WHERE field_id IN (
+        SELECT id
+        FROM loader_fields
+        WHERE field IN ('server_only', 'singleplayer', 'client_and_server', 'client_only')
+    );
+
+-- Switch loader fields definitions on the available loaders to use the new environment field
+ALTER TABLE loader_fields_loaders DROP CONSTRAINT unique_loader_field;
+ALTER TABLE loader_fields_loaders DROP CONSTRAINT loader_fields_loaders_pkey;
+
+UPDATE loader_fields_loaders
+    SET loader_field_id = VAR_env_field_id
+    WHERE loader_field_id IN (
+        SELECT id
+        FROM loader_fields
+        WHERE field IN ('server_only', 'singleplayer', 'client_and_server', 'client_only')
+    );
+
+-- Remove duplicate (loader_id, loader_field_id) pairs that may have been created due to several
+-- old fields being converted to a single new field
+DELETE FROM loader_fields_loaders
+    WHERE ctid NOT IN (
+        SELECT MIN(ctid)
+        FROM loader_fields_loaders
+        GROUP BY loader_id, loader_field_id
+    );
+
+-- Having both a PK and UNIQUE constraint for the same columns is redundant, so only restore the PK
+ALTER TABLE loader_fields_loaders ADD PRIMARY KEY (loader_id, loader_field_id);
+
+-- Finally, remove the old loader fields
+DELETE FROM loader_fields
+    WHERE field IN ('server_only', 'singleplayer', 'client_and_server', 'client_only');
+
+END;
+$$

--- a/apps/labrinth/src/models/v2/projects.rs
+++ b/apps/labrinth/src/models/v2/projects.rs
@@ -135,10 +135,11 @@ impl LegacyProject {
                     (f.field_name.clone(), f.value.clone().serialize_internal())
                 })
                 .collect::<HashMap<_, _>>();
-            (client_side, server_side) = v2_reroute::convert_side_types_v2(
-                &fields,
-                Some(&*og_project_type),
-            );
+            (client_side, server_side) =
+                v2_reroute::convert_v3_side_types_to_v2_side_types(
+                    &fields,
+                    Some(&*og_project_type),
+                );
 
             // - if loader is mrpack, this is a modpack
             // the loaders are whatever the corresponding loader fields are

--- a/apps/labrinth/src/models/v2/search.rs
+++ b/apps/labrinth/src/models/v2/search.rs
@@ -102,28 +102,20 @@ impl LegacyResultSearchProject {
 
         let project_loader_fields =
             result_search_project.project_loader_fields.clone();
-        let get_one_bool_loader_field = |key: &str| {
+        let get_one_string_loader_field = |key: &str| {
             project_loader_fields
                 .get(key)
-                .cloned()
-                .unwrap_or_default()
+                .map_or(&[][..], |values| values.as_slice())
                 .first()
-                .and_then(|s| s.as_bool())
+                .and_then(|s| s.as_str())
         };
 
-        let singleplayer = get_one_bool_loader_field("singleplayer");
-        let client_only =
-            get_one_bool_loader_field("client_only").unwrap_or(false);
-        let server_only =
-            get_one_bool_loader_field("server_only").unwrap_or(false);
-        let client_and_server = get_one_bool_loader_field("client_and_server");
+        let environment =
+            get_one_string_loader_field("environment").unwrap_or("unknown");
 
         let (client_side, server_side) =
-            v2_reroute::convert_side_types_v2_bools(
-                singleplayer,
-                client_only,
-                server_only,
-                client_and_server,
+            v2_reroute::convert_v3_environment_to_v2_side_types(
+                environment,
                 Some(&*og_project_type),
             );
         let client_side = client_side.to_string();

--- a/apps/labrinth/src/queue/moderation.rs
+++ b/apps/labrinth/src/queue/moderation.rs
@@ -242,7 +242,7 @@ impl AutomatedModerationQueue {
                                 version_specific: HashMap::new(),
                             };
 
-                            if project.project_types.iter().any(|x| ["mod", "modpack"].contains(&&**x)) && !project.aggregate_version_fields.iter().any(|x| ["server_only", "client_only", "client_and_server", "singleplayer"].contains(&&*x.field_name)) {
+                            if project.project_types.iter().any(|x| ["mod", "modpack"].contains(&&**x)) && !project.aggregate_version_fields.iter().any(|x| x.field_name == "environment") {
                                 mod_messages.messages.push(ModerationMessage::NoSideTypes);
                             }
 

--- a/apps/labrinth/src/routes/v2/project_creation.rs
+++ b/apps/labrinth/src/routes/v2/project_creation.rs
@@ -158,10 +158,12 @@ pub async fn project_create(
                 .into_iter()
                 .map(|v| {
                     let mut fields = HashMap::new();
-                    fields.extend(v2_reroute::convert_side_types_v3(
-                        client_side,
-                        server_side,
-                    ));
+                    fields.extend(
+                        v2_reroute::convert_v2_side_types_to_v3_side_types(
+                            client_side,
+                            server_side,
+                        ),
+                    );
                     fields.insert(
                         "game_versions".to_string(),
                         json!(v.game_versions),

--- a/apps/labrinth/src/routes/v2/projects.rs
+++ b/apps/labrinth/src/routes/v2/projects.rs
@@ -547,10 +547,12 @@ pub async fn project_edit(
             let version = Version::from(version);
             let mut fields = version.fields;
             let (current_client_side, current_server_side) =
-                v2_reroute::convert_side_types_v2(&fields, None);
+                v2_reroute::convert_v3_side_types_to_v2_side_types(
+                    &fields, None,
+                );
             let client_side = client_side.unwrap_or(current_client_side);
             let server_side = server_side.unwrap_or(current_server_side);
-            fields.extend(v2_reroute::convert_side_types_v3(
+            fields.extend(v2_reroute::convert_v2_side_types_to_v3_side_types(
                 client_side,
                 server_side,
             ));

--- a/apps/labrinth/src/routes/v2/version_creation.rs
+++ b/apps/labrinth/src/routes/v2/version_creation.rs
@@ -16,6 +16,7 @@ use actix_multipart::Multipart;
 use actix_web::http::header::ContentDisposition;
 use actix_web::web::Data;
 use actix_web::{HttpRequest, HttpResponse, post, web};
+use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use sqlx::postgres::PgPool;
@@ -136,53 +137,32 @@ pub async fn version_create(
                     .collect::<Vec<_>>();
 
                 // Copies side types of another version of the project.
-                // If no version exists, defaults to all false.
+                // If no version exists, defaults to an unknown side type.
                 // This is inherently lossy, but not much can be done about it, as side types are no longer associated with projects,
-                // so the 'missing' ones can't be easily accessed, and versions do need to have these fields explicitly set.
-                let side_type_loader_field_names = [
-                    "singleplayer",
-                    "client_and_server",
-                    "client_only",
-                    "server_only",
-                ];
+                // so the 'missing' ones can't be easily accessed, and versions do need to have that field explicitly set.
 
-                // Check if loader_fields_aggregate contains any of these side types
+                // Check if loader_fields_aggregate contains the side types
                 // We assume these four fields are linked together.
                 if loader_fields_aggregate
                     .iter()
-                    .any(|f| side_type_loader_field_names.contains(&f.as_str()))
+                    .any(|field| field == "environment")
                 {
-                    // If so, we get the fields of the example version of the project, and set the side types to match.
-                    fields.extend(
-                        side_type_loader_field_names
-                            .iter()
-                            .map(|f| (f.to_string(), json!(false))),
-                    );
-                    if let Some(example_version_fields) =
+                    // If so, we get the field of an example version of the project, and set the side types to match.
+                    fields.insert(
+                        "environment".into(),
                         get_example_version_fields(
                             legacy_create.project_id,
                             client,
                             &redis,
                         )
                         .await?
-                    {
-                        fields.extend(
-                            example_version_fields.into_iter().filter_map(
-                                |f| {
-                                    if side_type_loader_field_names
-                                        .contains(&f.field_name.as_str())
-                                    {
-                                        Some((
-                                            f.field_name,
-                                            f.value.serialize_internal(),
-                                        ))
-                                    } else {
-                                        None
-                                    }
-                                },
-                            ),
-                        );
-                    }
+                        .into_iter()
+                        .flatten()
+                        .find(|f| f.field_name == "environment")
+                        .map_or(json!("unknown"), |f| {
+                            f.value.serialize_internal()
+                        }),
+                    );
                 }
                 // Handle project type via file extension prediction
                 let mut project_type = None;

--- a/apps/labrinth/src/routes/v2_reroute.rs
+++ b/apps/labrinth/src/routes/v2_reroute.rs
@@ -164,69 +164,46 @@ where
     Ok(new_multipart)
 }
 
-// Converts a "client_side" and "server_side" pair into the new v3 corresponding fields
-pub fn convert_side_types_v3(
+/// Converts V2 side types to V3 side types.
+pub fn convert_v2_side_types_to_v3_side_types(
     client_side: LegacySideType,
     server_side: LegacySideType,
 ) -> HashMap<String, Value> {
-    use LegacySideType::{Optional, Required};
+    use LegacySideType::{Optional, Required, Unsupported};
 
-    let singleplayer = client_side == Required
-        || client_side == Optional
-        || server_side == Required
-        || server_side == Optional;
-    let client_and_server = singleplayer;
-    let client_only = (client_side == Required || client_side == Optional)
-        && server_side != Required;
-    let server_only = (server_side == Required || server_side == Optional)
-        && client_side != Required;
+    let environment = match (client_side, server_side) {
+        (Required, Required) => "client_and_server", // Or "singleplayer_only"
+        (Required, Unsupported) => "client_only",
+        (Required, Optional) => "client_only_server_optional",
+        (Unsupported, Required) => "server_only", // Or "dedicated_server_only"
+        (Optional, Required) => "server_only_client_optional",
+        (Optional, Optional) => "client_or_server", // Or "client_or_server_prefers_both"
+        _ => "unknown",
+    };
 
-    let mut fields = HashMap::new();
-    fields.insert("singleplayer".to_string(), json!(singleplayer));
-    fields.insert("client_and_server".to_string(), json!(client_and_server));
-    fields.insert("client_only".to_string(), json!(client_only));
-    fields.insert("server_only".to_string(), json!(server_only));
-    fields
+    [("environment".to_string(), json!(environment))]
+        .into_iter()
+        .collect()
 }
 
-// Convert search facets from V3 back to v2
-// this is not lossless. (See tests)
-pub fn convert_side_types_v2(
+/// Converts a V3 side types map into the corresponding V2 side types.
+pub fn convert_v3_side_types_to_v2_side_types(
     side_types: &HashMap<String, Value>,
     project_type: Option<&str>,
 ) -> (LegacySideType, LegacySideType) {
-    let client_and_server = side_types
-        .get("client_and_server")
-        .and_then(|x| x.as_bool())
-        .unwrap_or(false);
-    let singleplayer = side_types
-        .get("singleplayer")
-        .and_then(|x| x.as_bool())
-        .unwrap_or(client_and_server);
-    let client_only = side_types
-        .get("client_only")
-        .and_then(|x| x.as_bool())
-        .unwrap_or(false);
-    let server_only = side_types
-        .get("server_only")
-        .and_then(|x| x.as_bool())
-        .unwrap_or(false);
-
-    convert_side_types_v2_bools(
-        Some(singleplayer),
-        client_only,
-        server_only,
-        Some(client_and_server),
+    convert_v3_environment_to_v2_side_types(
+        side_types
+            .get("environment")
+            .and_then(|x| x.as_str())
+            .unwrap_or("unknown"),
         project_type,
     )
 }
 
-// Client side, server side
-pub fn convert_side_types_v2_bools(
-    singleplayer: Option<bool>,
-    client_only: bool,
-    server_only: bool,
-    client_and_server: Option<bool>,
+/// Converts a V3 environment and project type into the corresponding V2 side types.
+/// The first side type is for the client, the second is for the server.
+pub fn convert_v3_environment_to_v2_side_types(
+    environment: &str,
     project_type: Option<&str>,
 ) -> (LegacySideType, LegacySideType) {
     use LegacySideType::{Optional, Required, Unknown, Unsupported};
@@ -236,30 +213,18 @@ pub fn convert_side_types_v2_bools(
         Some("datapack") => (Optional, Required),
         Some("shader") => (Required, Unsupported),
         Some("resourcepack") => (Required, Unsupported),
-        _ => {
-            let singleplayer =
-                singleplayer.or(client_and_server).unwrap_or(false);
-
-            match (singleplayer, client_only, server_only) {
-                // Only singleplayer
-                (true, false, false) => (Required, Required),
-
-                // Client only and not server only
-                (false, true, false) => (Required, Unsupported),
-                (true, true, false) => (Required, Unsupported),
-
-                // Server only and not client only
-                (false, false, true) => (Unsupported, Required),
-                (true, false, true) => (Unsupported, Required),
-
-                // Both server only and client only
-                (true, true, true) => (Optional, Optional),
-                (false, true, true) => (Optional, Optional),
-
-                // Bad type
-                (false, false, false) => (Unknown, Unknown),
-            }
-        }
+        _ => match environment {
+            "client_and_server" => (Required, Required),
+            "client_only" => (Required, Unsupported),
+            "client_only_server_optional" => (Required, Optional),
+            "singleplayer_only" => (Required, Required),
+            "server_only" => (Unsupported, Required),
+            "server_only_client_optional" => (Optional, Required),
+            "dedicated_server_only" => (Unsupported, Required),
+            "client_or_server" => (Optional, Optional),
+            "client_or_server_prefers_both" => (Optional, Optional),
+            _ => (Unknown, Unknown), // "unknown"
+        },
     }
 }
 
@@ -279,13 +244,14 @@ mod tests {
     };
 
     #[test]
-    fn convert_types() {
-        // Converting types from V2 to V3 and back should be idempotent- for certain pairs
+    fn v2_v3_side_type_conversion() {
+        // Only nonsensical V2 side types cannot be round-tripped from V2 to V3 and back.
+        // When converting from V3 to V2, only additional information about the
+        // singleplayer-only, multiplayer-only, or install on both sides nature of the
+        // project is lost.
         let lossy_pairs = [
             (Optional, Unsupported),
             (Unsupported, Optional),
-            (Required, Optional),
-            (Optional, Required),
             (Unsupported, Unsupported),
         ];
 
@@ -294,10 +260,13 @@ mod tests {
                 if lossy_pairs.contains(&(client_side, server_side)) {
                     continue;
                 }
-                let side_types =
-                    convert_side_types_v3(client_side, server_side);
+                let side_types = convert_v2_side_types_to_v3_side_types(
+                    client_side,
+                    server_side,
+                );
                 let (client_side2, server_side2) =
-                    convert_side_types_v2(&side_types, None);
+                    convert_v3_side_types_to_v2_side_types(&side_types, None);
+
                 assert_eq!(client_side, client_side2);
                 assert_eq!(server_side, server_side2);
             }

--- a/apps/labrinth/src/search/indexing/local_import.rs
+++ b/apps/labrinth/src/search/indexing/local_import.rs
@@ -362,7 +362,7 @@ pub async fn index_local(
                 let (_, v2_og_project_type) =
                     LegacyProject::get_project_type(&project_types);
                 let (client_side, server_side) =
-                    v2_reroute::convert_side_types_v2(
+                    v2_reroute::convert_v3_side_types_to_v2_side_types(
                         &unvectorized_loader_fields,
                         Some(&v2_og_project_type),
                     );

--- a/apps/labrinth/src/search/indexing/mod.rs
+++ b/apps/labrinth/src/search/indexing/mod.rs
@@ -327,11 +327,8 @@ const DEFAULT_DISPLAYED_ATTRIBUTES: &[&str] = &[
     "color",
     // Note: loader fields are not here, but are added on as they are needed (so they can be dynamically added depending on which exist).
     // TODO: remove these- as they should be automatically populated. This is a band-aid fix.
-    "server_only",
-    "client_only",
+    "environment",
     "game_versions",
-    "singleplayer",
-    "client_and_server",
     "mrpack_loaders",
     // V2 legacy fields for logical consistency
     "client_side",
@@ -374,11 +371,8 @@ const DEFAULT_ATTRIBUTES_FOR_FACETING: &[&str] = &[
     "color",
     // Note: loader fields are not here, but are added on as they are needed (so they can be dynamically added depending on which exist).
     // TODO: remove these- as they should be automatically populated. This is a band-aid fix.
-    "server_only",
-    "client_only",
+    "environment",
     "game_versions",
-    "singleplayer",
-    "client_and_server",
     "mrpack_loaders",
     // V2 legacy fields for logical consistency
     "client_side",


### PR DESCRIPTION
Side types (also known as environment types) are Labrinth's way of representing where a version of a project can be installed (on the client, an integrated singleplayer server, a dedicated multiplayer server, or a combination of these) and where and how much functionality provides to the user (more on the client, more on the server, or both).

Historically, coming up with the right representation for that concept has been a challenging problem. Because projects can integrate into very diverse parts of the Minecraft game with differing levels of functionality, devising a single abstraction that handles all edge cases has proven difficult: the current `client_side`/`server_side` (in the v2 routes) and `server_only`/`singleplayer`/`client_and_server`/`client_only` (in the v3 routes) fields introduce issues for both developers and users. One one hand, developers struggle to write code that makes the right assumptions, e.g. when determining what mods to install on which side for modpacks. On the other hand, users can find it unclear which side type to select when authoring a project, increasing the workload for content moderators and leading to a worse user experience.

This PR lays the foundation for a new approach to side types, centered around a single `environment` loader enum field for project versions in the v3 routes. The design around this field reflects a consensus reached through an [RFC shared in the contributors channel of our Discord server](https://discord.com/channels/734077874708938864/848329986577399818/1304164758886285413), along with internal planning and discussions (see MOD-275, MOD-48). The values for that field are:

- `client_and_server`: must be installed on both the client and on a (possibly singleplayer) server.
- `client_only`: must be installed only on the client.
- `client_only_server_optional`: must be installed on the client, but may be installed on a (possibly singleplayer) server. The UI should highlight this as a mostly-client mod.
- `singleplayer_only`: Must be installed only on the integrated singleplayer server. Displayed as a server mod for singleplayer exclusively.
- `server_only`: must be installed only on a (possibly integrated) server.
- `server_only_client_optional`: must be installed on a (possibly singleplayer) server, but may be installed on the client. Displayed as a singleplayer-compatible server mod.
- `dedicated_server_only`: must be installed only on a dedicated multiplayer server (not the integrated singleplayer server). Displayed as a server mod for multiplayer exclusively.
- `client_or_server`: can be installed on both client and server, with no strong preference for either. Displayed as both a client and server mod.
- `client_or_server_prefers_both`: can be installed on both client and server, with a preference for being installed on both. Displayed as a client and server mod.
- `unknown`: fallback value for when the environment is not known yet.

For now, only the v3 routes, which are considered experimental and not subject to versioning guarantees, have had their fields changed. When a project is manipulated using v2 routes, the `environment` loader field is transparently converted to boolean `client_side` and `server_side` fields, which entail some loss, since `environment` can express more information. Similarly, the automatic translation done in the DB migration proposed in this PR between the `server_only`, `singleplayer`, `client_and_server`, and `client_only` fields to the new `environment` field may also change the semantics of how project sides are categorized.

## TODO
- [x] Test DB migration with realistic data from the staging environment.
- [ ] Review Labrinth integration tests, make sure they do not introduce any regressions.
- [ ] End-to-end testing of proper side type handling during project and version creation, edition, retrieval, and search.