### PR TITLE
Make Windows app installations per-user once again

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,7 @@ root = true
 [*]
 charset = utf-8
 indent_style = space
-indent_size = 2
+indent_size = 4
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
@@ -13,6 +13,3 @@ max_line_length = 100
 [*.md]
 max_line_length = off
 trim_trailing_whitespace = false
-
-[*.{rs,java,kts}]
-indent_size = 4

--- a/apps/app/nsis/hooks.nsi
+++ b/apps/app/nsis/hooks.nsi
@@ -1,41 +1,66 @@
-!macro NSIS_HOOK_POSTINSTALL
+!macro ShellExecWait verb app param workdir show exitoutvar ;only app and show must be != "", every thing else is optional
+    #define SEE_MASK_NOCLOSEPROCESS 0x40
+    System::Store S
+    !if "${NSIS_PTR_SIZE}" > 4
+    !define /ReDef /math SYSSIZEOF_SHELLEXECUTEINFO 14 * ${NSIS_PTR_SIZE}
+    !else ifndef SYSSIZEOF_SHELLEXECUTEINFO
+    !define SYSSIZEOF_SHELLEXECUTEINFO 60
+    !endif
+    System::Call '*(&i${SYSSIZEOF_SHELLEXECUTEINFO})i.r0'
+    System::Call '*$0(i ${SYSSIZEOF_SHELLEXECUTEINFO},i 0x40,p $hwndparent,t "${verb}",t $\'${app}$\',t $\'${param}$\',t "${workdir}",i ${show})p.r0'
+    System::Call 'shell32::ShellExecuteEx(t)(pr0)i.r1 ?e' ; (t) to trigger A/W selection
+    ${If} $1 <> 0
+        System::Call '*$0(is,i,p,p,p,p,p,p,p,p,p,p,p,p,p.r1)' ;stack value not really used, just a fancy pop ;)
+        System::Call 'kernel32::WaitForSingleObject(pr1,i-1)'
+        System::Call 'kernel32::GetExitCodeProcess(pr1,*i.s)'
+        System::Call 'kernel32::CloseHandle(pr1)'
+    ${EndIf}
+    System::Free $0
+    !if "${exitoutvar}" == ""
+        pop $0
+    !endif
+    System::Store L
+    !if "${exitoutvar}" != ""
+        pop ${exitoutvar}
+    !endif
+!macroend
+
+; --------------------------------------------------------------------------------
+
+Var /GLOBAL OldInstallDir
+
+!macro NSIS_HOOK_PREINSTALL
+    SetShellVarContext all
+    ${If} ${FileExists} "$SMPROGRAMS\${PRODUCTNAME}.lnk"
+        UserInfo::GetAccountType
+        Pop $0
+        ${If} $0 != "Admin"
+            MessageBox MB_ICONINFORMATION|MB_OK "An old installation of the Modrinth App was detected that requires administrator permission to update from. You will be prompted with admin prompt shortly."
+        ${EndIf}
+
+        ReadRegStr $4 SHCTX "${MANUPRODUCTKEY}" ""
+        ReadRegStr $R1 SHCTX "${UNINSTKEY}" "UninstallString"
+
+        ReadRegStr $OldInstallDir SHCTX "${UNINSTKEY}" "InstallLocation"
+        StrCpy $OldInstallDir $OldInstallDir "" 1
+        StrCpy $OldInstallDir $OldInstallDir -1 ""
+
+        DetailPrint "Executing $R1"
+        !insertmacro ShellExecWait "runas" '$R1' '/UPDATE /P _?=$4' "" ${SW_SHOW} $3
+        ${If} $3 <> 0
+            SetErrorLevel $3
+            MessageBox MB_ICONEXCLAMATION|MB_OK "Failed to uninstall old global installation"
+            Abort
+        ${EndIf}
+    ${EndIf}
     SetShellVarContext current
+!macroend
 
