### PR TITLE
Improve `get_user_from_headers` signature

### DIFF
--- a/apps/labrinth/src/auth/oauth/mod.rs
+++ b/apps/labrinth/src/auth/oauth/mod.rs
@@ -68,7 +68,7 @@ pub async fn init_oauth(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::USER_AUTH_WRITE]),
+        Scopes::USER_AUTH_WRITE,
     )
     .await?
     .1;
@@ -323,7 +323,7 @@ pub async fn accept_or_reject_client_scopes(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::SESSION_ACCESS]),
+        Scopes::SESSION_ACCESS,
     )
     .await?
     .1;

--- a/apps/labrinth/src/auth/validate.rs
+++ b/apps/labrinth/src/auth/validate.rs
@@ -15,7 +15,7 @@ pub async fn get_user_from_headers<'a, E>(
     executor: E,
     redis: &RedisPool,
     session_queue: &AuthQueue,
-    required_scopes: Option<&[Scopes]>,
+    required_scopes: Scopes,
 ) -> Result<(Scopes, User), AuthenticationError>
 where
     E: sqlx::Executor<'a, Database = sqlx::Postgres> + Copy,
@@ -33,12 +33,8 @@ where
 
     let user = User::from_full(db_user);
 
-    if let Some(required_scopes) = required_scopes {
-        for scope in required_scopes {
-            if !scopes.contains(*scope) {
-                return Err(AuthenticationError::InvalidCredentials);
-            }
-        }
+    if !scopes.contains(required_scopes) {
+        return Err(AuthenticationError::InvalidCredentials);
     }
 
     Ok((scopes, user))
@@ -175,7 +171,7 @@ pub async fn check_is_moderator_from_headers<'a, 'b, E>(
     executor: E,
     redis: &RedisPool,
     session_queue: &AuthQueue,
-    required_scopes: Option<&[Scopes]>,
+    required_scopes: Scopes,
 ) -> Result<User, AuthenticationError>
 where
     E: sqlx::Executor<'a, Database = sqlx::Postgres> + Copy,

--- a/apps/labrinth/src/routes/analytics.rs
+++ b/apps/labrinth/src/routes/analytics.rs
@@ -55,10 +55,15 @@ pub async fn page_view_ingest(
     pool: web::Data<PgPool>,
     redis: web::Data<RedisPool>,
 ) -> Result<HttpResponse, ApiError> {
-    let user =
-        get_user_from_headers(&req, &**pool, &redis, &session_queue, None)
-            .await
-            .ok();
+    let user = get_user_from_headers(
+        &req,
+        &**pool,
+        &redis,
+        &session_queue,
+        Scopes::empty(),
+    )
+    .await
+    .ok();
     let conn_info = req.connection_info().peer_addr().map(|x| x.to_string());
 
     let url = Url::parse(&url_input.url).map_err(|_| {
@@ -177,7 +182,7 @@ pub async fn playtime_ingest(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::PERFORM_ANALYTICS]),
+        Scopes::PERFORM_ANALYTICS,
     )
     .await?;
 

--- a/apps/labrinth/src/routes/internal/billing.rs
+++ b/apps/labrinth/src/routes/internal/billing.rs
@@ -102,7 +102,7 @@ pub async fn subscriptions(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::SESSION_ACCESS]),
+        Scopes::SESSION_ACCESS,
     )
     .await?
     .1;
@@ -161,7 +161,7 @@ pub async fn refund_charge(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::SESSION_ACCESS]),
+        Scopes::SESSION_ACCESS,
     )
     .await?
     .1;
@@ -325,7 +325,7 @@ pub async fn edit_subscription(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::SESSION_ACCESS]),
+        Scopes::SESSION_ACCESS,
     )
     .await?
     .1;
@@ -585,7 +585,7 @@ pub async fn user_customer(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::SESSION_ACCESS]),
+        Scopes::SESSION_ACCESS,
     )
     .await?
     .1;
@@ -623,7 +623,7 @@ pub async fn charges(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::SESSION_ACCESS]),
+        Scopes::SESSION_ACCESS,
     )
     .await?
     .1;
@@ -682,7 +682,7 @@ pub async fn add_payment_method_flow(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::SESSION_ACCESS]),
+        Scopes::SESSION_ACCESS,
     )
     .await?
     .1;
