### PR TITLE
Fix cargo rebuilding labrinth even when no change was made

### DIFF
--- a/apps/labrinth/build.rs
+++ b/apps/labrinth/build.rs
@@ -14,7 +14,7 @@ fn main() {
     let git_hash = String::from_utf8(output.stdout)
         .expect("valid UTF-8 output from `git` invocation");
 
-    println!("cargo::rerun-if-changed=.git/HEAD");
+    println!("cargo::rerun-if-changed=../../.git/HEAD");
     println!("cargo::rustc-env=GIT_HASH={}", git_hash.trim());
 
     let timedate_fmt = Local::now().format("%F @ %I:%M %p");


### PR DESCRIPTION
The `build.rs` script currently contains this line:

```
println!("cargo::rerun-if-changed=.git/HEAD");
```

For the purpose of recomputing the `GIT_HASH` build-time environment variable if the current commit changes. However, `.git` is not present in the labrinth root—it's in the monorepo's root.

Because `labrinth/.git/HEAD` never exists, Cargo will detect a change and always rebuild the whole crate, even when nothing really changed.

Arguably that whole section of the build script could be removed or reworked as it doesn't even work with Docker builds/in prod.