### PR TITLE
fix(web): prevent gallery item description from overflowing

### DIFF
--- a/apps/frontend/src/pages/[type]/[id]/gallery.vue
+++ b/apps/frontend/src/pages/[type]/[id]/gallery.vue
@@ -705,9 +705,9 @@ export default defineNuxtComponent({
   }
 
   .gallery-body {
-    flex-grow: 1;
     width: calc(100% - 2 * var(--spacing-card-md));
     padding: var(--spacing-card-sm) var(--spacing-card-md);
+    overflow-wrap: anywhere;
 
     .gallery-info {
       h2 {
@@ -716,8 +716,6 @@ export default defineNuxtComponent({
 
       p {
         margin: 0 0 0.5rem 0;
-        max-width: 250px;
-        overflow-wrap: break-word;
       }
     }
   }

--- a/apps/frontend/src/pages/[type]/[id]/gallery.vue
+++ b/apps/frontend/src/pages/[type]/[id]/gallery.vue
@@ -716,6 +716,9 @@ export default defineNuxtComponent({
 
       p {
         margin: 0 0 0.5rem 0;
+        max-width: 250px;
+        text-overflow: ellipsis;
+        overflow: hidden;
       }
     }
   }

--- a/apps/frontend/src/pages/[type]/[id]/gallery.vue
+++ b/apps/frontend/src/pages/[type]/[id]/gallery.vue
@@ -717,8 +717,7 @@ export default defineNuxtComponent({
       p {
         margin: 0 0 0.5rem 0;
         max-width: 250px;
-        text-overflow: ellipsis;
-        overflow: hidden;
+        overflow-wrap: break-word;
       }
     }
   }


### PR DESCRIPTION
## Before
<img width="1585" height="1467" alt="image" src="https://github.com/user-attachments/assets/a2ad37b6-c7c6-4179-aa83-d7a42dd7a151" />


## After 
<img width="1540" height="762" alt="image" src="https://github.com/user-attachments/assets/30827cc2-3f10-4107-bc35-6bf8369d4fc2" />

Fixes #3988 