### PR TITLE
feat: add simple mode editor to the moderation checklist

### DIFF
--- a/apps/frontend/src/components/ui/moderation/checklist/ModerationChecklist.vue
+++ b/apps/frontend/src/components/ui/moderation/checklist/ModerationChecklist.vue
@@ -50,12 +50,34 @@
         </div>
         <div v-else-if="generatedMessage">
           <div>
+            <ButtonStyled>
+              <button class="mb-2" @click="useSimpleEditor = !useSimpleEditor">
+                <template v-if="!useSimpleEditor">
+                  <ToggleLeftIcon aria-hidden="true" />
+                  Use simple mode
+                </template>
+                <template v-else>
+                  <ToggleRightIcon aria-hidden="true" />
+                  Use advanced mode
+                </template>
+              </button>
+            </ButtonStyled>
             <MarkdownEditor
+              v-if="!useSimpleEditor"
               v-model="message"
               :max-height="400"
               placeholder="No message generated."
               :disabled="false"
               :heading-buttons="false"
+            />
+            <textarea
+              v-else
+              v-model="message"
+              type="text"
+              class="bg-bg-input h-[400px] w-full rounded-lg border border-solid border-divider px-3 py-2 font-mono text-base"
+              placeholder="No message generated."
+              autocomplete="off"
+              @input="persistState"
             />
           </div>
         </div>
@@ -324,6 +346,8 @@ import {
   CheckIcon,
   KeyboardIcon,
   EyeOffIcon,
+  ToggleLeftIcon,
+  ToggleRightIcon,
 } from "@modrinth/assets";
 import {
   checklist,
@@ -391,6 +415,7 @@ const isModpackPermissionsStage = computed(() => {
   return currentStageObj.value.id === "modpack-permissions";
 });
 
+const useSimpleEditor = ref(false);
 const message = ref("");
 const generatedMessage = ref(false);
 const loadingMessage = ref(false);

--- a/apps/frontend/src/components/ui/moderation/checklist/ModerationChecklist.vue
+++ b/apps/frontend/src/components/ui/moderation/checklist/ModerationChecklist.vue
@@ -368,7 +368,6 @@ import {
   type Stage,
   finalPermissionMessages,
 } from "@modrinth/moderation";
-import * as prettier from "prettier";
 import ModpackPermissionsFlow from "./ModpackPermissionsFlow.vue";
 import KeybindsModal from "./ChecklistKeybindsModal.vue";
 import { useModerationStore } from "~/store/moderation.ts";
@@ -1118,19 +1117,7 @@ async function generateMessage() {
       }
     }
 
-    try {
-      const formattedMessage = await prettier.format(fullMessage, {
-        parser: "markdown",
-        printWidth: 80,
-        proseWrap: "always",
-        tabWidth: 2,
-        useTabs: false,
-      });
-      message.value = formattedMessage;
-    } catch (formattingError) {
-      console.warn("Failed to format markdown, using original:", formattingError);
-      message.value = fullMessage;
-    }
+    message.value = fullMessage;
 
     generatedMessage.value = true;
   } catch (error) {

--- a/packages/assets/generated-icons.ts
+++ b/packages/assets/generated-icons.ts
@@ -169,6 +169,8 @@ import _TerminalSquareIcon from './icons/terminal-square.svg?component'
 import _TestIcon from './icons/test.svg?component'
 import _TextQuoteIcon from './icons/text-quote.svg?component'
 import _TimerIcon from './icons/timer.svg?component'
+import _ToggleLeftIcon from './icons/toggle-left.svg?component'
+import _ToggleRightIcon from './icons/toggle-right.svg?component'
 import _TransferIcon from './icons/transfer.svg?component'
 import _TrashIcon from './icons/trash.svg?component'
 import _TriangleAlertIcon from './icons/triangle-alert.svg?component'
@@ -362,6 +364,8 @@ export const TerminalSquareIcon = _TerminalSquareIcon
 export const TestIcon = _TestIcon
 export const TextQuoteIcon = _TextQuoteIcon
 export const TimerIcon = _TimerIcon
+export const ToggleLeftIcon = _ToggleLeftIcon
+export const ToggleRightIcon = _ToggleRightIcon
 export const TransferIcon = _TransferIcon
 export const TrashIcon = _TrashIcon
 export const TriangleAlertIcon = _TriangleAlertIcon

--- a/packages/assets/icons/toggle-left.svg
+++ b/packages/assets/icons/toggle-left.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-toggle-left-icon lucide-toggle-left"><circle cx="9" cy="12" r="3"/><rect width="20" height="14" x="2" y="5" rx="7"/></svg>

--- a/packages/assets/icons/toggle-right.svg
+++ b/packages/assets/icons/toggle-right.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-toggle-right-icon lucide-toggle-right"><circle cx="15" cy="12" r="3"/><rect width="20" height="14" x="2" y="5" rx="7"/></svg>


### PR DESCRIPTION
Closes DEV-225

---

This PR adds a toggle button that allows moderators to switch between the advanced markdown editor and a simple plain text `textarea` input.

## Background

CodeMirror uses virtual scrolling for performance optimization, replacing off-screen content with `cm-gap` elements. However, this can cause rendering issues in certain contexts (such as floating containers), where lines become hidden even when they should be visible. 

It should be noted that this bug is rare, there's only been 2 recorded instances of it happening in the checklist.

Reference: https://discuss.codemirror.net/t/improve-scroll-performance-tradeoff/8825

## Changes

- Added a toggle button in the moderation message editor (an actual `Toggle` was not used so that it can fit in with the `MarkdownEditor` formatting buttons.)
- Moderators can switch between "advanced mode" (`MarkdownEditor`) and "simple mode" (`textarea`)
- Simple mode provides a fallback for rare cases where the markdown editor has rendering issues 