@@ -736,7 +736,7 @@ pub async fn edit_payment_method(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::SESSION_ACCESS]),
+        Scopes::SESSION_ACCESS,
     )
     .await?
     .1;
@@ -805,7 +805,7 @@ pub async fn remove_payment_method(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::SESSION_ACCESS]),
+        Scopes::SESSION_ACCESS,
     )
     .await?
     .1;
@@ -892,7 +892,7 @@ pub async fn payment_methods(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::SESSION_ACCESS]),
+        Scopes::SESSION_ACCESS,
     )
     .await?
     .1;
@@ -1089,7 +1089,7 @@ pub async fn initiate_payment(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::SESSION_ACCESS]),
+        Scopes::SESSION_ACCESS,
     )
     .await?
     .1;

--- a/apps/labrinth/src/routes/internal/flows.rs
+++ b/apps/labrinth/src/routes/internal/flows.rs
@@ -1243,7 +1243,7 @@ pub async fn delete_auth_provider(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::USER_AUTH_WRITE]),
+        Scopes::USER_AUTH_WRITE,
     )
     .await?
     .1;
@@ -1663,7 +1663,7 @@ pub async fn begin_2fa_flow(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::USER_AUTH_WRITE]),
+        Scopes::USER_AUTH_WRITE,
     )
     .await?
     .1;
@@ -1708,7 +1708,7 @@ pub async fn finish_2fa_flow(
             &**pool,
             &redis,
             &session_queue,
-            Some(&[Scopes::USER_AUTH_WRITE]),
+            Scopes::USER_AUTH_WRITE,
         )
         .await?
         .1;
@@ -2140,7 +2140,7 @@ pub async fn set_email(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::USER_AUTH_WRITE]),
+        Scopes::USER_AUTH_WRITE,
     )
     .await?
     .1;
@@ -2223,7 +2223,7 @@ pub async fn resend_verify_email(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::USER_AUTH_WRITE]),
+        Scopes::USER_AUTH_WRITE,
     )
     .await?
     .1;
@@ -2328,7 +2328,7 @@ pub async fn subscribe_newsletter(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::USER_AUTH_WRITE]),
+        Scopes::USER_AUTH_WRITE,
     )
     .await?
     .1;

--- a/apps/labrinth/src/routes/internal/gdpr.rs
+++ b/apps/labrinth/src/routes/internal/gdpr.rs
@@ -22,7 +22,7 @@ pub async fn export(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::SESSION_ACCESS]),
+        Scopes::SESSION_ACCESS,
     )
     .await?
     .1;

--- a/apps/labrinth/src/routes/internal/moderation.rs
+++ b/apps/labrinth/src/routes/internal/moderation.rs
@@ -39,7 +39,7 @@ pub async fn get_projects(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::PROJECT_READ]),
+        Scopes::PROJECT_READ,
     )
     .await?;
 
@@ -82,7 +82,7 @@ pub async fn get_project_meta(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::PROJECT_READ]),
+        Scopes::PROJECT_READ,
     )
     .await?;
 
@@ -234,7 +234,7 @@ pub async fn set_project_meta(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::PROJECT_READ]),
+        Scopes::PROJECT_READ,
     )
     .await?;
 

--- a/apps/labrinth/src/routes/internal/pats.rs
+++ b/apps/labrinth/src/routes/internal/pats.rs
@@ -39,7 +39,7 @@ pub async fn get_pats(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::PAT_READ]),
+        Scopes::PAT_READ,
     )
     .await?
     .1;
@@ -99,7 +99,7 @@ pub async fn create_pat(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::PAT_CREATE]),
+        Scopes::PAT_CREATE,
     )
     .await?
     .1;
@@ -174,7 +174,7 @@ pub async fn edit_pat(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::PAT_WRITE]),
+        Scopes::PAT_WRITE,
     )
     .await?
     .1;
@@ -266,7 +266,7 @@ pub async fn delete_pat(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::PAT_DELETE]),
+        Scopes::PAT_DELETE,
     )
     .await?
     .1;

--- a/apps/labrinth/src/routes/internal/session.rs
+++ b/apps/labrinth/src/routes/internal/session.rs
@@ -141,7 +141,7 @@ pub async fn list(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::SESSION_READ]),
+        Scopes::SESSION_READ,
     )
     .await?
     .1;
