### PR TITLE
revert: dont use local storage for filters on moderation dash

### DIFF
--- a/apps/frontend/src/pages/moderation/index.vue
+++ b/apps/frontend/src/pages/moderation/index.vue
@@ -100,7 +100,6 @@ import {
   ScaleIcon,
 } from "@modrinth/assets";
 import { defineMessages, useVIntl } from "@vintl/vintl";
-import { useLocalStorage } from "@vueuse/core";
 import ConfettiExplosion from "vue-confetti-explosion";
 import Fuse from "fuse.js";
 import ModerationQueueCard from "~/components/ui/moderation/ModerationQueueCard.vue";
@@ -215,7 +214,7 @@ watch(
   },
 );
 
-const currentFilterType = useLocalStorage("moderation-current-filter-type", () => "All projects");
+const currentFilterType = ref("All projects");
 const filterTypes: readonly string[] = readonly([
   "All projects",
   "Modpacks",
@@ -226,7 +225,7 @@ const filterTypes: readonly string[] = readonly([
   "Shaders",
 ]);
 
-const currentSortType = useLocalStorage("moderation-current-sort-type", () => "Oldest");
+const currentSortType = ref("Oldest");
 const sortTypes: readonly string[] = readonly(["Oldest", "Newest"]);
 
 const currentPage = ref(1);

--- a/apps/frontend/src/pages/moderation/reports/index.vue
+++ b/apps/frontend/src/pages/moderation/reports/index.vue
@@ -72,7 +72,6 @@
 import { DropdownSelect, Button, Pagination } from "@modrinth/ui";
 import { XIcon, SearchIcon, SortAscIcon, SortDescIcon, FilterIcon } from "@modrinth/assets";
 import { defineMessages, useVIntl } from "@vintl/vintl";
-import { useLocalStorage } from "@vueuse/core";
 import type { Report } from "@modrinth/utils";
 import Fuse from "fuse.js";
 import type { ExtendedReport } from "@modrinth/moderation";
@@ -170,10 +169,10 @@ watch(
   },
 );
 
-const currentFilterType = useLocalStorage("moderation-reports-filter-type", () => "All");
+const currentFilterType = ref("All");
 const filterTypes: readonly string[] = readonly(["All", "Unread", "Read"]);
 
-const currentSortType = useLocalStorage("moderation-reports-sort-type", () => "Oldest");
+const currentSortType = ref("Oldest");
 const sortTypes: readonly string[] = readonly(["Oldest", "Newest"]);
 
 const currentPage = ref(1);


### PR DESCRIPTION
Closes DEV-215

---

This PR removes the usage of `localStorage` for persisting filter and "Sort By" dropdown states on the reports and moderation queue pages to resolve hydration mismatches.

The current implementation uses `localStorage` to persist filter and sort preferences across page reloads. However, this causes hydration issues where the server-side rendered content doesn't match the client-side state, similar to the issues we've experienced with the tremendous reward images not synchronizing properly with their corresponding cards.

The trade-off of losing filter persistence is acceptable given the stability improvements and the fact that these are administrative pages where consistent, predictable behavior is more important than convenience