### PR TITLE
Remove new-projects channel emojis

### DIFF
--- a/apps/labrinth/src/util/webhook.rs
+++ b/apps/labrinth/src/util/webhook.rs
@@ -45,7 +45,6 @@ async fn get_webhook_metadata(
     project_id: ProjectId,
     pool: &PgPool,
     redis: &RedisPool,
-    emoji: bool,
 ) -> Result<Option<WebhookMetadata>, ApiError> {
     let project = crate::database::models::project_item::DBProject::get_id(
         project_id.into(),
@@ -159,56 +158,13 @@ async fn get_webhook_metadata(
             categories_formatted: project
                 .categories
                 .into_iter()
-                .map(|mut x| format!("{}{x}", x.remove(0).to_uppercase()))
-                .collect::<Vec<_>>(),
+                .map(format_category)
+                .collect(),
             loaders_formatted: project
                 .inner
                 .loaders
                 .into_iter()
-                .map(|loader| {
-                    let mut x = if &*loader == "datapack" {
-                        "Data Pack".to_string()
-                    } else if &*loader == "mrpack" {
-                        "Modpack".to_string()
-                    } else {
-                        loader.clone()
-                    };
-
-                    if emoji {
-                        let emoji_id: i64 = match &*loader {
-                            "bukkit" => 1049793345481883689,
-                            "bungeecord" => 1049793347067314220,
-                            "canvas" => 1107352170656968795,
-                            "datapack" => 1057895494652788866,
-                            "fabric" => 1049793348719890532,
-                            "folia" => 1107348745571537018,
-                            "forge" => 1049793350498275358,
-                            "iris" => 1107352171743281173,
-                            "liteloader" => 1049793351630733333,
-                            "minecraft" => 1049793352964526100,
-                            "modloader" => 1049793353962762382,
-                            "neoforge" => 1140437823783190679,
-                            "optifine" => 1107352174415052901,
-                            "paper" => 1049793355598540810,
-                            "purpur" => 1140436034505674762,
-                            "quilt" => 1049793857681887342,
-                            "rift" => 1049793359373414502,
-                            "spigot" => 1049793413886779413,
-                            "sponge" => 1049793416969605231,
-                            "vanilla" => 1107350794178678855,
-                            "velocity" => 1049793419108700170,
-                            "waterfall" => 1049793420937412638,
-                            _ => 1049805243866681424,
-                        };
-
-                        format!(
-                            "<:{loader}:{emoji_id}> {}{x}",
-                            x.remove(0).to_uppercase()
-                        )
-                    } else {
-                        format!("{}{x}", x.remove(0).to_uppercase())
-                    }
-                })
+                .map(format_category)
                 .collect(),
             versions_formatted: formatted_game_versions,
             gallery_image: project
@@ -229,7 +185,7 @@ pub async fn send_slack_webhook(
     webhook_url: String,
     message: Option<String>,
 ) -> Result<(), ApiError> {
-    let metadata = get_webhook_metadata(project_id, pool, redis, false).await?;
+    let metadata = get_webhook_metadata(project_id, pool, redis).await?;
 
     if let Some(metadata) = metadata {
         let mut blocks = vec![];
@@ -400,7 +356,7 @@ pub async fn send_discord_webhook(
     webhook_url: String,
     message: Option<String>,
 ) -> Result<(), ApiError> {
-    let metadata = get_webhook_metadata(project_id, pool, redis, true).await?;
+    let metadata = get_webhook_metadata(project_id, pool, redis).await?;
 
     if let Some(project) = metadata {
         let mut fields = vec![];
@@ -618,4 +574,33 @@ fn get_gv_range(
     }
 
     output
+}
+
+fn format_category(mut x: String) -> String {
+    match &*x {
+        "modloader" => "Risugami's ModLoader".to_string(),
+        "bungeecord" => "BungeeCord".to_string(),
+        "liteloader" => "LiteLoader".to_string(),
+        "neoforge" => "NeoForge".to_string(),
+        "game-mechanics" => "Game Mechanics".to_string(),
+        "worldgen" => "World Generation".to_string(),
+        "core-shaders" => "Core Shaders".to_string(),
+        "gui" => "GUI".to_string(),
+        "8x-" => "8x or lower".to_string(),
+        "512x+" => "512x or higher".to_string(),
+        "kitchen-sink" => "Kitchen Sink".to_string(),
+        "path-tracing" => "Path Tracing".to_string(),
+        "pbr" => "PBR".to_string(),
+        "datapack" => "Data Pack".to_string(),
+        "colored-lighting" => "Colored Lighting".to_string(),
+        "optifine" => "OptiFine".to_string(),
+        "bta-babric" => "BTA (Babric)".to_string(),
+        "legacy-fabric" => "Legacy Fabric".to_string(),
+        "java-agent" => "Java Agent".to_string(),
+        "nilloader" => "NilLoader".to_string(),
+        "mrpack" => "Modpack".to_string(),
+        "minecraft" => "Resource Pack".to_string(),
+        "vanilla" => "Vanilla Shader".to_string(),
+        _ => format!("{}{x}", x.remove(0).to_uppercase()),
+    }
 }


### PR DESCRIPTION
With new loaders, this functionality has become unwieldy. We don't have enough emoji slots in the server for the number of emojis we'd need for the loaders. It is easiest to simply format them in the same way knossos does.

Note: I forgor how the borrow checker works, this compiles but I'm sure it's gore to anyone who actually knows the difference between a string slice and a String, I come from Javaland though so pls forgive
