### PR TITLE
Improve errors when email is already in use

### DIFF
--- a/apps/labrinth/src/auth/mod.rs
+++ b/apps/labrinth/src/auth/mod.rs
@@ -43,7 +43,9 @@ pub enum AuthenticationError {
     InvalidAuthMethod,
     #[error("GitHub Token from incorrect Client ID")]
     InvalidClientId,
-    #[error("User email/account is already registered on Modrinth")]
+    #[error(
+        "User email is already registered on Modrinth. Try 'Forgot password' to access your account."
+    )]
     DuplicateUser,
     #[error("Invalid state sent, you probably need to get a new websocket")]
     SocketError,


### PR DESCRIPTION
Fixes #1485

Also fixes an issue where email_verified was being set to true regardless of whether the oauth provider provides an email (thus indicating that a null email is verified)
