### PR TITLE
Fix most packs showing as "Optimization" on the app homepage

### DIFF
--- a/apps/app-frontend/src/components/ui/ProjectCard.vue
+++ b/apps/app-frontend/src/components/ui/ProjectCard.vue
@@ -21,14 +21,11 @@ const props = defineProps({
 })
 
 const featuredCategory = computed(() => {
-  if (props.project.categories.includes('optimization')) {
+  if (props.project.display_categories.includes('optimization')) {
     return 'optimization'
   }
 
-  if (props.project.categories.length > 0) {
-    return props.project.categories[0]
-  }
-  return undefined
+  return props.project.display_categories[0] ?? props.project.categories[0]
 })
 
 const toColor = computed(() => {


### PR DESCRIPTION
Before, a project used to always show as "Optimization" if it was tagged as "Optimization". Now, it will only be forced to show as "Optimization" if it has "Optimization" as a *featured* tag. Additionally, featured tags are now always preferred over non-featured tags on the homepage.

Fixes DEV-219