### PR TITLE
fix(app-frontend): clamp current page in searches to the max possible

### DIFF
--- a/apps/app-frontend/src/pages/Browse.vue
+++ b/apps/app-frontend/src/pages/Browse.vue
@@ -220,6 +220,7 @@ async function refreshSearch() {
     }
   }
   results.value = rawResults.result
+  currentPage.value = Math.min(pageCount.value, currentPage.value)
 
   const persistentParams: LocationQuery = {}
 


### PR DESCRIPTION
When searching for content in the Modrinth App, users may update the search query at any time by modifying the search text or other filters. Any of these actions can reduce the number of result pages returned, which may entail the current page number exceeding the available page range, causing the UI to display an invalid, empty page.

This PR addresses the issue by clamping the current page to be at most equal to the total page count whenever search results are refreshed. This ensures users always see the closest valid page to the one they were previously viewing.

I think it's worth pointing out that currently the app only uses the related `useSearch` function in the `Browse.vue` view. As such, I considered deeper architectural changes to the `currentPage` property out of scope: broader changes could even be counterproductive, since I at least am not in a good position to predict how future code might rely on or update `currentPage`, potentially making such refactors unsuitable or wasteful.