@@ -178,7 +178,7 @@ pub async fn delete(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::SESSION_DELETE]),
+        Scopes::SESSION_DELETE,
     )
     .await?
     .1;
@@ -212,10 +212,15 @@ pub async fn refresh(
     redis: Data<RedisPool>,
     session_queue: Data<AuthQueue>,
 ) -> Result<HttpResponse, ApiError> {
-    let current_user =
-        get_user_from_headers(&req, &**pool, &redis, &session_queue, None)
-            .await?
-            .1;
+    let current_user = get_user_from_headers(
+        &req,
+        &**pool,
+        &redis,
+        &session_queue,
+        Scopes::empty(),
+    )
+    .await?
+    .1;
     let session = req
         .headers()
         .get(AUTHORIZATION)

--- a/apps/labrinth/src/routes/maven.rs
+++ b/apps/labrinth/src/routes/maven.rs
@@ -88,7 +88,7 @@ pub async fn maven_metadata(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::PROJECT_READ]),
+        Scopes::PROJECT_READ,
     )
     .await
     .map(|x| x.1)
@@ -294,7 +294,7 @@ pub async fn version_file(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::PROJECT_READ]),
+        Scopes::PROJECT_READ,
     )
     .await
     .map(|x| x.1)
@@ -360,7 +360,7 @@ pub async fn version_file_sha1(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::PROJECT_READ]),
+        Scopes::PROJECT_READ,
     )
     .await
     .map(|x| x.1)
@@ -405,7 +405,7 @@ pub async fn version_file_sha512(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::PROJECT_READ]),
+        Scopes::PROJECT_READ,
     )
     .await
     .map(|x| x.1)

--- a/apps/labrinth/src/routes/updates.rs
+++ b/apps/labrinth/src/routes/updates.rs
@@ -51,7 +51,7 @@ pub async fn forge_updates(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::PROJECT_READ]),
+        Scopes::PROJECT_READ,
     )
     .await
     .map(|x| x.1)

--- a/apps/labrinth/src/routes/v3/analytics_get.rs
+++ b/apps/labrinth/src/routes/v3/analytics_get.rs
@@ -82,7 +82,7 @@ pub async fn playtimes_get(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::ANALYTICS]),
+        Scopes::ANALYTICS,
     )
     .await
     .map(|x| x.1)?;
@@ -151,7 +151,7 @@ pub async fn views_get(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::ANALYTICS]),
+        Scopes::ANALYTICS,
     )
     .await
     .map(|x| x.1)?;
@@ -220,7 +220,7 @@ pub async fn downloads_get(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::ANALYTICS]),
+        Scopes::ANALYTICS,
     )
     .await
     .map(|x| x.1)?;
@@ -289,7 +289,7 @@ pub async fn revenue_get(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::PAYOUTS_READ]),
+        Scopes::PAYOUTS_READ,
     )
     .await
     .map(|x| x.1)?;
@@ -430,7 +430,7 @@ pub async fn countries_downloads_get(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::ANALYTICS]),
+        Scopes::ANALYTICS,
     )
     .await
     .map(|x| x.1)?;
@@ -503,7 +503,7 @@ pub async fn countries_views_get(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::ANALYTICS]),
+        Scopes::ANALYTICS,
     )
     .await
     .map(|x| x.1)?;

--- a/apps/labrinth/src/routes/v3/collections.rs
+++ b/apps/labrinth/src/routes/v3/collections.rs
@@ -71,7 +71,7 @@ pub async fn collection_create(
         &**client,
         &redis,
         &session_queue,
-        Some(&[Scopes::COLLECTION_CREATE]),
+        Scopes::COLLECTION_CREATE,
     )
     .await?
     .1;
@@ -156,7 +156,7 @@ pub async fn collections_get(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::COLLECTION_READ]),
+        Scopes::COLLECTION_READ,
     )
     .await
     .map(|x| x.1)
@@ -185,7 +185,7 @@ pub async fn collection_get(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::COLLECTION_READ]),
+        Scopes::COLLECTION_READ,
     )
     .await
     .map(|x| x.1)
@@ -231,7 +231,7 @@ pub async fn collection_edit(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::COLLECTION_WRITE]),
+        Scopes::COLLECTION_WRITE,
     )
     .await?
     .1;
