### PR TITLE
ci(theseus): assorted tweaks and fixes

### DIFF
--- a/.github/workflows/theseus-build.yml
+++ b/.github/workflows/theseus-build.yml
@@ -43,7 +43,7 @@ jobs:
       - name: 📥 Check out code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
       - name: 🧰 Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -77,9 +77,9 @@ jobs:
 
       - name: ⚙️ Set application version
         shell: bash
-        env:
-          APP_VERSION: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || format('v1.0.0-canary+{0}', github.sha) }}
         run: |
+          APP_VERSION="$(git describe --tags --always | sed -E 's/-([0-9]+)-(g[0-9a-fA-F]+)$/-canary+\1.\2/')"
+          echo "Setting application version to $APP_VERSION"
           dasel put -f apps/app/Cargo.toml -t string -v "${APP_VERSION#v}" 'package.version'
           dasel put -f packages/app-lib/Cargo.toml -t string -v "${APP_VERSION#v}" 'package.version'
           dasel put -f apps/app-frontend/package.json -t string -v "${APP_VERSION#v}" 'version'

--- a/.github/workflows/theseus-build.yml
+++ b/.github/workflows/theseus-build.yml
@@ -100,12 +100,6 @@ jobs:
             dasel delete -f apps/app/tauri-release.conf.json 'bundle.windows.signCommand'
           fi
 
-      - name: 🗑️ Clean up cached bundles
-        shell: bash
-        run: |
-          rm -rf target/release/bundle
-          rm -rf target/*/release/bundle || true
-
       - name: 🔨 Build macOS app
         run: pnpm --filter=@modrinth/app run tauri build --target universal-apple-darwin --config tauri-release.conf.json
         if: startsWith(matrix.platform, 'macos')
@@ -147,5 +141,10 @@ jobs:
         with:
           name: App bundle (${{ matrix.artifact-target-name }})
           path: |
-            target/release/bundle/**
-            target/*/release/bundle/**
+            target/release/bundle/appimage/Modrinth App_*.AppImage*
+            target/release/bundle/deb/Modrinth App_*.deb*
+            target/release/bundle/rpm/Modrinth App-*.rpm*
+            target/universal-apple-darwin/release/bundle/macos/Modrinth App.app.tar.gz*
+            target/universal-apple-darwin/release/bundle/dmg/Modrinth App_*.dmg*
+            target/release/bundle/nsis/Modrinth App_*-setup.exe*
+            target/release/bundle/nsis/Modrinth App_*-setup.nsis.zip*

--- a/.github/workflows/theseus-release.yml
+++ b/.github/workflows/theseus-release.yml
@@ -67,7 +67,7 @@ jobs:
                 "install_urls": [
                   @uri "${{ env.LAUNCHER_FILES_BUCKET_BASE_URL }}/versions/\($versionTag)/linux/\("Modrinth App_" + $versionTag + "_amd64.deb")",
                   @uri "${{ env.LAUNCHER_FILES_BUCKET_BASE_URL }}/versions/\($versionTag)/linux/\("Modrinth App_" + $versionTag + "_amd64.AppImage")",
-                  @uri "${{ env.LAUNCHER_FILES_BUCKET_BASE_URL }}/versions/\($versionTag)/linux/\("Modrinth App_" + $versionTag + "-1.x86_64.rpm")"
+                  @uri "${{ env.LAUNCHER_FILES_BUCKET_BASE_URL }}/versions/\($versionTag)/linux/\("Modrinth App-" + $versionTag + "-1.x86_64.rpm")"
                 ]
               },
               "windows-x86_64": {


### PR DESCRIPTION
This PR refines the new Theseus build and release GitHub Actions workflows with the following improvements:

- The build workflow now excludes non-bundle work files generated by Tauri from the uploaded artifacts. This reduces artifact size and prevents unnecessary uploads to our S3-compatible bucket, saving on write operations and storage.
- The release workflow now correctly constructs URLs for RPM packages, fixing a typo (thanks to @Prospector for catching such a sneaky typo!).
- App builds triggered by non-tag pushes now use shorter, more user-friendly version strings. Previously, these strings included the full commit hash, which made them too long to display properly in the app's "About" screen. The version string is now generated using `git describe`, which combines the latest release tag, the distance from that tag to the current commit, and the shortest unique prefix of the current commit hash, which can be used in Git commands just like a full hash.