### PR TITLE
fix: format `PromotionWrapper.vue` according to Prettier style

### DIFF
--- a/apps/app-frontend/src/components/ui/PromotionWrapper.vue
+++ b/apps/app-frontend/src/components/ui/PromotionWrapper.vue
@@ -51,7 +51,8 @@ function updateAdPosition() {
   </div>
 </template>
 <style lang="scss" scoped>
-.light, .light-mode {
+.light,
+.light-mode {
   .dark-image {
     display: none;
   }


### PR DESCRIPTION
This fixes the lint and test CI workflow failure first seen at https://github.com/modrinth/code/actions/runs/16041837752/job/45264780693, which is blocking PRs such as #3884 from getting merged.