### PR TITLE
Use `rust-lld` linker on MSVC Windows

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,5 +2,8 @@
 [target.'cfg(windows)']
 rustflags = ["-C", "link-args=/STACK:16777220", "--cfg", "tokio_unstable"]
 
+[target.x86_64-pc-windows-msvc]
+linker = "rust-lld"
+
 [build]
 rustflags = ["--cfg", "tokio_unstable"]


### PR DESCRIPTION
The latest version of MSVC fails when linking labrinth, making now a perfect opportunity to switch over to the `rust-lld` linker instead.