@@ -390,7 +390,7 @@ pub async fn collection_icon_edit(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::COLLECTION_WRITE]),
+        Scopes::COLLECTION_WRITE,
     )
     .await?
     .1;
@@ -471,7 +471,7 @@ pub async fn delete_collection_icon(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::COLLECTION_WRITE]),
+        Scopes::COLLECTION_WRITE,
     )
     .await?
     .1;
@@ -528,7 +528,7 @@ pub async fn collection_delete(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::COLLECTION_DELETE]),
+        Scopes::COLLECTION_DELETE,
     )
     .await?
     .1;

--- a/apps/labrinth/src/routes/v3/friends.rs
+++ b/apps/labrinth/src/routes/v3/friends.rs
@@ -36,7 +36,7 @@ pub async fn add_friend(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::USER_WRITE]),
+        Scopes::USER_WRITE,
     )
     .await?
     .1;
@@ -154,7 +154,7 @@ pub async fn remove_friend(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::USER_WRITE]),
+        Scopes::USER_WRITE,
     )
     .await?
     .1;
@@ -200,7 +200,7 @@ pub async fn friends(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::USER_READ]),
+        Scopes::USER_READ,
     )
     .await?
     .1;

--- a/apps/labrinth/src/routes/v3/images.rs
+++ b/apps/labrinth/src/routes/v3/images.rs
@@ -49,14 +49,12 @@ pub async fn images_add(
 ) -> Result<HttpResponse, ApiError> {
     let mut context = ImageContext::from_str(&data.context, None);
 
-    let scopes = vec![context.relevant_scope()];
-
     let user = get_user_from_headers(
         &req,
         &**pool,
         &redis,
         &session_queue,
-        Some(&scopes),
+        context.relevant_scope(),
     )
     .await?
     .1;

--- a/apps/labrinth/src/routes/v3/notifications.rs
+++ b/apps/labrinth/src/routes/v3/notifications.rs
@@ -40,7 +40,7 @@ pub async fn notifications_get(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::NOTIFICATION_READ]),
+        Scopes::NOTIFICATION_READ,
     )
     .await?
     .1;
@@ -82,7 +82,7 @@ pub async fn notification_get(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::NOTIFICATION_READ]),
+        Scopes::NOTIFICATION_READ,
     )
     .await?
     .1;
@@ -119,7 +119,7 @@ pub async fn notification_read(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::NOTIFICATION_WRITE]),
+        Scopes::NOTIFICATION_WRITE,
     )
     .await?
     .1;
@@ -169,7 +169,7 @@ pub async fn notification_delete(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::NOTIFICATION_WRITE]),
+        Scopes::NOTIFICATION_WRITE,
     )
     .await?
     .1;
@@ -220,7 +220,7 @@ pub async fn notifications_read(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::NOTIFICATION_WRITE]),
+        Scopes::NOTIFICATION_WRITE,
     )
     .await?
     .1;
@@ -273,7 +273,7 @@ pub async fn notifications_delete(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::NOTIFICATION_WRITE]),
+        Scopes::NOTIFICATION_WRITE,
     )
     .await?
     .1;

--- a/apps/labrinth/src/routes/v3/oauth_clients.rs
+++ b/apps/labrinth/src/routes/v3/oauth_clients.rs
@@ -69,7 +69,7 @@ pub async fn get_user_clients(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::SESSION_ACCESS]),
+        Scopes::SESSION_ACCESS,
     )
     .await?
     .1;
@@ -167,7 +167,7 @@ pub async fn oauth_client_create(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::SESSION_ACCESS]),
+        Scopes::SESSION_ACCESS,
     )
     .await?
     .1;
@@ -228,7 +228,7 @@ pub async fn oauth_client_delete(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::SESSION_ACCESS]),
+        Scopes::SESSION_ACCESS,
     )
     .await?
     .1;
@@ -285,7 +285,7 @@ pub async fn oauth_client_edit(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::SESSION_ACCESS]),
+        Scopes::SESSION_ACCESS,
     )
     .await?
     .1;
@@ -363,7 +363,7 @@ pub async fn oauth_client_icon_edit(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::SESSION_ACCESS]),
+        Scopes::SESSION_ACCESS,
     )
     .await?
     .1;
@@ -430,7 +430,7 @@ pub async fn oauth_client_icon_delete(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::SESSION_ACCESS]),
+        Scopes::SESSION_ACCESS,
     )
     .await?
     .1;
