### PR TITLE
Fix the problem of can't use sign-up page

### DIFF
--- a/apps/frontend/src/pages/auth/sign-up.vue
+++ b/apps/frontend/src/pages/auth/sign-up.vue
@@ -111,7 +111,7 @@
       <button
         class="btn btn-primary continue-btn centered-btn"
         :disabled="!token"
-        @click="createAccount"
+        @click="createAccount()"
       >
         {{ formatMessage(messages.createAccountButton) }} <RightArrowIcon />
       </button>


### PR DESCRIPTION
fix `src/pages/auth/sign-up.vue` in the frontend.

In the origin one, the property `@click`, is set to `createAccount`.
In this case, the function can't be called properly, so I fixed it to `createAccont()`.