### PR TITLE
fix(app): make per-instance launch hooks clearable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8887,6 +8887,7 @@ dependencies = [
  "serde",
  "serde_ini",
  "serde_json",
+ "serde_with",
  "sha1_smol",
  "sha2",
  "sqlx",

--- a/apps/app-frontend/src/components/ui/instance_settings/HooksSettings.vue
+++ b/apps/app-frontend/src/components/ui/instance_settings/HooksSettings.vue
@@ -25,9 +25,8 @@ const editProfileObject = computed(() => {
     hooks?: Hooks
   } = {}
 
-  if (overrideHooks.value) {
-    editProfile.hooks = hooks.value
-  }
+  // When hooks are not overridden per-instance, we want to clear them
+  editProfile.hooks = overrideHooks.value ? hooks.value : {};
 
   return editProfile
 })

--- a/apps/app-frontend/src/components/ui/instance_settings/HooksSettings.vue
+++ b/apps/app-frontend/src/components/ui/instance_settings/HooksSettings.vue
@@ -26,7 +26,7 @@ const editProfileObject = computed(() => {
   } = {}
 
   // When hooks are not overridden per-instance, we want to clear them
-  editProfile.hooks = overrideHooks.value ? hooks.value : {};
+  editProfile.hooks = overrideHooks.value ? hooks.value : {}
 
   return editProfile
 })

--- a/packages/app-lib/Cargo.toml
+++ b/packages/app-lib/Cargo.toml
@@ -9,6 +9,7 @@ bytes.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 serde_ini.workspace = true
+serde_with.workspace = true
 sha1_smol.workspace = true
 sha2.workspace = true
 url = { workspace = true, features = ["serde"] }

--- a/packages/app-lib/src/api/profile/mod.rs
+++ b/packages/app-lib/src/api/profile/mod.rs
@@ -644,7 +644,6 @@ pub async fn run(
 /// Run Minecraft using a profile, and credentials for authentication
 /// Returns Arc pointer to RwLock to Child
 #[tracing::instrument(skip(credentials))]
-
 pub async fn run_credentials(
     path: &str,
     credentials: &Credentials,
@@ -662,7 +661,8 @@ pub async fn run_credentials(
         .hooks
         .pre_launch
         .as_ref()
-        .or(settings.hooks.pre_launch.as_ref());
+        .or(settings.hooks.pre_launch.as_ref())
+        .filter(|hook_command| !hook_command.is_empty());
     if let Some(hook) = pre_launch_hooks {
         // TODO: hook parameters
         let mut cmd = hook.split(' ');
@@ -692,7 +692,12 @@ pub async fn run_credentials(
         .clone()
         .unwrap_or(settings.extra_launch_args);
 
-    let wrapper = profile.hooks.wrapper.clone().or(settings.hooks.wrapper);
+    let wrapper = profile
+        .hooks
+        .wrapper
+        .clone()
+        .or(settings.hooks.wrapper)
+        .filter(|hook_command| !hook_command.is_empty());
 
     let memory = profile.memory.unwrap_or(settings.memory);
     let resolution =
@@ -704,8 +709,12 @@ pub async fn run_credentials(
         .unwrap_or(settings.custom_env_vars);
 
     // Post post exit hooks
-    let post_exit_hook =
-        profile.hooks.post_exit.clone().or(settings.hooks.post_exit);
+    let post_exit_hook = profile
+        .hooks
+        .post_exit
+        .clone()
+        .or(settings.hooks.post_exit)
+        .filter(|hook_command| !hook_command.is_empty());
 
     // Any options.txt settings that we want set, add here
     let mut mc_set_options: Vec<(String, String)> = vec![];

--- a/packages/app-lib/src/launcher/mod.rs
+++ b/packages/app-lib/src/launcher/mod.rs
@@ -352,9 +352,11 @@ pub async fn install_minecraft(
                     }
                 }
 
-                let cp = wrap_ref_builder!(cp = processor.classpath.clone() => {
-                    cp.push(processor.jar.clone())
-                });
+                let cp = {
+                    let mut cp = processor.classpath.clone();
+                    cp.push(processor.jar.clone());
+                    cp
+                };
 
                 let child = Command::new(&java_version.path)
                     .arg("-cp")
@@ -577,7 +579,9 @@ pub async fn launch_minecraft(
     let args = version_info.arguments.clone().unwrap_or_default();
     let mut command = match wrapper {
         Some(hook) => {
-            wrap_ref_builder!(it = Command::new(hook) => {it.arg(&java_version.path)})
+            let mut command = Command::new(hook);
+            command.arg(&java_version.path);
+            command
         }
         None => Command::new(&java_version.path),
     };

--- a/packages/app-lib/src/state/settings.rs
+++ b/packages/app-lib/src/state/settings.rs
@@ -247,9 +247,13 @@ pub struct WindowSize(pub u16, pub u16);
 
 /// Game initialization hooks
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde_with::serde_as]
 pub struct Hooks {
+    #[serde_as(as = "serde_with::NoneAsEmptyString")]
     pub pre_launch: Option<String>,
+    #[serde_as(as = "serde_with::NoneAsEmptyString")]
     pub wrapper: Option<String>,
+    #[serde_as(as = "serde_with::NoneAsEmptyString")]
     pub post_exit: Option<String>,
 }
 

--- a/packages/app-lib/src/util/mod.rs
+++ b/packages/app-lib/src/util/mod.rs
@@ -4,15 +4,3 @@ pub mod io;
 pub mod jre;
 pub mod platform;
 pub mod server_ping;
-
-/// Wrap a builder which uses a mut reference into one which outputs an owned value
-macro_rules! wrap_ref_builder {
-    ($id:ident = $init:expr => $transform:block) => {{
-        let mut it = $init;
-        {
-            let $id = &mut it;
-            $transform;
-        }
-        it
-    }};
-}


### PR DESCRIPTION
This PR fixes the cleanup of per-instance launch hook overrides by bundling together several related, though technically distinct, smaller fixes:

- The `HookSettings` frontend page previously couldn't clear per-instance launch hooks because it failed to instruct the backend to clear the stored hook strings when no hooks were explicitly overridden. The frontend now correctly instructs the backend to clear the hooks in such cases.
- The backend incorrectly treated a `Some("")` launch hook as valid for launching Minecraft, even though it clearly isn't. It now correctly interprets `Some("")`, which may be read from the app state database for instances affected by issue #3730, as equivalent to `None`.
- During (de)serialization of launch hook structs to the frontend, the backend also mishandled `Some("")`, treating it as distinct from `None`. This led to the storage of empty instance hook strings in the database, which triggered the issue described above.

I chose not to modify the app database schema to enforce a non-empty hook command string constraint in the profiles table because SQLite's `ALTER TABLE` does not support adding constraints to existing columns, and implementing such a change would require an overly complex migration for an issue that can be much simply resolved in the application layer. That said, I would definitely add such a constraint in a new schema design.

Additionally, I removed the `wrap_ref_builder` macro, which was only used in two places, made the code that used it harder to read, and didn't result in a reduction in lines of code.

As a result of these changes, removing per-instance launch hooks now works reliably and intuitively in the test scenario described in [this issue comment](https://github.com/modrinth/code/issues/3730#issuecomment-2954034430).