### PR TITLE
Update config.toml to fix the panic on windows

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,6 @@
 # Windows has stack overflows when calling from Tauri, so we increase the default stack size used by the compiler
 [target.'cfg(windows)']
-rustflags = ["-C", "link-args=/STACK:16777220"]
+rustflags = ["-C", "link-args=/STACK:16777220", "--cfg", "tokio_unstable"]
 
 [build]
 rustflags = ["--cfg", "tokio_unstable"]


### PR DESCRIPTION
```
[target.'cfg(windows)']
rustflags = ["-C", "link-args=/STACK:16777220"]
```
This will overwrite the flags ["--cfg", "tokio_unstable"] and cause panic.