### PR TITLE
fix: reset reset-icon state value correctly in edit world modal

### DIFF
--- a/apps/app-frontend/src/components/ui/world/modal/EditSingleplayerWorldModal.vue
+++ b/apps/app-frontend/src/components/ui/world/modal/EditSingleplayerWorldModal.vue
@@ -56,6 +56,7 @@ function show(world: SingleplayerWorld) {
   icon.value = world.icon
   displayStatus.value = world.display_status
   hideFromHome.value = world.display_status === 'hidden'
+  removeIcon.value = false
   modal.value.show()
 }
 


### PR DESCRIPTION
This PR ensures that the `removeIcon` state inside the edit singleplayer world modal is reset correctly after closing (showing) the modal.

Previously it's state was not reset.


## Media
### New behaviour

https://github.com/user-attachments/assets/2ede1a69-c41c-4ad5-8e00-88f1954fd46e


### Original behaviour
https://github.com/user-attachments/assets/a2e86daf-90f6-47bd-aca9-274d71849e60

