### PR TITLE
Small CI flakiness fix and performance tweak

### DIFF
--- a/.github/workflows/turbo-ci.yml
+++ b/.github/workflows/turbo-ci.yml
@@ -66,7 +66,7 @@ jobs:
         run: pnpm install
 
       - name: ⚙️ Start services
-        run: docker compose up -d
+        run: docker compose up --wait
 
       - name: ⚙️ Setup Labrinth environment and database
         working-directory: apps/labrinth

--- a/.github/workflows/turbo-ci.yml
+++ b/.github/workflows/turbo-ci.yml
@@ -25,12 +25,6 @@ jobs:
         with:
           fetch-depth: 2
 
-      # This is required because Tauri depends on the frontend build directory to
-      # exist, but it is not created until the frontend is built, which may happen
-      # after the backend is built
-      - name: 📁 Create Tauri frontend build directories
-        run: mkdir -p apps/app-frontend/dist
-
       - name: 🧰 Install build dependencies
         run: |
           sudo apt-get update
@@ -71,17 +65,14 @@ jobs:
       - name: 🧰 Install dependencies
         run: pnpm install
 
-      - name: 🔍 Lint
-        run: pnpm lint
-
       - name: ⚙️ Start services
         run: docker compose up -d
 
       - name: ⚙️ Setup Labrinth environment and database
         working-directory: apps/labrinth
         run: |
-          mv .env.local .env
+          cp .env.local .env
           sqlx database setup
 
-      - name: ✔️ Test
-        run: pnpm test
+      - name: 🔍 Lint and test
+        run: pnpm run ci

--- a/apps/app/turbo.jsonc
+++ b/apps/app/turbo.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "../../node_modules/turbo/schema.json",
   "extends": ["//"],
   "tasks": {
     // Running Clippy and tests on a Tauri application requires

--- a/apps/app/turbo.jsonc
+++ b/apps/app/turbo.jsonc
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    // Running Clippy and tests on a Tauri application requires
+    // the frontend to be built at least once first
+    "lint": {
+      "dependsOn": ["@modrinth/app-frontend#build"]
+    },
+    "test": {
+      "dependsOn": ["@modrinth/app-frontend#build"]
+    }
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,11 @@ services:
       POSTGRES_USER: labrinth
       POSTGRES_PASSWORD: labrinth
       POSTGRES_HOST_AUTH_METHOD: trust
+    healthcheck:
+      test: ['CMD', 'pg_isready']
+      interval: 3s
+      timeout: 5s
+      retries: 3
   meilisearch:
     image: getmeili/meilisearch:v1.12.0
     restart: on-failure
@@ -19,6 +24,11 @@ services:
     environment:
       MEILI_MASTER_KEY: modrinth
       MEILI_HTTP_PAYLOAD_SIZE_LIMIT: 107374182400
+    healthcheck:
+      test: ['CMD', 'curl', '--fail', 'http://localhost:7700/health']
+      interval: 3s
+      timeout: 5s
+      retries: 3
   redis:
     image: redis:alpine
     restart: on-failure
@@ -26,6 +36,11 @@ services:
       - '6379:6379'
     volumes:
       - redis-data:/data
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'PING']
+      interval: 3s
+      timeout: 5s
+      retries: 3
   clickhouse:
     image: clickhouse/clickhouse-server
     ports:
@@ -33,6 +48,11 @@ services:
     environment:
       CLICKHOUSE_USER: default
       CLICKHOUSE_PASSWORD: default
+    healthcheck:
+      test: ['CMD', 'clickhouse-client', '--query', 'SELECT 1']
+      interval: 3s
+      timeout: 5s
+      retries: 3
 volumes:
   meilisearch-data:
   db-data:

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "lint": "turbo run lint --continue",
     "test": "turbo run test --continue",
     "fix": "turbo run fix --continue",
+    "ci": "turbo run lint test --continue",
     "intl:extract": "pnpm ui:intl:extract && pnpm web:intl:extract && pnpm app:intl:extract"
   },
   "devDependencies": {

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -45,15 +45,8 @@
       "cache": false,
       "persistent": true,
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
-      "env": [
-        "DISPLAY",
-        "WEBKIT_DISABLE_DMABUF_RENDERER",
-        "CARGO_*",
-        "RUST_*",
-        "RUSTFLAGS",
-        "FORCE_COLOR",
-        "NEXTEST_*"
-      ]
+      "env": ["CARGO_*", "RUST_*", "RUSTFLAGS", "FORCE_COLOR", "NEXTEST_*"],
+      "passThroughEnv": ["DISPLAY", "WEBKIT_DISABLE_DMABUF_RENDERER"]
     },
     "test": {
       "env": [


### PR DESCRIPTION
This PR builds on #3776 by merging the separate lint and test steps in the CI workflow into a single "lint and test" step, which instructs Turborepo to run both tasks across all packages. The main benefit of this approach is that Turborepo can better parallelize the task execution graph (for instance, it can test the Rust app-lib while the app frontend is being linted), which potentially improves runtime (even though GitHub Actions runners have few CPU cores, so the effects won't probably be very significant).

Additionally, I've addressed a source of intermittent CI failures caused by database migrations being attempted before the database was fully initialized by adding health checks to the Compose file, and configuring the CI workflow to wait until those checks pass.