### PR TITLE
Sign Windows Theseus binaries with DigiCert KeyLocker's cloud HSM

### DIFF
--- a/.github/workflows/theseus-release.yml
+++ b/.github/workflows/theseus-release.yml
@@ -136,7 +136,7 @@ jobs:
       - name: build app (Windows)
         run: |
           [System.Convert]::FromBase64String($env:DIGICERT_ONE_SIGNER_CLIENT_CERTIFICATE_BASE64) | Set-Content -Path signer-client-cert.p12 -AsByteStream
-          $env:DIGICERT_ONE_SIGNER_CREDENTIALS = "$env:DIGICERT_ONE_SIGNER_API_KEY|signer-client-cert.p12|$env:DIGICERT_ONE_SIGNER_CLIENT_CERTIFICATE_PASSWORD"
+          $env:DIGICERT_ONE_SIGNER_CREDENTIALS = "$env:DIGICERT_ONE_SIGNER_API_KEY|$PWD\signer-client-cert.p12|$env:DIGICERT_ONE_SIGNER_CLIENT_CERTIFICATE_PASSWORD"
           pnpm --filter=@modrinth/app run tauri build --config "tauri-release.conf.json" --verbose
           Remove-Item -Path signer-client-cert.p12
         if: startsWith(matrix.platform, 'windows')

--- a/.github/workflows/theseus-release.yml
+++ b/.github/workflows/theseus-release.yml
@@ -105,7 +105,7 @@ jobs:
 
       - name: Install code signing client (Windows only)
         if: startsWith(matrix.platform, 'windows')
-        run: choco install jsign
+        run: choco install jsign --ignore-dependencies
 
       - name: Install frontend dependencies
         run: pnpm install

--- a/.github/workflows/theseus-release.yml
+++ b/.github/workflows/theseus-release.yml
@@ -111,7 +111,7 @@ jobs:
         run: pnpm install
 
       - name: build app (macos)
-        run: pnpm --filter=@modrinth/app run tauri build --target universal-apple-darwin --config "tauri-release.conf.json"
+        run: pnpm --filter=@modrinth/app run tauri build --target universal-apple-darwin --config tauri-release.conf.json
         if: startsWith(matrix.platform, 'macos')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -126,7 +126,7 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
 
       - name: build app (Linux)
-        run: pnpm --filter=@modrinth/app run tauri build --config "tauri-release.conf.json"
+        run: pnpm --filter=@modrinth/app run tauri build --config tauri-release.conf.json
         if: startsWith(matrix.platform, 'ubuntu')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -135,9 +135,9 @@ jobs:
 
       - name: build app (Windows)
         run: |
-          [System.Convert]::FromBase64String($env:DIGICERT_ONE_SIGNER_CLIENT_CERTIFICATE_BASE64.Trim()) | Set-Content -Path signer-client-cert.p12 -AsByteStream
-          $env:DIGICERT_ONE_SIGNER_CREDENTIALS = "$env:DIGICERT_ONE_SIGNER_API_KEY.Trim()|$PWD\signer-client-cert.p12|$env:DIGICERT_ONE_SIGNER_CLIENT_CERTIFICATE_PASSWORD.Trim()"
-          pnpm --filter=@modrinth/app run tauri build --config "tauri-release.conf.json" --verbose
+          [System.Convert]::FromBase64String("$env:DIGICERT_ONE_SIGNER_CLIENT_CERTIFICATE_BASE64") | Set-Content -Path signer-client-cert.p12 -AsByteStream
+          $env:DIGICERT_ONE_SIGNER_CREDENTIALS = "$env:DIGICERT_ONE_SIGNER_API_KEY|$PWD\signer-client-cert.p12|$env:DIGICERT_ONE_SIGNER_CLIENT_CERTIFICATE_PASSWORD"
+          pnpm --filter=@modrinth/app run tauri build --config tauri-release.conf.json --verbose
           Remove-Item -Path signer-client-cert.p12
         if: startsWith(matrix.platform, 'windows')
         env:

--- a/.github/workflows/theseus-release.yml
+++ b/.github/workflows/theseus-release.yml
@@ -103,6 +103,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev build-essential curl wget file libxdo-dev libssl-dev pkg-config libayatana-appindicator3-dev librsvg2-dev
 
+      - name: Install code signing client (Windows only)
+        if: startsWith(matrix.platform, 'windows')
+        run: choco install jsign
+
       - name: Install frontend dependencies
         run: pnpm install
 
@@ -121,14 +125,28 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
 
-      - name: build app
+      - name: build app (Linux)
         run: pnpm --filter=@modrinth/app run tauri build --config "tauri-release.conf.json"