@@ -477,7 +477,7 @@ pub async fn get_user_oauth_authorizations(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::SESSION_ACCESS]),
+        Scopes::SESSION_ACCESS,
     )
     .await?
     .1;
@@ -507,7 +507,7 @@ pub async fn revoke_oauth_authorization(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::SESSION_ACCESS]),
+        Scopes::SESSION_ACCESS,
     )
     .await?
     .1;

--- a/apps/labrinth/src/routes/v3/organizations.rs
+++ b/apps/labrinth/src/routes/v3/organizations.rs
@@ -63,7 +63,7 @@ pub async fn organization_projects_get(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::ORGANIZATION_READ, Scopes::PROJECT_READ]),
+        Scopes::ORGANIZATION_READ | Scopes::PROJECT_READ,
     )
     .await
     .map(|x| x.1)
@@ -127,7 +127,7 @@ pub async fn organization_create(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::ORGANIZATION_CREATE]),
+        Scopes::ORGANIZATION_CREATE,
     )
     .await?
     .1;
@@ -224,7 +224,7 @@ pub async fn organization_get(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::ORGANIZATION_READ]),
+        Scopes::ORGANIZATION_READ,
     )
     .await
     .map(|x| x.1)
@@ -315,7 +315,7 @@ pub async fn organizations_get(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::ORGANIZATION_READ]),
+        Scopes::ORGANIZATION_READ,
     )
     .await
     .map(|x| x.1)
@@ -396,7 +396,7 @@ pub async fn organizations_edit(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::ORGANIZATION_WRITE]),
+        Scopes::ORGANIZATION_WRITE,
     )
     .await?
     .1;
@@ -559,7 +559,7 @@ pub async fn organization_delete(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::ORGANIZATION_DELETE]),
+        Scopes::ORGANIZATION_DELETE,
     )
     .await?
     .1;
@@ -700,7 +700,7 @@ pub async fn organization_projects_add(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::PROJECT_WRITE, Scopes::ORGANIZATION_WRITE]),
+        Scopes::PROJECT_WRITE | Scopes::ORGANIZATION_WRITE,
     )
     .await?
     .1;
@@ -863,7 +863,7 @@ pub async fn organization_projects_remove(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::PROJECT_WRITE, Scopes::ORGANIZATION_WRITE]),
+        Scopes::PROJECT_WRITE | Scopes::ORGANIZATION_WRITE,
     )
     .await?
     .1;
@@ -1051,7 +1051,7 @@ pub async fn organization_icon_edit(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::ORGANIZATION_WRITE]),
+        Scopes::ORGANIZATION_WRITE,
     )
     .await?
     .1;
@@ -1154,7 +1154,7 @@ pub async fn delete_organization_icon(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::ORGANIZATION_WRITE]),
+        Scopes::ORGANIZATION_WRITE,
     )
     .await?
     .1;

--- a/apps/labrinth/src/routes/v3/payouts.rs
+++ b/apps/labrinth/src/routes/v3/payouts.rs
@@ -313,7 +313,7 @@ pub async fn user_payouts(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::PAYOUTS_READ]),
+        Scopes::PAYOUTS_READ,
     )
     .await?
     .1;
@@ -653,7 +653,7 @@ pub async fn cancel_payout(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::PAYOUTS_WRITE]),
+        Scopes::PAYOUTS_WRITE,
     )
     .await?
     .1;
@@ -783,7 +783,7 @@ pub async fn get_balance(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::PAYOUTS_READ]),
+        Scopes::PAYOUTS_READ,
     )
     .await?
     .1;

--- a/apps/labrinth/src/routes/v3/project_creation.rs
+++ b/apps/labrinth/src/routes/v3/project_creation.rs
@@ -342,7 +342,7 @@ async fn project_create_inner(
         pool,
         redis,
         session_queue,
-        Some(&[Scopes::PROJECT_CREATE]),
+        Scopes::PROJECT_CREATE,
     )
     .await?
     .1;

--- a/apps/labrinth/src/routes/v3/projects.rs
+++ b/apps/labrinth/src/routes/v3/projects.rs
@@ -142,7 +142,7 @@ pub async fn projects_get(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::PROJECT_READ]),
+        Scopes::PROJECT_READ,
     )
     .await
     .map(|x| x.1)
