### PR TITLE
feat(app): increase logs card height

### DIFF
--- a/apps/app-frontend/src/pages/instance/Logs.vue
+++ b/apps/app-frontend/src/pages/instance/Logs.vue
@@ -483,7 +483,7 @@ onUnmounted(() => {
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  height: calc(100vh - 11rem);
+  height: 100vh;
 }
 
 .button-row {


### PR DESCRIPTION
This increases logs card's height to make it look more better, since right now I think it looks squished, I believe this change is also going to make logs easier to read in the app, screenshots below show before/after the change.

![before](https://github.com/user-attachments/assets/1d9e0820-7eeb-417f-a19f-ac1ee9b9167e)
![after](https://github.com/user-attachments/assets/e43ed33f-ebdb-4dba-ba05-3645c7be3395)
