### PR TITLE
Fix MinecraftLaunch failing in the case of a package-private main class on Java 8

### DIFF
--- a/packages/app-lib/java/src/main/java/com/modrinth/theseus/MinecraftLaunch.java
+++ b/packages/app-lib/java/src/main/java/com/modrinth/theseus/MinecraftLaunch.java
@@ -123,6 +123,7 @@ public final class MinecraftLaunch {
             setAccessible0.setAccessible(true);
             setAccessible0.invoke(object, true);
         } catch (NoSuchMethodException e) {
+            object.setAccessible(true);
         }
         return object;
     }


### PR DESCRIPTION
I don't know of any mod loaders where this would be the case, but I think it's better to be safe than sorry.