### PR TITLE
fix: undefined instance path by using emitted event instead when opening world folder

### DIFF
--- a/apps/app-frontend/src/components/ui/world/WorldItem.vue
+++ b/apps/app-frontend/src/components/ui/world/WorldItem.vue
@@ -1,10 +1,7 @@
 <script setup lang="ts">
 import dayjs from 'dayjs'
 import type { ServerStatus, ServerWorld, SingleplayerWorld, World } from '@/helpers/worlds.ts'
-import {
-  set_world_display_status,
-  getWorldIdentifier,
-} from '@/helpers/worlds.ts'
+import { set_world_display_status, getWorldIdentifier } from '@/helpers/worlds.ts'
 import { formatNumber, getPingLevel } from '@modrinth/utils'
 import {
   useRelativeTime,
@@ -47,8 +44,8 @@ const formatRelativeTime = useRelativeTime()
 const router = useRouter()
 
 const emit = defineEmits<{
-  (e: 'play' | 'play-instance' | 'update' | 'stop' | 'refresh' | 'edit' | 'delete'): void,
-  (e: 'open-folder', world: SingleplayerWorld): void,
+  (e: 'play' | 'play-instance' | 'update' | 'stop' | 'refresh' | 'edit' | 'delete'): void
+  (e: 'open-folder', world: SingleplayerWorld): void
 }>()
 
 const props = withDefaults(
@@ -380,7 +377,7 @@ const messages = defineMessages({
               {
                 id: 'open-folder',
                 shown: world.type === 'singleplayer',
-                action: () => world.type === 'singleplayer' ?  emit('open-folder', world) : {},
+                action: () => (world.type === 'singleplayer' ? emit('open-folder', world) : {}),
               },
               {
                 divider: true,

--- a/apps/app-frontend/src/components/ui/world/WorldItem.vue
+++ b/apps/app-frontend/src/components/ui/world/WorldItem.vue
@@ -1,10 +1,9 @@
 <script setup lang="ts">
 import dayjs from 'dayjs'
-import type { ServerStatus, ServerWorld, World } from '@/helpers/worlds.ts'
+import type { ServerStatus, ServerWorld, SingleplayerWorld, World } from '@/helpers/worlds.ts'
 import {
   set_world_display_status,
   getWorldIdentifier,
-  showWorldInFolder,
 } from '@/helpers/worlds.ts'
 import { formatNumber, getPingLevel } from '@modrinth/utils'
 import {
@@ -48,7 +47,8 @@ const formatRelativeTime = useRelativeTime()
 const router = useRouter()
 
 const emit = defineEmits<{
-  (e: 'play' | 'play-instance' | 'update' | 'stop' | 'refresh' | 'edit' | 'delete'): void
+  (e: 'play' | 'play-instance' | 'update' | 'stop' | 'refresh' | 'edit' | 'delete'): void,
+  (e: 'open-folder', world: SingleplayerWorld): void,
 }>()
 
 const props = withDefaults(
@@ -380,8 +380,7 @@ const messages = defineMessages({
               {
                 id: 'open-folder',
                 shown: world.type === 'singleplayer',
-                action: () =>
-                  world.type === 'singleplayer' ? showWorldInFolder(instancePath, world.path) : {},
+                action: () => world.type === 'singleplayer' ?  emit('open-folder', world) : {},
               },
               {
                 divider: true,

--- a/apps/app-frontend/src/pages/instance/Worlds.vue
+++ b/apps/app-frontend/src/pages/instance/Worlds.vue
@@ -86,6 +86,7 @@
             world.type === 'server' ? editServerModal?.show(world) : editWorldModal?.show(world)
         "
         @delete="() => promptToRemoveWorld(world)"
+        @open-folder="(world: SingleplayerWorld) => showWorldInFolder(instance.path, world.path)"
       />
     </div>
   </div>
@@ -151,6 +152,7 @@ import {
   hasQuickPlaySupport,
   refreshWorlds,
   handleDefaultProfileUpdateEvent,
+  showWorldInFolder,
 } from '@/helpers/worlds.ts'
 import AddServerModal from '@/components/ui/world/modal/AddServerModal.vue'
 import EditServerModal from '@/components/ui/world/modal/EditServerModal.vue'


### PR DESCRIPTION
This PR fixes the mentioned issue, by first seeing that the instance-path passed to the `showWorldInFolder` was missing, when accessing the `WorldItem` under an instance. 

1. Attempt was to just pass `:instance-path` to the `WorldItem` from the `Worlds` instance page, however that resulted in the action menu being wrong.
2. So final fix was to emit an event, which takes the singleplayer world to avoid having the check outside, which passes the instance path and the world path to the `showWorldInFolder` method.


https://github.com/user-attachments/assets/449454fa-e1eb-464b-9afe-b90dfbaadde6


closes: #3699 