@@ -171,7 +171,7 @@ pub async fn project_get(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::PROJECT_READ]),
+        Scopes::PROJECT_READ,
     )
     .await
     .map(|x| x.1)
@@ -261,7 +261,7 @@ pub async fn project_edit(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::PROJECT_WRITE]),
+        Scopes::PROJECT_WRITE,
     )
     .await?
     .1;
@@ -1017,7 +1017,7 @@ pub async fn dependency_list(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::PROJECT_READ]),
+        Scopes::PROJECT_READ,
     )
     .await
     .map(|x| x.1)
@@ -1129,7 +1129,7 @@ pub async fn projects_edit(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::PROJECT_WRITE]),
+        Scopes::PROJECT_WRITE,
     )
     .await?
     .1;
@@ -1426,7 +1426,7 @@ pub async fn project_icon_edit(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::PROJECT_WRITE]),
+        Scopes::PROJECT_WRITE,
     )
     .await?
     .1;
@@ -1537,7 +1537,7 @@ pub async fn delete_project_icon(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::PROJECT_WRITE]),
+        Scopes::PROJECT_WRITE,
     )
     .await?
     .1;
@@ -1644,7 +1644,7 @@ pub async fn add_gallery_item(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::PROJECT_WRITE]),
+        Scopes::PROJECT_WRITE,
     )
     .await?
     .1;
@@ -1802,7 +1802,7 @@ pub async fn edit_gallery_item(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::PROJECT_WRITE]),
+        Scopes::PROJECT_WRITE,
     )
     .await?
     .1;
@@ -1969,7 +1969,7 @@ pub async fn delete_gallery_item(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::PROJECT_WRITE]),
+        Scopes::PROJECT_WRITE,
     )
     .await?
     .1;
@@ -2078,7 +2078,7 @@ pub async fn project_delete(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::PROJECT_DELETE]),
+        Scopes::PROJECT_DELETE,
     )
     .await?
     .1;
@@ -2181,7 +2181,7 @@ pub async fn project_follow(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::USER_WRITE]),
+        Scopes::USER_WRITE,
     )
     .await?
     .1;
@@ -2261,7 +2261,7 @@ pub async fn project_unfollow(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::USER_WRITE]),
+        Scopes::USER_WRITE,
     )
     .await?
     .1;
@@ -2337,7 +2337,7 @@ pub async fn project_get_organization(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::PROJECT_READ, Scopes::ORGANIZATION_READ]),
+        Scopes::PROJECT_READ | Scopes::ORGANIZATION_READ,
     )
     .await
     .map(|x| x.1)

--- a/apps/labrinth/src/routes/v3/reports.rs
+++ b/apps/labrinth/src/routes/v3/reports.rs
@@ -58,7 +58,7 @@ pub async fn report_create(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::REPORT_CREATE]),
+        Scopes::REPORT_CREATE,
     )
     .await?
     .1;
@@ -254,7 +254,7 @@ pub async fn reports(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::REPORT_READ]),
+        Scopes::REPORT_READ,
     )
     .await?
     .1;
@@ -338,7 +338,7 @@ pub async fn reports_get(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::REPORT_READ]),
+        Scopes::REPORT_READ,
     )
     .await?
     .1;
@@ -364,7 +364,7 @@ pub async fn report_get(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::REPORT_READ]),
+        Scopes::REPORT_READ,
     )
     .await?
     .1;
@@ -406,7 +406,7 @@ pub async fn report_edit(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::REPORT_WRITE]),
+        Scopes::REPORT_WRITE,
     )
     .await?
     .1;
@@ -506,7 +506,7 @@ pub async fn report_delete(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::REPORT_DELETE]),
+        Scopes::REPORT_DELETE,
     )
     .await?;
 

--- a/apps/labrinth/src/routes/v3/teams.rs
+++ b/apps/labrinth/src/routes/v3/teams.rs
@@ -57,7 +57,7 @@ pub async fn team_members_get_project(
             &**pool,
             &redis,
             &session_queue,
-            Some(&[Scopes::PROJECT_READ]),
+            Scopes::PROJECT_READ,
         )
         .await
         .map(|x| x.1)
