### PR TITLE
feat(labrinth): allow editing loader fields in bulk in v3 project PATCH

### DIFF
--- a/apps/labrinth/src/routes/v2/projects.rs
+++ b/apps/labrinth/src/routes/v2/projects.rs
@@ -512,6 +512,7 @@ pub async fn project_edit(
         moderation_message_body: v2_new_project.moderation_message_body,
         monetization_status: v2_new_project.monetization_status,
         side_types_migration_review_status: None, // Not to be exposed in v2
+        loader_fields: HashMap::new(), // Loader fields are not a thing in v2
     };
 
     // This returns 204 or failure so we don't need to do anything with it


### PR DESCRIPTION
## Overview

This small PR makes it possible to set the value of a loader field for all versions of a project at once through the v3 project PATCH route, which comes in handy for implementing some frontend operations more efficiently. As with other v3 routes, this is meant primarily for internal usage and is not subject to any stability guarantees whatsoever.