### PR TITLE
docs(issue template): do not skip closed issues in link to existing issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-app-bug.yml
+++ b/.github/ISSUE_TEMPLATE/1-app-bug.yml
@@ -6,7 +6,7 @@ body:
     attributes:
       label: Please confirm the following.
       options:
-        - label: I checked the [existing issues](https://github.com/modrinth/code/issues) for duplicate problems
+        - label: I checked the [existing issues](https://github.com/modrinth/code/issues?q=is%3Aissue) for duplicate problems
           required: true
         - label: I have tried resolving the issue using the [support portal](https://support.modrinth.com)
           required: true

--- a/.github/ISSUE_TEMPLATE/2-web-bug.yml
+++ b/.github/ISSUE_TEMPLATE/2-web-bug.yml
@@ -6,7 +6,7 @@ body:
     attributes:
       label: Please confirm the following.
       options:
-        - label: I checked the [existing issues](https://github.com/modrinth/code/issues) for duplicate problems
+        - label: I checked the [existing issues](https://github.com/modrinth/code/issues?q=is%3Aissue) for duplicate problems
           required: true
         - label: I have tried resolving the issue using the [support portal](https://support.modrinth.com)
           required: true

--- a/.github/ISSUE_TEMPLATE/3-api-bug.yml
+++ b/.github/ISSUE_TEMPLATE/3-api-bug.yml
@@ -6,7 +6,7 @@ body:
     attributes:
       label: Please confirm the following.
       options:
-        - label: I checked the [existing issues](https://github.com/modrinth/code/issues) for duplicate problems
+        - label: I checked the [existing issues](https://github.com/modrinth/code/issues?q=is%3Aissue) for duplicate problems
           required: true
         - label: I have tried resolving the issue using the [support portal](https://support.modrinth.com)
           required: true

--- a/.github/ISSUE_TEMPLATE/4-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/4-feature-request.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       label: Please confirm the following.
       options:
-        - label: I checked the [existing issues](https://github.com/modrinth/code/issues) for duplicate feature requests
+        - label: I checked the [existing issues](https://github.com/modrinth/code/issues?q=is%3Aissue) for duplicate feature requests
           required: true
         - label: I have checked that this feature request is not on our [roadmap](https://roadmap.modrinth.com)
           required: true


### PR DESCRIPTION
When an issue has been already handled by our part, and thus gets closed, but affects many users and the fix takes a while to be rolled out, it usually happens that those who notice the matter later on don't realize previous reports already exist and end up creating duplicate issues.

Let's try to improve a little bit on that by not filtering out closed issues in the links for checking whether the same issue was already reported. This should make it more obvious to users who follow the link whether an issue for their problem already exists.