@@ -142,7 +142,7 @@ pub async fn team_members_get_organization(
             &**pool,
             &redis,
             &session_queue,
-            Some(&[Scopes::ORGANIZATION_READ]),
+            Scopes::ORGANIZATION_READ,
         )
         .await
         .map(|x| x.1)
@@ -222,7 +222,7 @@ pub async fn team_members_get(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::PROJECT_READ]),
+        Scopes::PROJECT_READ,
     )
     .await
     .map(|x| x.1)
@@ -294,7 +294,7 @@ pub async fn teams_get(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::PROJECT_READ]),
+        Scopes::PROJECT_READ,
     )
     .await
     .map(|x| x.1)
@@ -348,7 +348,7 @@ pub async fn join_team(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::PROJECT_WRITE]),
+        Scopes::PROJECT_WRITE,
     )
     .await?
     .1;
@@ -437,7 +437,7 @@ pub async fn add_team_member(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::PROJECT_WRITE]),
+        Scopes::PROJECT_WRITE,
     )
     .await?
     .1;
@@ -692,7 +692,7 @@ pub async fn edit_team_member(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::PROJECT_WRITE]),
+        Scopes::PROJECT_WRITE,
     )
     .await?
     .1;
@@ -878,7 +878,7 @@ pub async fn transfer_ownership(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::PROJECT_WRITE]),
+        Scopes::PROJECT_WRITE,
     )
     .await?
     .1;
@@ -1050,7 +1050,7 @@ pub async fn remove_team_member(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::PROJECT_WRITE]),
+        Scopes::PROJECT_WRITE,
     )
     .await?
     .1;

--- a/apps/labrinth/src/routes/v3/threads.rs
+++ b/apps/labrinth/src/routes/v3/threads.rs
@@ -285,7 +285,7 @@ pub async fn thread_get(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::THREAD_READ]),
+        Scopes::THREAD_READ,
     )
     .await?
     .1;
@@ -341,7 +341,7 @@ pub async fn threads_get(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::THREAD_READ]),
+        Scopes::THREAD_READ,
     )
     .await?
     .1;
@@ -379,7 +379,7 @@ pub async fn thread_send_message(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::THREAD_WRITE]),
+        Scopes::THREAD_WRITE,
     )
     .await?
     .1;
@@ -577,7 +577,7 @@ pub async fn message_delete(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::THREAD_WRITE]),
+        Scopes::THREAD_WRITE,
     )
     .await?
     .1;

--- a/apps/labrinth/src/routes/v3/users.rs
+++ b/apps/labrinth/src/routes/v3/users.rs
@@ -60,7 +60,7 @@ pub async fn admin_user_email(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::SESSION_ACCESS]),
+        Scopes::SESSION_ACCESS,
     )
     .await
     .map(|x| x.1)?;
@@ -114,7 +114,7 @@ pub async fn projects_list(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::PROJECT_READ]),
+        Scopes::PROJECT_READ,
     )
     .await
     .map(|x| x.1)
@@ -150,7 +150,7 @@ pub async fn user_auth_get(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::USER_READ]),
+        Scopes::USER_READ,
     )
     .await?;
 
@@ -200,7 +200,7 @@ pub async fn user_get(
             &**pool,
             &redis,
             &session_queue,
-            Some(&[Scopes::SESSION_ACCESS]),
+            Scopes::SESSION_ACCESS,
         )
         .await
         .map(|x| x.1)
@@ -231,7 +231,7 @@ pub async fn collections_list(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::COLLECTION_READ]),
+        Scopes::COLLECTION_READ,
     )
     .await
     .map(|x| x.1)
@@ -279,7 +279,7 @@ pub async fn orgs_list(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::PROJECT_READ]),
+        Scopes::PROJECT_READ,
     )
     .await
     .map(|x| x.1)
@@ -389,7 +389,7 @@ pub async fn user_edit(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::USER_WRITE]),
+        Scopes::USER_WRITE,
     )
     .await?;
 
@@ -561,7 +561,7 @@ pub async fn user_icon_edit(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::USER_WRITE]),
+        Scopes::USER_WRITE,
     )
     .await?
     .1;
@@ -633,7 +633,7 @@ pub async fn user_icon_delete(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::USER_WRITE]),
+        Scopes::USER_WRITE,
     )
     .await?
     .1;
@@ -685,7 +685,7 @@ pub async fn user_delete(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::USER_DELETE]),
+        Scopes::USER_DELETE,
     )
     .await?
     .1;
