### PR TITLE
Fix failure when "Test"ing a Java installation

### DIFF
--- a/apps/app-frontend/src/components/ui/JavaSelector.vue
+++ b/apps/app-frontend/src/components/ui/JavaSelector.vue
@@ -108,7 +108,6 @@ async function testJava() {
   testingJava.value = true
   testingJavaSuccess.value = await test_jre(
     props.modelValue ? props.modelValue.path : '',
-    1,
     props.version,
   )
   testingJava.value = false

--- a/apps/app-frontend/src/helpers/jre.js
+++ b/apps/app-frontend/src/helpers/jre.js
@@ -36,8 +36,8 @@ export async function get_jre(path) {
 
 // Tests JRE version by running 'java -version' on it.
 // Returns true if the version is valid, and matches given (after extraction)
-export async function test_jre(path, majorVersion, minorVersion) {
-  return await invoke('plugin:jre|jre_test_jre', { path, majorVersion, minorVersion })
+export async function test_jre(path, majorVersion) {
+  return await invoke('plugin:jre|jre_test_jre', { path, majorVersion })
 }
 
 // Automatically installs specified java version

--- a/packages/app-lib/src/api/jre.rs
+++ b/packages/app-lib/src/api/jre.rs
@@ -166,10 +166,15 @@ pub async fn test_jre(
     path: PathBuf,
     major_version: u32,
 ) -> crate::Result<bool> {
-    let Ok(jre) = jre::check_java_at_filepath(&path).await else {
-        return Ok(false);
+    let jre = match jre::check_java_at_filepath(&path).await {
+        Ok(jre) => jre,
+        Err(e) => {
+            tracing::warn!("Invalid Java at {}: {e}", path.display());
+            return Ok(false);
+        }
     };
     let version = extract_java_version(&jre.version)?;
+    tracing::info!("Expected Java version {major_version}, and found {version} at {}", path.display());
     Ok(version == major_version)
 }
 


### PR DESCRIPTION
Since 0.10, clicking "Test" for a Java installation would always fail. This PR fixes that issue.