### PR TITLE
Clear owner's project cache after deleting organization

### DIFF
--- a/apps/labrinth/src/routes/v3/organizations.rs
+++ b/apps/labrinth/src/routes/v3/organizations.rs
@@ -649,6 +649,9 @@ pub async fn organization_delete(
             ordering: 0,
         };
         member.insert(&mut transaction).await?;
+
+        database::models::DBUser::clear_project_cache(&[owner_id], &redis)
+            .await?;
     }
     // Safely remove the organization
     let result = database::models::DBOrganization::remove(


### PR DESCRIPTION
Fixes an issue where people would think their projects were deleted along with their organization, when this isn't actually the case.
