### PR TITLE
Colorize output in CI `intl:extract` verification

### DIFF
--- a/.github/workflows/turbo-ci.yml
+++ b/.github/workflows/turbo-ci.yml
@@ -80,4 +80,4 @@ jobs:
       - name: 🔍 Verify intl:extract has been run
         run: |
           pnpm intl:extract
-          git diff --exit-code */*/src/locales/en-US/index.json
+          git diff --exit-code --color */*/src/locales/en-US/index.json


### PR DESCRIPTION
Simply adding `--color` to the final step in the CI does this.