### PR TITLE
Count failed payments as "open" charges

### DIFF
--- a/apps/labrinth/.sqlx/query-cf020daa52a1316e5f60d197196b880b72c0b2a576e470d9fd7182558103d055.json
+++ b/apps/labrinth/.sqlx/query-cf020daa52a1316e5f60d197196b880b72c0b2a576e470d9fd7182558103d055.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            SELECT\n                id, user_id, price_id, amount, currency_code, status, due, last_attempt,\n                charge_type, subscription_id,\n                -- Workaround for https://github.com/launchbadge/sqlx/issues/3336\n                subscription_interval AS \"subscription_interval?\",\n                payment_platform,\n                payment_platform_id AS \"payment_platform_id?\",\n                parent_charge_id AS \"parent_charge_id?\",\n                net AS \"net?\"\n            FROM charges\n            WHERE subscription_id = $1 AND (status = 'open' OR status = 'cancelled')",
+  "query": "\n            SELECT\n                id, user_id, price_id, amount, currency_code, status, due, last_attempt,\n                charge_type, subscription_id,\n                -- Workaround for https://github.com/launchbadge/sqlx/issues/3336\n                subscription_interval AS \"subscription_interval?\",\n                payment_platform,\n                payment_platform_id AS \"payment_platform_id?\",\n                parent_charge_id AS \"parent_charge_id?\",\n                net AS \"net?\"\n            FROM charges\n            WHERE subscription_id = $1 AND (status = 'open' OR status = 'cancelled' OR status = 'failed')",
   "describe": {
     "columns": [
       {
@@ -102,5 +102,5 @@
       true
     ]
   },
-  "hash": "99cca53fd3f35325e2da3b671532bf98b8c7ad8e7cb9158e4eb9c5bac66d20b2"
+  "hash": "cf020daa52a1316e5f60d197196b880b72c0b2a576e470d9fd7182558103d055"
 }

--- a/apps/labrinth/src/database/models/charge_item.rs
+++ b/apps/labrinth/src/database/models/charge_item.rs
@@ -197,7 +197,7 @@ impl DBCharge {
     ) -> Result<Option<DBCharge>, DatabaseError> {
         let user_subscription_id = user_subscription_id.0;
         let res = select_charges_with_predicate!(
-            "WHERE subscription_id = $1 AND (status = 'open' OR status = 'cancelled')",
+            "WHERE subscription_id = $1 AND (status = 'open' OR status = 'cancelled' OR status = 'failed')",
             user_subscription_id
         )
         .fetch_optional(exec)


### PR DESCRIPTION
This allows people to cancel failed payments, currently it fails with error "There is no open charge for this subscription"
