### PR TITLE
Update Java to 11 with `--release 8`

### DIFF
--- a/packages/app-lib/java/build.gradle.kts
+++ b/packages/app-lib/java/build.gradle.kts
@@ -14,11 +14,12 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(8)
+        languageVersion = JavaLanguageVersion.of(11)
     }
 }
 
 tasks.withType<JavaCompile>().configureEach {
+    options.release = 8
     options.compilerArgs.addAll(listOf("-Xlint:all", "-Werror"))
 }
 


### PR DESCRIPTION
Spotless requires at least Java 11 to run. This updates Gradle to use Java 11, using `--release 8` to retain Java 8 compatibility.