### PR TITLE
fix: only check the first project type in filtering

### DIFF
--- a/apps/frontend/src/pages/moderation/index.vue
+++ b/apps/frontend/src/pages/moderation/index.vue
@@ -287,8 +287,10 @@ const typeFiltered = computed(() => {
   const projectType = filterMap[currentFilterType.value];
   if (!projectType) return baseFiltered.value;
 
-  return baseFiltered.value.filter((queueItem) =>
-    queueItem.project.project_types.includes(projectType),
+  return baseFiltered.value.filter(
+    (queueItem) =>
+      queueItem.project.project_types.length > 0 &&
+      queueItem.project.project_types[0] === projectType,
   );
 });
 


### PR DESCRIPTION
Closes DEV-216

---

This PR changes the filtering logic in the moderation dashboard so that only the first project type in the `project_types` array is used. Generally the first project type in the array is the initial type, and anything after was done after the first version was uploaded (e.g. another version or the first version was edited) - there is a rare case when the first version triggers a mixed `project_types`, there is no way to work around that issue.

Ideally the backend should provide the actual type of the project, this could be addressed in the future changes to how the backend provides moderation queue/reports information, not a huge priority though, I couldn't find any projects in the queue in which the first version triggered multiple `project_types` to exist.