### PR TITLE
Fix launching older Forge versions

### DIFF
--- a/packages/app-lib/java/src/main/java/com/modrinth/theseus/MinecraftLaunch.java
+++ b/packages/app-lib/java/src/main/java/com/modrinth/theseus/MinecraftLaunch.java
@@ -2,6 +2,7 @@ package com.modrinth.theseus;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
@@ -76,14 +77,14 @@ public final class MinecraftLaunch {
 
             Object thisObject = null;
             if (!Modifier.isStatic(mainMethod.getModifiers())) {
-                thisObject = mainClass.getDeclaredConstructor().newInstance();
+                thisObject = forceAccessible(mainClass.getDeclaredConstructor()).newInstance();
             }
 
             final Object[] parameters = mainMethod.getParameterCount() > 0 ? new Object[] {args} : new Object[] {};
 
             mainMethod.invoke(thisObject, parameters);
         } else {
-            findSimpleMainMethod(mainClass).invoke(null, new Object[] {args});
+            forceAccessible(findSimpleMainMethod(mainClass)).invoke(null, new Object[] {args});
         }
     }
 
@@ -114,5 +115,12 @@ public final class MinecraftLaunch {
 
     private static Method findSimpleMainMethod(Class<?> mainClass) throws NoSuchMethodException {
         return mainClass.getMethod("main", String[].class);
+    }
+
+    private static <T extends AccessibleObject> T forceAccessible(T object) throws ReflectiveOperationException {
+        final Method setAccessible0 = AccessibleObject.class.getDeclaredMethod("setAccessible0", boolean.class);
+        setAccessible0.setAccessible(true);
+        setAccessible0.invoke(object, true);
+        return object;
     }
 }

--- a/packages/app-lib/src/launcher/mod.rs
+++ b/packages/app-lib/src/launcher/mod.rs
@@ -619,6 +619,12 @@ pub async fn launch_minecraft(
         .into_iter(),
     );
 
+    // The java launcher requires access to java.lang.reflect in order to force access in to
+    // whatever module the main class is in
+    if java_version.parsed_version >= 9 {
+        command.arg("--add-opens=java.base/java.lang.reflect=ALL-UNNAMED");
+    }
+
     // The java launcher code requires internal JDK code in Java 25+ in order to support JEP 512
     if java_version.parsed_version >= 25 {
         command.arg("--add-opens=jdk.internal/jdk.internal.misc=ALL-UNNAMED");


### PR DESCRIPTION
As of the latest update, older Forge versions would fail to launch due to the launch wrapper being unable to access the main class's module. This bypasses that by forcing the main method to be accessible with accessibility checks.

Fixes #3910 