### PR TITLE
fix: temp fix to prevent 503 retries on servers page

### DIFF
--- a/apps/frontend/src/composables/pyroServers.ts
+++ b/apps/frontend/src/composables/pyroServers.ts
@@ -207,7 +207,7 @@ async function PyroFetch<T>(
         }
 
         const statusCode = error.response?.status;
-        const isRetryable = statusCode ? [408, 429, 500, 502, 503, 504].includes(statusCode) : true;
+        const isRetryable = statusCode ? [408, 429, 500, 502, 504].includes(statusCode) : true;
 
         if (!isRetryable || attempts >= maxAttempts) {
           throw new ServersError(error.message, statusCode, error, module, v1Error);


### PR DESCRIPTION
Will be completely refactoring `pyroServers.ts` & `pyroFetch.ts` in a later PR - it's a mess, some of the options don't work (such as `retry: false`)

Closes: DEV-19