### PR TITLE
fix(app): use the same CSP during `tauri dev` as `tauri build`

### DIFF
--- a/apps/app-frontend/tsconfig.node.json
+++ b/apps/app-frontend/tsconfig.node.json
@@ -10,6 +10,7 @@
     "isolatedModules": true,
     "moduleDetection": "force",
     "noEmit": true,
+    "resolveJsonModule": true,
 
     "strict": true
   },

--- a/apps/app-frontend/vite.config.ts
+++ b/apps/app-frontend/vite.config.ts
@@ -4,6 +4,8 @@ import svgLoader from 'vite-svg-loader'
 
 import vue from '@vitejs/plugin-vue'
 
+import tauriConf from '../app/tauri.conf.json'
+
 const projectRootDir = resolve(__dirname)
 
 // https://vitejs.dev/config/
@@ -41,17 +43,21 @@ export default defineConfig({
   server: {
     port: 1420,
     strictPort: true,
+    headers: {
+      // The additional websocket connect-src is required for Vite dev tools such as HMR to work
+      'content-security-policy': tauriConf.app.security.csp.replace('connect-src ', 'connect-src ws://*:1420 '),
+    },
   },
   // to make use of `TAURI_ENV_DEBUG` and other env variables
   // https://v2.tauri.app/reference/environment-variables/#tauri-cli-hook-commands
   envPrefix: ['VITE_', 'TAURI_'],
   build: {
     // Tauri supports es2021
-    target: process.env.TAURI_PLATFORM == 'windows' ? 'chrome105' : 'safari13', // eslint-disable-line turbo/no-undeclared-env-vars
+    target: process.env.TAURI_ENV_PLATFORM == 'windows' ? 'chrome105' : 'safari13', // eslint-disable-line turbo/no-undeclared-env-vars
     // don't minify for debug builds
-    minify: !process.env.TAURI_DEBUG ? 'esbuild' : false, // eslint-disable-line turbo/no-undeclared-env-vars
+    minify: !process.env.TAURI_ENV_DEBUG ? 'esbuild' : false, // eslint-disable-line turbo/no-undeclared-env-vars
     // produce sourcemaps for debug builds
-    sourcemap: !!process.env.TAURI_DEBUG, // eslint-disable-line turbo/no-undeclared-env-vars
+    sourcemap: !!process.env.TAURI_ENV_DEBUG, // eslint-disable-line turbo/no-undeclared-env-vars
     commonjsOptions: {
       esmExternals: true,
     },

--- a/apps/app/tauri.conf.json
+++ b/apps/app/tauri.conf.json
@@ -84,16 +84,7 @@
         "enable": true
       },
       "capabilities": ["ads", "core", "plugins"],
-      "csp": {
-        "default-src": "'self' customprotocol: asset:",
-        "connect-src": "ipc: http://ipc.localhost https://modrinth.com https://*.modrinth.com https://*.posthog.com https://*.sentry.io https://api.mclo.gs",
-        "font-src": ["https://cdn-raw.modrinth.com/fonts/"],
-        "img-src": "https: 'unsafe-inline' 'self' asset: http://asset.localhost blob: data:",
-        "style-src": "'unsafe-inline' 'self'",
-        "script-src": "https://*.posthog.com 'self'",
-        "frame-src": "https://www.youtube.com https://www.youtube-nocookie.com https://discord.com 'self'",
-        "media-src": "https://*.githubusercontent.com"
-      }
+      "csp": "font-src https://cdn-raw.modrinth.com/fonts/; media-src https://*.githubusercontent.com; style-src 'unsafe-inline' 'self'; connect-src ipc: http://ipc.localhost https://modrinth.com https://*.modrinth.com https://*.posthog.com https://*.sentry.io https://api.mclo.gs; frame-src https://www.youtube.com https://www.youtube-nocookie.com https://discord.com 'self'; default-src 'self' customprotocol: asset:; script-src https://*.posthog.com 'self'; img-src https: 'unsafe-inline' 'self' asset: http://asset.localhost blob: data:"
     }
   }
 }


### PR DESCRIPTION
When running the Modrinth App using `tauri dev`, the standard Vite development server is responsible for serving application assets and enabling development-friendly features like hot module reloading (HMR) over a standard TCP HTTP socket. However, in this setup, Tauri's `csp` setting is not honored because the application files are not delivered through Tauri's asset protocol, and Tauri does not intercept these files or their HTTP responses to inject the expected `Content-Security-Policy` (CSP) header, unlike when using such asset protocol.

As a result, only production builds (which must use Tauri's asset protocol due to the absence of a web server) respect the `csp` setting. This discrepancy has caused and continues to cause developers to overlook important loading issues, such as those reported in [#1297](https://github.com/modrinth/code/issues/1297), [#648](https://github.com/modrinth/code/pull/648), and [#223](https://github.com/modrinth/code/issues/223), during the development of both existing and new features.

This PR significantly improves the consistency of CSP enforcement by adjusting the Vite configuration to include a `Content-Security-Policy` header with a value sourced from the Tauri configuration. This ensures CSP mismatches are caught early and consistently during development, entirely eliminating classes of issues before wider testing or deployment. Additionally, I've cleaned up outdated references to environment variables that were removed in Tauri v2.