### PR TITLE
fix: Insufficient gallery images moderation message indentation

### DIFF
--- a/apps/frontend/src/components/ui/ModerationChecklist.vue
+++ b/apps/frontend/src/components/ui/ModerationChecklist.vue
@@ -654,11 +654,11 @@ For a brief rundown of how this works:
         {
           name: "Insufficient",
           resultingMessage: `## Insufficient Gallery Images
-        We ask that projects like yours show off their content using images in the Gallery, or optionally in the Description, in order to effectively and clearly inform users of its content per section 2.1 of [Modrinth's content rules](https://modrinth.com/legal/rules#general-expectations).
-        Keep in mind that you should:
-        - Set a featured image that best represents your project.
-        - Ensure all your images have titles that accurately label the image, and optionally, details on the contents of the image in the images Description.
-        - Upload any relevant images in your Description to your Gallery tab for best results.`,
+We ask that projects like yours show off their content using images in the Gallery, or optionally in the Description, in order to effectively and clearly inform users of its content per section 2.1 of [Modrinth's content rules](https://modrinth.com/legal/rules#general-expectations).
+Keep in mind that you should:
+- Set a featured image that best represents your project.
+- Ensure all your images have titles that accurately label the image, and optionally, details on the contents of the image in the images Description.
+- Upload any relevant images in your Description to your Gallery tab for best results.`,
         },
         {
           name: "Not relevant",


### PR DESCRIPTION
Fixes indentation in the "Insufficient gallery images" moderation checklist message.