### PR TITLE
Fix the wrong version of meilisearch in the docker-compose.yml

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,6 @@
 # Windows has stack overflows when calling from Tauri, so we increase the default stack size used by the compiler
 [target.'cfg(windows)']
-rustflags = ["-C", "link-args=/STACK:16777220"]
+rustflags = ["-C", "link-args=/STACK:16777220", "--cfg", "tokio_unstable"]
 
 [build]
 rustflags = ["--cfg", "tokio_unstable"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       timeout: 5s
       retries: 3
   meilisearch:
-    image: getmeili/meilisearch:v1.12.0
+    image: getmeili/meilisearch:v1.5.0
     restart: on-failure
     ports:
       - '7700:7700'


### PR DESCRIPTION
The version of meilisearch is wrong, it needs the version v1.5.0.