### PR TITLE
perf(docker): cache image builds through cache mounts and GHA cache

### DIFF
--- a/.github/workflows/daedalus-docker.yml
+++ b/.github/workflows/daedalus-docker.yml
@@ -22,23 +22,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       - name: Fetch docker metadata
         id: docker_meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           images: ghcr.io/modrinth/daedalus
       - name: Login to GitHub Images
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
-        id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           file: ./apps/daedalus_client/Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
+          cache-from: type=gha,scope=daedalus_client
+          cache-to: type=gha,mode=max,ignore-error=true,scope=daedalus_client

--- a/.github/workflows/daedalus-docker.yml
+++ b/.github/workflows/daedalus-docker.yml
@@ -43,5 +43,5 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
-          cache-from: type=gha,scope=daedalus_client
-          cache-to: type=gha,mode=max,ignore-error=true,scope=daedalus_client
+          cache-from: type=registry,ref=ghcr.io/modrinth/daedalus:main
+          cache-to: type=inline

--- a/.github/workflows/labrinth-docker.yml
+++ b/.github/workflows/labrinth-docker.yml
@@ -20,23 +20,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       - name: Fetch docker metadata
         id: docker_meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           images: ghcr.io/modrinth/labrinth
       - name: Login to GitHub Images
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
-        id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           file: ./apps/labrinth/Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
+          cache-from: type=gha,scope=labrinth
+          cache-to: type=gha,mode=max,ignore-error=true,scope=labrinth

--- a/.github/workflows/labrinth-docker.yml
+++ b/.github/workflows/labrinth-docker.yml
@@ -41,5 +41,5 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
-          cache-from: type=gha,scope=labrinth
-          cache-to: type=gha,mode=max,ignore-error=true,scope=labrinth
+          cache-from: type=registry,ref=ghcr.io/modrinth/labrinth:main
+          cache-to: type=inline

--- a/apps/daedalus_client/Dockerfile
+++ b/apps/daedalus_client/Dockerfile
@@ -1,9 +1,19 @@
+# syntax=docker/dockerfile:1
+
 FROM rust:1.88.0 AS build
 
 WORKDIR /usr/src/daedalus
 COPY . .
-RUN cargo build --release --package daedalus_client
+RUN --mount=type=cache,target=/usr/src/daedalus/target \
+  --mount=type=cache,target=/usr/local/cargo/git/db \
+  --mount=type=cache,target=/usr/local/cargo/registry \
+  cargo build --release --package daedalus_client
 
+FROM build AS artifacts
+
+RUN --mount=type=cache,target=/usr/src/daedalus/target \
+  mkdir /daedalus \
+  && cp /usr/src/daedalus/target/release/daedalus_client /daedalus/daedalus_client
 
 FROM debian:bookworm-slim
 
@@ -11,7 +21,7 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends ca-certificates openssl \
   && rm -rf /var/lib/apt/lists/*
 
-COPY --from=build /usr/src/daedalus/target/release/daedalus_client /daedalus/daedalus_client
-WORKDIR /daedalus_client
+COPY --from=artifacts /daedalus /daedalus
 
-CMD /daedalus/daedalus_client
+WORKDIR /daedalus_client
+CMD ["/daedalus/daedalus_client"]

--- a/apps/labrinth/Dockerfile
+++ b/apps/labrinth/Dockerfile
@@ -1,8 +1,21 @@
+# syntax=docker/dockerfile:1
+
 FROM rust:1.88.0 AS build
 
 WORKDIR /usr/src/labrinth
 COPY . .
-RUN SQLX_OFFLINE=true cargo build --release --package labrinth
+RUN --mount=type=cache,target=/usr/src/labrinth/target \
+  --mount=type=cache,target=/usr/local/cargo/git/db \
+  --mount=type=cache,target=/usr/local/cargo/registry \
+  SQLX_OFFLINE=true cargo build --release --package labrinth
+
+FROM build AS artifacts
+
+RUN --mount=type=cache,target=/usr/src/labrinth/target \
+  mkdir /labrinth \
+  && cp /usr/src/labrinth/target/release/labrinth /labrinth/labrinth \
+  && cp -r /usr/src/labrinth/apps/labrinth/migrations /labrinth \
+  && cp -r /usr/src/labrinth/apps/labrinth/assets /labrinth
 
 FROM debian:bookworm-slim
 
@@ -14,10 +27,8 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends ca-certificates dumb-init curl \
   && rm -rf /var/lib/apt/lists/*
 
-COPY --from=build /usr/src/labrinth/target/release/labrinth /labrinth/labrinth
-COPY --from=build /usr/src/labrinth/apps/labrinth/migrations/* /labrinth/migrations/
-COPY --from=build /usr/src/labrinth/apps/labrinth/assets /labrinth/assets
-WORKDIR /labrinth
+COPY --from=artifacts /labrinth /labrinth
 
+WORKDIR /labrinth
 ENTRYPOINT ["dumb-init", "--"]
 CMD ["/labrinth/labrinth"]


### PR DESCRIPTION
## Overview

These changes improve the performance of our Docker image building process by enabling the reuse of cached results from previous runs in two ways:

- The Cargo target and source checkout directories are now set up as [cache mounts](https://docs.docker.com/build/cache/optimize/#use-cache-mounts). This allows Docker's BuildKit to reuse these directories even if the build layer cache is invalidated, which usually happens due to changes in source files copied via a previous `COPY` instruction.
- BuildKit caches are now stored externally as GitHub Actions cache artifacts, using [a dedicated storage backend](https://docs.docker.com/build/cache/backends/gha/). This enables cache reuse across workflow runs.

The first improvement can significantly enhance the developer experience during local builds. The second builds upon the first to bring similar benefits to our CI environment.

That said, expectations on the CI case should be tempered. Accessing the GitHub Actions cache introduces some performance overhead, and we are already using the 10 GiB limit for cache artifacts. As a result, hit rates are expected to be low (<40%), and the overall speedup can be minimal. Still, there is no noticeable downside, and this setup offers an easy opportunity to gain speed improvements without additional compute. Combined with the improved local development experience, this seems like the right call to make.