### PR TITLE
fix: tooltip text color

### DIFF
--- a/packages/assets/styles/classes.scss
+++ b/packages/assets/styles/classes.scss
@@ -884,7 +884,7 @@ a,
 .v-popper--theme-tooltip {
   .v-popper__inner {
     background: var(--color-tooltip-bg) !important;
-    color: initial !important;
+    color: var(--color-tooltip-text) !important;
     padding: 0.5rem 0.5rem !important;
     border-radius: var(--radius-sm) !important;
     filter: drop-shadow(5px 5px 0.8rem rgba(0, 0, 0, 0.35));


### PR DESCRIPTION
Fixed the issue where the text in tooltip was difficult to see after commit c793b68a
![Light mode](https://github.com/user-attachments/assets/067a26c8-7a76-487b-af0c-8107c9e3947e)
![Dark mode](https://github.com/user-attachments/assets/f84a6975-e4d3-46dd-89ef-c5380d76f6fa)