-    IfFileExists "$LOCALAPPDATA${PRODUCTNAME}\theseus_gui.exe" file_found file_not_found
-    file_found:
-        Delete "$LOCALAPPDATA${PRODUCTNAME}\theseus_gui.exe"
-
-        Delete "$LOCALAPPDATA${PRODUCTNAME}\uninstall.exe"
-        RMDir "$LOCALAPPDATA${PRODUCTNAME}"
-
-        !insertmacro DeleteAppUserModelId
-
-        ; Remove start menu shortcut
-        !insertmacro MUI_STARTMENU_GETFOLDER Application $AppStartMenuFolder
-        !insertmacro IsShortcutTarget "$SMPROGRAMS$AppStartMenuFolder${PRODUCTNAME}.lnk" "$LOCALAPPDATA${PRODUCTNAME}\theseus_gui.exe"
-        Pop $0
-        ${If} $0 = 1
-          !insertmacro UnpinShortcut "$SMPROGRAMS$AppStartMenuFolder${PRODUCTNAME}.lnk"
-          Delete "$SMPROGRAMS$AppStartMenuFolder${PRODUCTNAME}.lnk"
-          RMDir "$SMPROGRAMS$AppStartMenuFolder"
-        ${EndIf}
-        !insertmacro IsShortcutTarget "$SMPROGRAMS${PRODUCTNAME}.lnk" "$LOCALAPPDATA${PRODUCTNAME}\theseus_gui.exe"
-        Pop $0
-        ${If} $0 = 1
-          !insertmacro UnpinShortcut "$SMPROGRAMS${PRODUCTNAME}.lnk"
-          Delete "$SMPROGRAMS${PRODUCTNAME}.lnk"
-        ${EndIf}
-
-        !insertmacro IsShortcutTarget "$DESKTOP${PRODUCTNAME}.lnk" "$LOCALAPPDATA${PRODUCTNAME}\theseus_gui.exe"
-        Pop $0
-        ${If} $0 = 1
-          !insertmacro UnpinShortcut "$DESKTOP${PRODUCTNAME}.lnk"
-          Delete "$DESKTOP${PRODUCTNAME}.lnk"
-        ${EndIf}
-
-        DeleteRegKey HKCU "${UNINSTKEY}"
-
-        goto end_of_test ;<== important for not continuing on the else branch
-    file_not_found:
-    end_of_test:
+!macro NSIS_HOOK_POSTINSTALL
+    !insertmacro IsShortcutTarget "$DESKTOP\${PRODUCTNAME}.lnk" "$OldInstallDir\${MAINBINARYNAME}.exe"
+    Pop $0
+    ${If} $0 = 1
+        !insertmacro SetShortcutTarget "$DESKTOP\${PRODUCTNAME}.lnk" "$INSTDIR\${MAINBINARYNAME}.exe"
+        Return
+    ${EndIf}
 !macroend

--- a/apps/app/nsis/hooks.nsi
+++ b/apps/app/nsis/hooks.nsi
@@ -47,7 +47,7 @@ Var /GLOBAL OldInstallDir
         StrCpy $OldInstallDir $OldInstallDir -1 ""
 
         DetailPrint "Executing $R1"
-        !insertmacro ShellExecWait "runas" '$R1' '/UPDATE /P _?=$4' "" ${SW_SHOW} $3
+        !insertmacro ShellExecWait "runas" '$R1' '/P _?=$4' "" ${SW_SHOW} $3
         ${If} $3 <> 0
             SetErrorLevel $3
             MessageBox MB_ICONEXCLAMATION|MB_OK "Failed to uninstall old global installation"

--- a/apps/app/nsis/hooks.nsi
+++ b/apps/app/nsis/hooks.nsi
@@ -1,3 +1,4 @@
+; https://nsis.sourceforge.io/ShellExecWait
 !macro ShellExecWait verb app param workdir show exitoutvar ;only app and show must be != "", every thing else is optional
     #define SEE_MASK_NOCLOSEPROCESS 0x40
     System::Store S

--- a/apps/app/tauri.conf.json
+++ b/apps/app/tauri.conf.json
@@ -15,7 +15,6 @@
     "icon": ["icons/128x128.png", "icons/128x128@2x.png", "icons/icon.icns", "icons/icon.ico"],
     "windows": {
       "nsis": {
-        "installMode": "perMachine",
         "installerHooks": "./nsis/hooks.nsi"
       }
     },


### PR DESCRIPTION
If an old global installation is present, the installer will prompt for admin permissions and uninstall the global installation before installing the update. Desktop shortcuts will also be automatically migrated if they exist.

Fixes #2386 