### PR TITLE
Set `JAVA_HOME` to `JAVA_HOME_11_X64` on Windows for theseus-release

### DIFF
--- a/.github/workflows/theseus-release.yml
+++ b/.github/workflows/theseus-release.yml
@@ -147,6 +147,7 @@ jobs:
         run: |
           [System.Convert]::FromBase64String("$env:DIGICERT_ONE_SIGNER_CLIENT_CERTIFICATE_BASE64") | Set-Content -Path signer-client-cert.p12 -AsByteStream
           $env:DIGICERT_ONE_SIGNER_CREDENTIALS = "$env:DIGICERT_ONE_SIGNER_API_KEY|$PWD\signer-client-cert.p12|$env:DIGICERT_ONE_SIGNER_CLIENT_CERTIFICATE_PASSWORD"
+          $env:JAVA_HOME = $env:JAVA_HOME_11_X64
           pnpm --filter=@modrinth/app run tauri build --config tauri-release.conf.json --verbose --bundles 'nsis,updater'
           Remove-Item -Path signer-client-cert.p12
         if: startsWith(matrix.platform, 'windows')


### PR DESCRIPTION
Windows Actions runners default to Java 8, which is incompatible with Spotless. This PR attempts to fix this by setting `JAVA_HOME` to `JAVA_HOME_11_X64`, which contains the path to Java 11.