### PR TITLE
Tweak Modrinth+ page according to latest changes

### DIFF
--- a/apps/frontend/src/pages/plus.vue
+++ b/apps/frontend/src/pages/plus.vue
@@ -73,7 +73,7 @@
         <SparklesIcon class="h-8 w-8 text-purple" />
         <span class="text-lg font-bold">Remove all ads</span>
         <span class="leading-5 text-secondary">
-          Never see an advertisement again on the Modrinth app or the website.
+          Never see an advertisement again on the Modrinth app.
         </span>
       </div>
       <div class="flex flex-col gap-4 rounded-xl bg-bg-raised p-4">

--- a/apps/frontend/src/pages/plus.vue
+++ b/apps/frontend/src/pages/plus.vue
@@ -82,7 +82,7 @@
         <span class="leading-5 text-secondary">Get an exclusive badge on your user page.</span>
       </div>
     </div>
-    <span class="mt-4 text-secondary">...and much more coming soon!</span>
+    <span class="mt-4 text-secondary">...and much more coming soon™!</span>
   </div>
 </template>
 <script setup>


### PR DESCRIPTION
PR https://github.com/modrinth/code/pull/3858 disabled ads for all logged-in users on the website, turning what before was a exclusive Modrinth+ perk into a standard platform behavior. It should be noted, however, that in-app ads still require a Modrinth+ subscription to be disabled.

This PR updates the wording of the Modrinth+ product page accordingly. While at it, I've also tweaked the "and much more coming soon" sentence to be more realistic and [playful](https://wowpedia.fandom.com/wiki/Soon) :wink: (But if this is deemed too playful, please feel free to revert the commit.)