### PR TITLE
feat(labrinth): allow protected resource and data packs to pass validation

### DIFF
--- a/apps/labrinth/src/util/routes.rs
+++ b/apps/labrinth/src/util/routes.rs
@@ -32,11 +32,13 @@ pub async fn read_from_field(
 ) -> Result<BytesMut, CreateError> {
     let mut bytes = BytesMut::new();
     while let Some(chunk) = field.next().await {
-        if bytes.len() >= cap {
+        let chunk = chunk?;
+
+        if bytes.len().saturating_add(chunk.len()) > cap {
             return Err(CreateError::InvalidInput(String::from(err_msg)));
-        } else {
-            bytes.extend_from_slice(&chunk?);
         }
+
+        bytes.extend_from_slice(&chunk);
     }
     Ok(bytes)
 }

--- a/apps/labrinth/src/validate/datapack.rs
+++ b/apps/labrinth/src/validate/datapack.rs
@@ -1,6 +1,7 @@
 use crate::validate::{
     SupportedGameVersions, ValidationError, ValidationResult,
 };
+use chrono::DateTime;
 use std::io::Cursor;
 use zip::ZipArchive;
 
@@ -16,7 +17,10 @@ impl super::Validator for DataPackValidator {
     }
 
     fn get_supported_game_versions(&self) -> SupportedGameVersions {
-        SupportedGameVersions::All
+        // Time since release of 17w43a, 2017-10-25, which introduced datapacks
+        SupportedGameVersions::PastDate(
+            DateTime::from_timestamp(1508889600, 0).unwrap(),
+        )
     }
 
     fn validate(

--- a/apps/labrinth/src/validate/mod.rs
+++ b/apps/labrinth/src/validate/mod.rs
@@ -17,10 +17,14 @@ use crate::validate::rift::RiftValidator;
 use crate::validate::shader::{
     CanvasShaderValidator, CoreShaderValidator, ShaderValidator,
 };
+use bytes::Bytes;
 use chrono::{DateTime, Utc};
-use std::io::Cursor;
+use std::io::{self, Cursor};
+use std::mem;
+use std::sync::LazyLock;
 use thiserror::Error;
 use zip::ZipArchive;
+use zip::result::ZipError;
 
 mod datapack;
 mod fabric;
@@ -80,14 +84,43 @@ pub enum SupportedGameVersions {
     Custom(Vec<MinecraftGameVersion>),
 }
 
+pub enum MaybeProtectedZipFile {
+    Unprotected(ZipArchive<Cursor<Bytes>>),
+    MaybeProtected { read_error: ZipError, data: Bytes },
+}
+
 pub trait Validator: Sync {
     fn get_file_extensions(&self) -> &[&str];
     fn get_supported_loaders(&self) -> &[&str];
     fn get_supported_game_versions(&self) -> SupportedGameVersions;
+
     fn validate(
         &self,
         archive: &mut ZipArchive<Cursor<bytes::Bytes>>,
-    ) -> Result<ValidationResult, ValidationError>;
+    ) -> Result<ValidationResult, ValidationError> {
+        // By default, any non-protected ZIP archive is valid
+        let _ = archive;
+        Ok(ValidationResult::Pass)
+    }
+
+    fn validate_maybe_protected_zip(
+        &self,
+        file: &mut MaybeProtectedZipFile,
+    ) -> Result<ValidationResult, ValidationError> {
+        // By default, validate that the ZIP file is not protected, and if so,
+        // delegate to the inner validate method with a known good archive
+        match file {
+            MaybeProtectedZipFile::Unprotected(archive) => {
+                self.validate(archive)
+            }
+            MaybeProtectedZipFile::MaybeProtected { read_error, .. } => {
+                Err(ValidationError::Zip(mem::replace(
+                    read_error,
+                    ZipError::Io(io::Error::other("ZIP archive reading error")),
+                )))
+            }
+        }
+    }
 }
 
 static ALWAYS_ALLOWED_EXT: &[&str] = &["zip", "txt"];
@@ -112,6 +145,29 @@ static VALIDATORS: &[&dyn Validator] = &[
     &RiftValidator,
     &NeoForgeValidator,
 ];
+
+/// A regex that matches a potentially protected ZIP archive containing
+/// a vanilla Minecraft pack, with a requisite `pack.mcmeta` file.
+///
+/// Please note that this regex avoids false negatives at the cost of false
+/// positives being possible, i.e. it may match files that are not actually
+/// Minecraft packs, but it will not miss packs that the game can load.
+static PLAUSIBLE_PACK_REGEX: LazyLock<regex::bytes::Regex> =
+    LazyLock::new(|| {
+        regex::bytes::RegexBuilder::new(concat!(
+            r"\x50\x4b\x01\x02", // CEN signature
+            r".{24}",            // CEN fields
+            r"[\x0B\x0C]\x00",   // CEN file name length
+            r".{16}",            // More CEN fields
+            r"pack\.mcmeta/?",   // CEN file name
+            r".*",               // Rest of CEN entries and records
+            r"\x50\x4b\x05\x06", // EOCD signature
+        ))
+        .unicode(false)
+        .dot_matches_new_line(true)
+        .build()
+        .unwrap()
+    });
 
 /// The return value is whether this file should be marked as primary or not, based on the analysis of the file
 #[allow(clippy::too_many_arguments)]
@@ -144,7 +200,7 @@ pub async fn validate_file(
 }
 
 async fn validate_minecraft_file(
-    data: bytes::Bytes,
+    data: Bytes,
     file_extension: String,
     loaders: Vec<Loader>,
     game_versions: Vec<MinecraftGameVersion>,
@@ -152,13 +208,18 @@ async fn validate_minecraft_file(
     file_type: Option<FileType>,
 ) -> Result<ValidationResult, ValidationError> {
     actix_web::web::block(move || {
-        let reader = Cursor::new(data);
-        let mut zip = ZipArchive::new(reader)?;
+        let mut zip = match ZipArchive::new(Cursor::new(Bytes::clone(&data))) {
+            Ok(zip) => MaybeProtectedZipFile::Unprotected(zip),
+            Err(read_error) => MaybeProtectedZipFile::MaybeProtected {
+                read_error,
+                data,
+            },
+        };
 
         if let Some(file_type) = file_type {
             match file_type {
                 FileType::RequiredResourcePack | FileType::OptionalResourcePack => {
-                    return PackValidator.validate(&mut zip);
+                    return PackValidator.validate_maybe_protected_zip(&mut zip);
                 }
                 FileType::Unknown => {}
             }
@@ -177,7 +238,7 @@ async fn validate_minecraft_file(
                 )
             {
                 if validator.get_file_extensions().contains(&&*file_extension) {
-                    let result = validator.validate(&mut zip)?;
+                    let result = validator.validate_maybe_protected_zip(&mut zip)?;
                     match result {
                         ValidationResult::PassWithPackDataAndFiles { .. } => {
                             saved_result = Some(result);

--- a/apps/labrinth/src/validate/resourcepack.rs
+++ b/apps/labrinth/src/validate/resourcepack.rs
@@ -1,5 +1,6 @@
 use crate::validate::{
-    SupportedGameVersions, ValidationError, ValidationResult,
+    MaybeProtectedZipFile, PLAUSIBLE_PACK_REGEX, SupportedGameVersions,
+    ValidationError, ValidationResult,
 };
 use chrono::DateTime;
 use std::io::Cursor;
@@ -23,17 +24,24 @@ impl super::Validator for PackValidator {
         )
     }
 
-    fn validate(
+    fn validate_maybe_protected_zip(
         &self,
-        archive: &mut ZipArchive<Cursor<bytes::Bytes>>,
+        file: &mut MaybeProtectedZipFile,
     ) -> Result<ValidationResult, ValidationError> {
-        if archive.by_name("pack.mcmeta").is_err() {
-            return Ok(ValidationResult::Warning(
-                "No pack.mcmeta present for pack file. Tip: Make sure pack.mcmeta is in the root directory of your pack!",
-            ));
+        if match file {
+            MaybeProtectedZipFile::Unprotected(archive) => {
+                archive.by_name("pack.mcmeta").is_ok()
+            }
+            MaybeProtectedZipFile::MaybeProtected { data, .. } => {
+                PLAUSIBLE_PACK_REGEX.is_match(data)
+            }
+        } {
+            Ok(ValidationResult::Pass)
+        } else {
+            Ok(ValidationResult::Warning(
+                "No pack.mcmeta present for resourcepack file. Tip: Make sure pack.mcmeta is in the root directory of your pack!",
+            ))
         }
-
-        Ok(ValidationResult::Pass)
     }
 }
 

--- a/apps/labrinth/src/validate/shader.rs
+++ b/apps/labrinth/src/validate/shader.rs
@@ -1,7 +1,8 @@
 use crate::validate::{
-    SupportedGameVersions, ValidationError, ValidationResult,
+    MaybeProtectedZipFile, PLAUSIBLE_PACK_REGEX, SupportedGameVersions,
+    ValidationError, ValidationResult,
 };
-use std::io::Cursor;
+use std::{io::Cursor, sync::LazyLock};
 use zip::ZipArchive;
 
 pub struct ShaderValidator;
@@ -83,25 +84,42 @@ impl super::Validator for CoreShaderValidator {
         SupportedGameVersions::All
     }
 
-    fn validate(
+    fn validate_maybe_protected_zip(
         &self,
-        archive: &mut ZipArchive<Cursor<bytes::Bytes>>,
+        file: &mut MaybeProtectedZipFile,
     ) -> Result<ValidationResult, ValidationError> {
-        if archive.by_name("pack.mcmeta").is_err() {
-            return Ok(ValidationResult::Warning(
-                "No pack.mcmeta present for pack file. Tip: Make sure pack.mcmeta is in the root directory of your pack!",
-            ));
-        };
+        static VANILLA_SHADER_CEN_ENTRY_REGEX: LazyLock<regex::bytes::Regex> =
+            LazyLock::new(|| {
+                regex::bytes::RegexBuilder::new(concat!(
+                    r"\x50\x4b\x01\x02",          // CEN signature
+                    r".{24}",                     // CEN fields
+                    r".{2}",                      // CEN file name length
+                    r".{16}",                     // More CEN fields
+                    r"assets/minecraft/shaders/", // CEN file name
+                ))
+                .unicode(false)
+                .dot_matches_new_line(true)
+                .build()
+                .unwrap()
+            });
 
-        if !archive
-            .file_names()
-            .any(|x| x.starts_with("assets/minecraft/shaders/"))
-        {
-            return Ok(ValidationResult::Warning(
-                "No shaders folder present for vanilla shaders.",
-            ));
+        if match file {
+            MaybeProtectedZipFile::Unprotected(archive) => {
+                archive.by_name("pack.mcmeta").is_ok()
+                    && archive
+                        .file_names()
+                        .any(|x| x.starts_with("assets/minecraft/shaders/"))
+            }
+            MaybeProtectedZipFile::MaybeProtected { data, .. } => {
+                PLAUSIBLE_PACK_REGEX.is_match(data)
+                    && VANILLA_SHADER_CEN_ENTRY_REGEX.is_match(data)
+            }
+        } {
+            Ok(ValidationResult::Pass)
+        } else {
+            Ok(ValidationResult::Warning(
+                "No pack.mcmeta or vanilla shaders folder present for pack file. Tip: Make sure pack.mcmeta is in the root directory of your pack!",
+            ))
         }
-
-        Ok(ValidationResult::Pass)
     }
 }


### PR DESCRIPTION
## Overview

As described in #2844, protected resource and data packs currently fail Labrinth's version file validation step because they cannot be reliably opened as ZIP archives by most ZIP libraries.

This is an intentional consequence of pack protection schemes, where the only invariant that has to be upheld is that game can load them just fine. Like other technical protection measures, these schemes can be used for both legitimate and malicious purposes, and Labrinth is not in a position to judge the intent. So, given Modrinth's largely neutral stance on the types of content allowed on the platform, it seems inappropriate to reject protected packs at this validation stage. (For reference, the linked issue describes a legitimate use case for such protection.)

This PR addresses the issue by introducing a fallback validation method for cases where a pack cannot be opened as a standard ZIP archive. The fallback uses a more lenient approach, based on regular expression lookups for internal ZIP file records that both protected and unprotected packs must contain. As with the current system, all valid packs will match these regexes, and files that the game itself cannot load may be occasionally accepted. Comprehensive validation has always been beyond Labrinth's scope, so this trade-off seems acceptable.

If these changes result in protected packs being too burdensome for our team to moderate, I'd be happy to support their efforts with training and tools on a strictly confidential, need-to-know basis, to help ensure the legitimate interests of all parties involved are respected as fully as possible.

While at it, I've pushed a few more minor fixes that do what's stated on their commit title.

## Testing

I manually tested these changes by creating a project in a local Modrinth development environment and confirming that protected packs can now be successfully attached to versions.