### PR TITLE
fix(labrinth): tentative billing period update fix

### DIFF
--- a/apps/labrinth/src/routes/internal/billing.rs
+++ b/apps/labrinth/src/routes/internal/billing.rs
@@ -1020,6 +1020,7 @@ fn infer_currency_code(country: &str) -> String {
         "BE" => "EUR",
         "CY" => "EUR",
         "EE" => "EUR",
+        "ES" => "EUR",
         "FI" => "EUR",
         "FR" => "EUR",
         "DE" => "EUR",
@@ -1066,6 +1067,7 @@ fn infer_currency_code(country: &str) -> String {
         "TW" => "TWD",
         "SA" => "SAR",
         "QA" => "QAR",
+        "SG" => "SGD",
         _ => "USD",
     }
     .to_string()

--- a/apps/labrinth/src/routes/internal/billing.rs
+++ b/apps/labrinth/src/routes/internal/billing.rs
@@ -1304,6 +1304,12 @@ pub async fn initiate_payment(
             amount: Some(price),
             currency: Some(stripe_currency),
             customer: Some(customer),
+            metadata: interval.map(|interval| {
+                HashMap::from([(
+                    "modrinth_subscription_interval".to_string(),
+                    interval.as_str().to_string(),
+                )])
+            }),
             ..Default::default()
         };
 


### PR DESCRIPTION
I haven't tested this fix locally due to the complexity of setting up a proper environment, with working billing. However, a quick deployment to the staging environment should confirm whether these changes resolve the issue with subscription interval updates from the frontend not being applied in the database.

While I was at it, I also added two missing countries (one of them is mine!) to the hardcoded list of preferred currencies by country, which comes in handy if we end up doing regional (i.e., not USD-only) pricing at some point.