### PR TITLE
Add coventry europe region support

### DIFF
--- a/apps/frontend/src/locales/en-US/index.json
+++ b/apps/frontend/src/locales/en-US/index.json
@@ -383,14 +383,14 @@
   "layout.footer.about": {
     "message": "About"
   },
-  "layout.footer.about.news": {
-    "message": "News"
-  },
   "layout.footer.about.careers": {
     "message": "Careers"
   },
   "layout.footer.about.changelog": {
     "message": "Changelog"
+  },
+  "layout.footer.about.news": {
+    "message": "News"
   },
   "layout.footer.about.rewards-program": {
     "message": "Rewards Program"

--- a/packages/ui/src/components/billing/ServersPurchase1Region.vue
+++ b/packages/ui/src/components/billing/ServersPurchase1Region.vue
@@ -40,7 +40,7 @@ const selectedPrice = computed(() => {
   return amount ? amount / monthsInInterval[props.interval] : undefined
 })
 
-const regionOrder: string[] = ['us-vin', 'eu-lim']
+const regionOrder: string[] = ['us-vin', 'eu-cov', 'eu-lim']
 
 const sortedRegions = computed(() => {
   return props.regions.slice().sort((a, b) => {

--- a/packages/ui/src/locales/en-US/index.json
+++ b/packages/ui/src/locales/en-US/index.json
@@ -512,11 +512,11 @@
   "servers.purchase.step.review.title": {
     "defaultMessage": "Review"
   },
+  "servers.region.central-europe": {
+    "defaultMessage": "Central Europe"
+  },
   "servers.region.custom.prompt": {
     "defaultMessage": "How much RAM do you want your server to have?"
-  },
-  "servers.region.europe": {
-    "defaultMessage": "Europe"
   },
   "servers.region.north-america": {
     "defaultMessage": "North America"
@@ -526,6 +526,9 @@
   },
   "servers.region.region-unsupported": {
     "defaultMessage": "Region not listed? <link>Let us know where you'd like to see Modrinth Servers next!</link>"
+  },
+  "servers.region.western-europe": {
+    "defaultMessage": "Western Europe"
   },
   "settings.account.title": {
     "defaultMessage": "Account and security"

--- a/packages/ui/src/utils/regions.ts
+++ b/packages/ui/src/utils/regions.ts
@@ -6,11 +6,11 @@ export const regionOverrides = {
     flag: 'https://flagcdn.com/us.svg',
   },
   'eu-lim': {
-    name: defineMessage({ id: 'servers.region.europe', defaultMessage: 'Europe' }),
-    flag: 'https://flagcdn.com/eu.svg',
+    name: defineMessage({ id: 'servers.region.central-europe', defaultMessage: 'Central Europe' }),
+    flag: 'https://flagcdn.com/de.svg',
   },
-  'de-fra': {
-    name: defineMessage({ id: 'servers.region.europe', defaultMessage: 'Europe' }),
-    flag: 'https://flagcdn.com/eu.svg',
+  'eu-cov': {
+    name: defineMessage({ id: 'servers.region.western-europe', defaultMessage: 'Western Europe' }),
+    flag: 'https://flagcdn.com/gb.svg',
   },
 } satisfies Record<string, { name?: MessageDescriptor; flag?: string }>


### PR DESCRIPTION
- Added eu-cov support, displayed as "Western Europe"
- Changed eu-lim to display as "Central Europe" instead of just "Europe"
- Changed eu-lim location to use flag of Germany