### PR TITLE
refactor: inherit Clippy lint config and Rust edition from workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ members = [
   "packages/daedalus",
 ]
 
+[workspace.package]
+edition = "2024"
+
 [workspace.dependencies]
 actix-cors = "0.7.1"
 actix-files = "0.6.6"
@@ -21,6 +24,7 @@ actix-web-prom = "0.10.0"
 actix-ws = "0.3.0"
 argon2 = { version = "0.5.3", features = ["std"] }
 ariadne = { path = "packages/ariadne" }
+async_zip = "0.0.17"
 async-compression = { version = "0.4.24", default-features = false }
 async-recursion = "1.1.1"
 async-stripe = { version = "0.41.0", default-features = false, features = [
@@ -31,7 +35,6 @@ async-tungstenite = { version = "0.29.1", default-features = false, features = [
   "futures-03-sink",
 ] }
 async-walkdir = "2.1.0"
-async_zip = "0.0.17"
 base64 = "0.22.1"
 bitflags = "2.9.1"
 bytes = "1.10.1"
@@ -89,19 +92,19 @@ quartz_nbt = "0.2.9"
 quick-xml = "0.37.5"
 rand = "=0.8.5"  # Locked on 0.8 until argon2 and p256 update to 0.9
 rand_chacha = "=0.3.1"  # Locked on 0.3 until we can update rand to 0.9
-redis = "=0.31.0" # Locked on 0.31 until deadpool-redis updates to 0.32
+redis = "=0.31.0"  # Locked on 0.31 until deadpool-redis updates to 0.32
 regex = "1.11.1"
 reqwest = { version = "0.12.19", default-features = false }
-rust-s3 = { version = "0.35.1", default-features = false, features = [
-  "fail-on-err",
-  "tags",
-  "tokio-rustls-tls",
-] }
 rust_decimal = { version = "1.37.1", features = [
   "serde-with-float",
   "serde-with-str",
 ] }
 rust_iso3166 = "0.1.14"
+rust-s3 = { version = "0.35.1", default-features = false, features = [
+  "fail-on-err",
+  "tags",
+  "tokio-rustls-tls",
+] }
 rusty-money = "0.4.1"
 sentry = { version = "0.38.1", default-features = false, features = [
   "backtrace",
@@ -113,12 +116,12 @@ sentry = { version = "0.38.1", default-features = false, features = [
 ] }
 sentry-actix = "0.38.1"
 serde = "1.0.219"
-serde-xml-rs = "0.8.1"  # Also an XML (de)serializer, consider dropping yaserde in favor of this
 serde_bytes = "0.11.17"
 serde_cbor = "0.11.2"
 serde_ini = "0.2.0"
 serde_json = "1.0.140"
 serde_with = "3.12.0"
+serde-xml-rs = "0.8.1"  # Also an XML (de)serializer, consider dropping yaserde in favor of this
 sha1 = "0.10.6"
 sha1_smol = { version = "1.0.1", features = ["std"] }
 sha2 = "0.10.9"
@@ -167,6 +170,17 @@ zip = { version = "4.0.0", default-features = false, features = [
   "zstd",
 ] }
 zxcvbn = "3.1.0"
+
+[workspace.lints.clippy]
+# Turn most warnings into errors by default
+all = { level = "deny", priority = -1 }
+clear_with_drain = "deny"
+large_stack_arrays = "deny"
+negative_feature_names = "deny"
+non_std_lazy_statics = "deny"
+read_zero_byte_vec = "deny"
+redundant_feature_names = "deny"
+wildcard_dependencies = "deny"
 
 [patch.crates-io]
 wry = { git = "https://github.com/modrinth/wry", rev = "cafdaa9" }

--- a/apps/app-playground/Cargo.toml
+++ b/apps/app-playground/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "theseus_playground"
 version = "0.0.0"
-edition = "2024"
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -9,3 +9,6 @@ edition = "2024"
 theseus = { workspace = true, features = ["cli"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 enumset.workspace = true
+
+[lints]
+workspace = true

--- a/apps/app/Cargo.toml
+++ b/apps/app/Cargo.toml
@@ -4,8 +4,7 @@ version = "0.9.5"
 description = "The Modrinth App is a desktop application for managing your Minecraft mods"
 license = "GPL-3.0-only"
 repository = "https://github.com/modrinth/code/apps/app/"
-edition = "2024"
-build = "build.rs"
+edition.workspace = true
 
 [build-dependencies]
 tauri-build = { workspace = true, features = ["codegen"] }
@@ -56,3 +55,6 @@ default = ["custom-protocol"]
 # DO NOT remove this
 custom-protocol = ["tauri/custom-protocol"]
 updater = []
+
+[lints]
+workspace = true

--- a/apps/daedalus_client/Cargo.toml
+++ b/apps/daedalus_client/Cargo.toml
@@ -2,7 +2,7 @@
 name = "daedalus_client"
 version = "0.2.2"
 authors = ["Jai A <jai@modrinth.com>"]
-edition = "2024"
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -28,3 +28,6 @@ tracing-error.workspace = true
 
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
+
+[lints]
+workspace = true

--- a/apps/labrinth/Cargo.toml
+++ b/apps/labrinth/Cargo.toml
@@ -2,7 +2,7 @@
 name = "labrinth"
 version = "2.7.0"
 authors = ["geometrically <jai@modrinth.com>"]
-edition = "2024"
+edition.workspace = true
 license = "AGPL-3.0"
 
 # This seems redundant, but it's necessary for Docker to work
@@ -131,3 +131,6 @@ actix-http.workspace = true
 dotenv-build.workspace = true
 chrono.workspace = true
 iana-time-zone.workspace = true
+
+[lints]
+workspace = true

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,2 @@
+allow-dbg-in-tests = true
+msrv = "1.86.0"

--- a/packages/app-lib/Cargo.toml
+++ b/packages/app-lib/Cargo.toml
@@ -2,7 +2,7 @@
 name = "theseus"
 version = "0.9.5"
 authors = ["Jai A <jaiagr+gpg@pm.me>"]
-edition = "2024"
+edition.workspace = true
 
 [dependencies]
 bytes.workspace = true
@@ -75,3 +75,6 @@ winreg.workspace = true
 [features]
 tauri = ["dep:tauri"]
 cli = ["dep:indicatif"]
+
+[lints]
+workspace = true

--- a/packages/ariadne/Cargo.toml
+++ b/packages/ariadne/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ariadne"
 version = "0.1.0"
-edition = "2024"
+edition.workspace = true
 
 [dependencies]
 serde = { workspace = true, features = ["derive"] }
@@ -13,3 +13,6 @@ rand.workspace = true
 either.workspace = true
 chrono = { workspace = true, features = ["serde"] }
 serde_cbor.workspace = true
+
+[lints]
+workspace = true

--- a/packages/daedalus/Cargo.toml
+++ b/packages/daedalus/Cargo.toml
@@ -2,7 +2,7 @@
 name = "daedalus"
 version = "0.2.3"
 authors = ["Jai A <jai@modrinth.com>"]
-edition = "2024"
+edition.workspace = true
 license = "MIT"
 description = "Utilities for querying and parsing Minecraft metadata"
 repository = "https://github.com/modrinth/daedalus/"
@@ -18,3 +18,6 @@ serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 chrono = { workspace = true, features = ["serde"] }
 thiserror.workspace = true
+
+[lints]
+workspace = true


### PR DESCRIPTION
This also ensures developers running `clippy lint` locally get the same lints as during CI, especially when the Rust toolchain version is fixed through a `rust-toolchain.toml` file.

This also has the side effect of restoring the previous behavior of treating lint warnings as errors on CI after #3776 landed, since this configuration achieves the same result, but consistently across environments.