### PR TITLE
tweak(labrinth): return proper error message for invalid password change flows

### DIFF
--- a/apps/labrinth/src/routes/internal/flows.rs
+++ b/apps/labrinth/src/routes/internal/flows.rs
@@ -2031,7 +2031,9 @@ pub async fn change_password(
 
             Some(user)
         } else {
-            None
+            return Err(ApiError::CustomAuthentication(
+                "The password change flow code is invalid or has expired. Did you copy it promptly and correctly?".to_string(),
+            ));
         }
     } else {
         None


### PR DESCRIPTION
The PR title is pretty self-explanatory. @triphora asked me why otherwise a pretty puzzling `Authentication method was not valid` error was shown when an user attempted to reset their password.