### PR TITLE
tweak(frontend): improve Nuxt build state generation logging and caching

### DIFF
--- a/apps/frontend/nuxt.config.ts
+++ b/apps/frontend/nuxt.config.ts
@@ -143,8 +143,13 @@ export default defineNuxtConfig({
         state.lastGenerated &&
         new Date(state.lastGenerated).getTime() + TTL > new Date().getTime() &&
         // ...but only if the API URL is the same
-        state.apiUrl === API_URL
+        state.apiUrl === API_URL &&
+        // ...and if no errors were caught during the last generation
+        (state.errors ?? []).length === 0
       ) {
+        console.log(
+          "Tags already recently generated. Delete apps/frontend/generated/state.json to force regeneration.",
+        );
         return;
       }
 


### PR DESCRIPTION
## Overview

This PR improves two aspects of the Nuxt state generation build hook:

- Previously, state generation would be skipped if any errors occurred during the last build, which causes poor developer experience when API endpoints are temporarily unavailable. Now, state generation is no longer skipped if errors happened, which provides a smoother development workflow without negative side effects (production builds occur infrequently enough that API rate limits aren't a concern, and it makes sense to retry fetching data if errors happen anyway).
- When generation is skipped, a message now appears informing about that, with instructions on how to force regeneration. This improves the development experience when working with local Labrinth deployments that may serve different data over short spans of time, preventing confusion about why frontend builds seem to ignore data changes.