### PR TITLE
fix(labrinth): use a proper `CDN_URL` for local deployments

### DIFF
--- a/apps/frontend/.env.local
+++ b/apps/frontend/.env.local
@@ -2,4 +2,3 @@ BASE_URL=http://127.0.0.1:8000/v2/
 BROWSER_BASE_URL=http://127.0.0.1:8000/v2/
 PYRO_BASE_URL=https://staging-archon.modrinth.com
 PROD_OVERRIDE=true
-

--- a/apps/labrinth/.env.local
+++ b/apps/labrinth/.env.local
@@ -3,7 +3,8 @@ RUST_LOG=info,sqlx::query=warn
 SENTRY_DSN=none
 
 SITE_URL=http://localhost:3000
-CDN_URL=https://staging-cdn.modrinth.com
+# This CDN URL matches the local storage backend set below, which uses MOCK_FILE_PATH
+CDN_URL=file:///tmp/modrinth
 LABRINTH_ADMIN_KEY=feedbeef
 RATE_LIMIT_IGNORE_KEY=feedbeef
 
@@ -25,7 +26,6 @@ PUBLIC_DISCORD_WEBHOOK=
 CLOUDFLARE_INTEGRATION=false
 
 STORAGE_BACKEND=local
-
 MOCK_FILE_PATH=/tmp/modrinth
 
 BACKBLAZE_KEY_ID=none


### PR DESCRIPTION
Labrinth's `.env.local` file is configured to use a local filesystem storage backend for CDN content, storing CDN files (namely, user and project icons, and project versions) under `MOCK_FILE_PATH`. However, the `CDN_URL` in that file currently points to the staging environment CDN, which local deployments can't interact with. As a result, CDN-backed features are nonfunctional in local environments.

This PR addresses the issue by updating `CDN_URL` to use a proper file URL prefix pointing to the `MOCK_FILE_PATH` directory, thereby restoring the proper functioning of those features in local setups.

However, it's important to note that, for security reasons, most web browsers restrict HTTP origins from accessing file URLs. As such, this solution isn't sufficient out of the box to get the frontend to load content from such a CDN backend. Luckily, [Firefox allows easily configuring a per-site `checkloaduri` security policy in `about:config` to enable such access](https://kb.mozillazine.org/Links_to_local_pages_do_not_work).

Alternatively, `CDN_URL` could be set to a local web server serving that directory, which could be spun up via `docker compose`. But this adds unnecessary complexity for development purposes, as allowing the browser to access file URLs directly requires no server setup and is sufficient for effective local development.