-        id: build_os
-        if: "!startsWith(matrix.platform, 'macos')"
+        if: startsWith(matrix.platform, 'ubuntu')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
+
+      - name: build app (Windows)
+        run: |
+          [System.Convert]::FromBase64String($env:DIGICERT_ONE_SIGNER_CLIENT_CERTIFICATE_BASE64) | Set-Content -Path signer-client-cert.p12 -AsByteStream
+          $env:DIGICERT_ONE_SIGNER_CREDENTIALS = "$env:DIGICERT_ONE_SIGNER_API_KEY|signer-client-cert.p12|$env:DIGICERT_ONE_SIGNER_CLIENT_CERTIFICATE_PASSWORD"
+          pnpm --filter=@modrinth/app run tauri build --config "tauri-release.conf.json" --verbose
+          Remove-Item -Path signer-client-cert.p12
+        if: startsWith(matrix.platform, 'windows')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
+          DIGICERT_ONE_SIGNER_API_KEY: ${{ secrets.DIGICERT_ONE_SIGNER_API_KEY }}
+          DIGICERT_ONE_SIGNER_CLIENT_CERTIFICATE_BASE64: ${{ secrets.DIGICERT_ONE_SIGNER_CLIENT_CERTIFICATE_BASE64 }}
+          DIGICERT_ONE_SIGNER_CLIENT_CERTIFICATE_PASSWORD: ${{ secrets.DIGICERT_ONE_SIGNER_CLIENT_CERTIFICATE_PASSWORD }}
 
       - name: upload ${{ matrix.platform }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/theseus-release.yml
+++ b/.github/workflows/theseus-release.yml
@@ -135,8 +135,8 @@ jobs:
 
       - name: build app (Windows)
         run: |
-          [System.Convert]::FromBase64String($env:DIGICERT_ONE_SIGNER_CLIENT_CERTIFICATE_BASE64) | Set-Content -Path signer-client-cert.p12 -AsByteStream
-          $env:DIGICERT_ONE_SIGNER_CREDENTIALS = "$env:DIGICERT_ONE_SIGNER_API_KEY|$PWD\signer-client-cert.p12|$env:DIGICERT_ONE_SIGNER_CLIENT_CERTIFICATE_PASSWORD"
+          [System.Convert]::FromBase64String($env:DIGICERT_ONE_SIGNER_CLIENT_CERTIFICATE_BASE64.Trim()) | Set-Content -Path signer-client-cert.p12 -AsByteStream
+          $env:DIGICERT_ONE_SIGNER_CREDENTIALS = "$env:DIGICERT_ONE_SIGNER_API_KEY.Trim()|$PWD\signer-client-cert.p12|$env:DIGICERT_ONE_SIGNER_CLIENT_CERTIFICATE_PASSWORD.Trim()"
           pnpm --filter=@modrinth/app run tauri build --config "tauri-release.conf.json" --verbose
           Remove-Item -Path signer-client-cert.p12
         if: startsWith(matrix.platform, 'windows')

--- a/apps/app/tauri.conf.json
+++ b/apps/app/tauri.conf.json
@@ -14,9 +14,22 @@
     "externalBin": [],
     "icon": ["icons/128x128.png", "icons/128x128@2x.png", "icons/icon.icns", "icons/icon.ico"],
     "windows": {
-      "certificateThumbprint": null,
-      "digestAlgorithm": "sha256",
-      "timestampUrl": "http://timestamp.digicert.com",
+      "signCommand": {
+        "cmd": "jsign",
+        "args": [
+          "sign",
+          "--verbose",
+          "--storetype",
+          "DIGICERTONE",
+          "--keystore",
+          "https://clientauth.one.digicert.com",
+          "--storepass",
+          "env:DIGICERT_ONE_SIGNER_CREDENTIALS",
+          "--tsaurl",
+          "https://timestamp.sectigo.com,http://timestamp.digicert.com",
+          "%1"
+        ]
+      },
       "nsis": {
         "installMode": "perMachine",
         "installerHooks": "./nsis/hooks.nsi"


### PR DESCRIPTION
Our code signing certificate recently expired, which gave us an opportunity to streamline the app signing process for better scalability and maintainability while we obtained a new EV code signing certificate.

@Geometrically has arranged for a new certificate to be made available via DigiCert KeyLocker. To us, this service provides a REST API for securely signing Modrinth App binaries using a trusted private key that remains safely stored in a hardware security module (HSM) within DigiCert's cloud infrastructure. To begin using this new certificate and unblock new app releases, I've arranged for the necessary secrets to be configured in the repository and updated our Tauri configuration to use [Jsign](https://ebourg.github.io/jsign/), a versatile, lightweight, and portable Authenticode signing tool I've had success with in the past, for integration with DigiCert KeyLocker.

At this point, [the GitHub workflow appears to be nearly functional](https://chatgpt.com/c/685c121a-8cf0-8004-a6df-64682909eaa6). The only remaining issue is a failure at the signing step which seems to be related to a permissions problem with the signer user for the specified keypair, and I'm fairly confident @Geometrically will be able to fix.