@@ -726,7 +726,7 @@ pub async fn user_follows(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::USER_READ]),
+        Scopes::USER_READ,
     )
     .await?
     .1;
@@ -768,7 +768,7 @@ pub async fn user_notifications(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::NOTIFICATION_READ]),
+        Scopes::NOTIFICATION_READ,
     )
     .await?
     .1;

--- a/apps/labrinth/src/routes/v3/version_creation.rs
+++ b/apps/labrinth/src/routes/v3/version_creation.rs
@@ -169,7 +169,7 @@ async fn version_create_inner(
         pool,
         redis,
         session_queue,
-        Some(&[Scopes::VERSION_CREATE]),
+        Scopes::VERSION_CREATE,
     )
     .await?
     .1;
@@ -599,7 +599,7 @@ async fn upload_file_to_version_inner(
         &**client,
         &redis,
         session_queue,
-        Some(&[Scopes::VERSION_WRITE]),
+        Scopes::VERSION_WRITE,
     )
     .await?
     .1;

--- a/apps/labrinth/src/routes/v3/version_file.rs
+++ b/apps/labrinth/src/routes/v3/version_file.rs
@@ -46,7 +46,7 @@ pub async fn get_version_from_hash(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::VERSION_READ]),
+        Scopes::VERSION_READ,
     )
     .await
     .map(|x| x.1)
@@ -132,7 +132,7 @@ pub async fn get_update_from_hash(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::VERSION_READ]),
+        Scopes::VERSION_READ,
     )
     .await
     .map(|x| x.1)
@@ -231,7 +231,7 @@ pub async fn get_versions_from_hashes(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::VERSION_READ]),
+        Scopes::VERSION_READ,
     )
     .await
     .map(|x| x.1)
@@ -285,7 +285,7 @@ pub async fn get_projects_from_hashes(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::PROJECT_READ, Scopes::VERSION_READ]),
+        Scopes::PROJECT_READ | Scopes::VERSION_READ,
     )
     .await
     .map(|x| x.1)
@@ -437,7 +437,7 @@ pub async fn update_individual_files(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::VERSION_READ]),
+        Scopes::VERSION_READ,
     )
     .await
     .map(|x| x.1)
@@ -569,7 +569,7 @@ pub async fn delete_file(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::VERSION_WRITE]),
+        Scopes::VERSION_WRITE,
     )
     .await?
     .1;
@@ -699,7 +699,7 @@ pub async fn download_version(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::VERSION_READ]),
+        Scopes::VERSION_READ,
     )
     .await
     .map(|x| x.1)

--- a/apps/labrinth/src/routes/v3/versions.rs
+++ b/apps/labrinth/src/routes/v3/versions.rs
@@ -80,7 +80,7 @@ pub async fn version_project_get_helper(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::PROJECT_READ, Scopes::VERSION_READ]),
+        Scopes::PROJECT_READ | Scopes::VERSION_READ,
     )
     .await
     .map(|x| x.1)
@@ -145,7 +145,7 @@ pub async fn versions_get(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::VERSION_READ]),
+        Scopes::VERSION_READ,
     )
     .await
     .map(|x| x.1)
@@ -184,7 +184,7 @@ pub async fn version_get_helper(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::VERSION_READ]),
+        Scopes::VERSION_READ,
     )
     .await
     .map(|x| x.1)
@@ -281,7 +281,7 @@ pub async fn version_edit_helper(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::VERSION_WRITE]),
+        Scopes::VERSION_WRITE,
     )
     .await?
     .1;
@@ -736,7 +736,7 @@ pub async fn version_list(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::PROJECT_READ, Scopes::VERSION_READ]),
+        Scopes::PROJECT_READ | Scopes::VERSION_READ,
     )
     .await
     .map(|x| x.1)
@@ -883,7 +883,7 @@ pub async fn version_delete(
         &**pool,
         &redis,
         &session_queue,
-        Some(&[Scopes::VERSION_DELETE]),
+        Scopes::VERSION_DELETE,
     )
     .await?
     .1;


### PR DESCRIPTION
This makes `get_user_from_headers` (and the similar function `check_is_moderator_from_headers`) take in a single `Scopes` parameter as a bitflag, rather than an `Option<&[Scopes]>`. This improves the performance and ergonomics of these functions.