### PR TITLE
Split wrapper string into separate command and arguments

### DIFF
--- a/packages/app-lib/src/launcher/mod.rs
+++ b/packages/app-lib/src/launcher/mod.rs
@@ -563,7 +563,18 @@ pub async fn launch_minecraft(
     let args = version_info.arguments.clone().unwrap_or_default();
     let mut command = match wrapper {
         Some(hook) => {
-            let mut command = Command::new(hook);
+            // Treat first as command and all after as args
+            let mut hook = hook.split_whitespace();
+            let cmd = hook.next().ok_or_else(|| {
+                crate::ErrorKind::LauncherError(
+                    "Empty wrapper string".to_string(),
+                )
+            })?;
+
+            let mut command = Command::new(cmd);
+            hook.for_each(|arg| {
+                command.arg(arg);
+            });
             command.arg(&java_version.path);
             command
         }


### PR DESCRIPTION
Fixes #1035 by splitting the wrapper string by whitespace using `split_whitespace` and only passing the first element as the main command with all subsequent elements passed as arguments. This allows usage of multiple wrappers and passing arguments to wrapper scripts.

Example:
`gamemoderun gamescope -f -w 2560 -h 1440 -W 3840 -H 2160 --` (changes fullscreen resolution)
In this example, `gamemoderun` is the base command and everything else is passed as an argument. `gamemoderun` runs `gamescope` which in turn runs the game.

I don't think Modrinth needs to use a special identifier for the game executable like how Steam uses %command% since that is primarily used for passing arguments to the game which Modrinth already provides in the Java arguments option.