### PR TITLE
Fix direct lint of `packages/app-lib`

### DIFF
--- a/apps/app/Cargo.toml
+++ b/apps/app/Cargo.toml
@@ -16,7 +16,7 @@ serde_json.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_with.workspace = true
 
-tauri = { workspace = true, features = ["devtools", "macos-private-api", "protocol-asset", "unstable"] }
+tauri = { workspace = true, features = ["devtools", "macos-private-api", "protocol-asset"] }
 tauri-plugin-window-state.workspace = true
 tauri-plugin-deep-link.workspace = true
 tauri-plugin-os.workspace = true

--- a/packages/app-lib/Cargo.toml
+++ b/packages/app-lib/Cargo.toml
@@ -39,7 +39,7 @@ tracing-error.workspace = true
 
 paste.workspace = true
 
-tauri = { workspace = true, optional = true }
+tauri = { workspace = true, optional = true, features = ["unstable"] }
 indicatif = { workspace = true, optional = true }
 
 async-tungstenite = { workspace = true, features = ["tokio-runtime", "tokio-rustls-webpki-roots"] }


### PR DESCRIPTION
Currently, when attempting to compile or lint `packages/app-lib` directly, it fails due to requiring a `tauri` feature that is only enabled in `apps/app`. This PR adds this feature directly to `packages/app-lib`. It also removes it from `apps/app`, where it was unused.