### PR TITLE
fix: status alerts and version buttons no longer cause a failed to generate error.

### DIFF
--- a/packages/moderation/data/stages/status-alerts.ts
+++ b/packages/moderation/data/stages/status-alerts.ts
@@ -50,6 +50,8 @@ const statusAlerts: Stage = {
         project.project_type === 'mod' ||
         project.project_type === 'shader' ||
         project.project_type.toString() === 'plugin',
+      weight: -999999,
+      message: async () => '',
       enablesActions: [
         {
           id: 'status_tec_source_request_options',

--- a/packages/moderation/data/stages/versions.ts
+++ b/packages/moderation/data/stages/versions.ts
@@ -25,6 +25,8 @@ const versions: Stage = {
       label: 'Incorrect Project Type',
       suggestedStatus: 'rejected',
       severity: 'medium',
+      weight: -999999,
+      message: async () => '',
       enablesActions: [
         {
           id: 'versions_incorrect_project_type_options',
@@ -62,6 +64,8 @@ const versions: Stage = {
       label: 'Alternate Versions',
       suggestedStatus: 'flagged',
       severity: 'medium',
+      weight: -999999,
+      message: async () => '',
       enablesActions: [
         {
           id: 'versions_incorrect_project_type_options',


### PR DESCRIPTION
Added empty messages to actions that previously had no message, fixing broken message generation.