### PR TITLE
dist(docker): add `curl` package to Labrinth image, some other minor tweaks

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.gitignore

--- a/.github/workflows/labrinth-docker.yml
+++ b/.github/workflows/labrinth-docker.yml
@@ -18,9 +18,6 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./apps/labrinth
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -38,8 +35,6 @@ jobs:
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v2
-        env:
-          SQLX_OFFLINE: true
         with:
           file: ./apps/labrinth/Dockerfile
           push: ${{ github.event_name != 'pull_request' }}

--- a/apps/daedalus_client/Dockerfile
+++ b/apps/daedalus_client/Dockerfile
@@ -1,5 +1,4 @@
 FROM rust:1.88.0 AS build
-ENV PKG_CONFIG_ALLOW_CROSS=1
 
 WORKDIR /usr/src/daedalus
 COPY . .
@@ -10,10 +9,7 @@ FROM debian:bookworm-slim
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends ca-certificates openssl \
-  && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
-
-RUN update-ca-certificates
 
 COPY --from=build /usr/src/daedalus/target/release/daedalus_client /daedalus/daedalus_client
 WORKDIR /daedalus_client

--- a/apps/labrinth/Dockerfile
+++ b/apps/labrinth/Dockerfile
@@ -11,7 +11,7 @@ LABEL org.opencontainers.image.description="Modrinth API"
 LABEL org.opencontainers.image.licenses=AGPL-3.0
 
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends ca-certificates openssl dumb-init \
+  && apt-get install -y --no-install-recommends ca-certificates openssl dumb-init curl \
   && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /usr/src/labrinth/target/release/labrinth /labrinth/labrinth

--- a/apps/labrinth/Dockerfile
+++ b/apps/labrinth/Dockerfile
@@ -1,11 +1,8 @@
 FROM rust:1.88.0 AS build
-ENV PKG_CONFIG_ALLOW_CROSS=1
 
 WORKDIR /usr/src/labrinth
 COPY . .
-COPY apps/labrinth/.sqlx/ .sqlx/
-RUN cargo build --release --package labrinth
-
+RUN SQLX_OFFLINE=true cargo build --release --package labrinth
 
 FROM debian:bookworm-slim
 
@@ -15,10 +12,7 @@ LABEL org.opencontainers.image.licenses=AGPL-3.0
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends ca-certificates openssl dumb-init \
-  && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
-
-RUN update-ca-certificates
 
 COPY --from=build /usr/src/labrinth/target/release/labrinth /labrinth/labrinth
 COPY --from=build /usr/src/labrinth/apps/labrinth/migrations/* /labrinth/migrations/


### PR DESCRIPTION
The changes proposed in this PR are pretty self-explanatory given its title and commits.

While at it, I've removed invocations of `apt-get clean` and `update-ca-certificates` because the APT package manager already has hooks in place to execute those during the installation of the required packages. Similarly, `PKG_CONFIG_ALLOW_CROSS` is not necessary because these images are not designed to do cross-compilation.