### PR TITLE
Verify that `intl:extract` has been run

### DIFF
--- a/.github/workflows/turbo-ci.yml
+++ b/.github/workflows/turbo-ci.yml
@@ -76,3 +76,8 @@ jobs:
 
       - name: 🔍 Lint and test
         run: pnpm run ci
+
+      - name: 🔍 Verify intl:extract has been run
+        run: |
+          pnpm intl:extract
+          git diff --exit-code */*/src/locales/en-US/index.json


### PR DESCRIPTION
It's easy to forget to run `pnpm intl:extract` after adding translations. This PR makes the CI fail if the default translation files are outdated (i.e. if `pnpm intl:extract` has not been run).