### PR TITLE
chore(ci): switch back to upstream `cache-cargo-install-action`

### DIFF
--- a/.github/workflows/turbo-ci.yml
+++ b/.github/workflows/turbo-ci.yml
@@ -52,7 +52,7 @@ jobs:
       # cargo-binstall does not have pre-built binaries for sqlx-cli, so we fall
       # back to a cached cargo install
       - name: 🧰 Setup cargo-sqlx
-        uses: AlexTMjugador/cache-cargo-install-action@feat/features-support
+        uses: taiki-e/cache-cargo-install-action@v2
         with:
           tool: sqlx-cli
           locked: false


### PR DESCRIPTION
## Overview

When #3776 was made, I had to use a personal fork of `cache-cargo-install-action` to install and cache `sqlx-cli` in the new CI workflow with specific features. Without these specific feature selection, compilation failed, but even if it succeeded it would take longer than necessary due to drivers being built for databases we don't use.

While creating that fork, I also submitted the required changes as a pull request upstream: https://github.com/taiki-e/cache-cargo-install-action/pull/9. This PR was recently merged and released as part of a new version of the action.

Now that the upstream version includes the necessary changes, let's switch to the official repository and tag to simplify workflow maintenance.