### PR TITLE
Minor compose and editorconfig fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,11 +14,5 @@ max_line_length = 100
 max_line_length = off
 trim_trailing_whitespace = false
 
-[*.json]
-indent_size = 2
-
-[*.yml]
-indent_size = 2
-
-[*.yaml]
+[*.{json,ts,vue,scss,css,html,js,yml,yaml}]
 indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -16,3 +16,9 @@ trim_trailing_whitespace = false
 
 [*.json]
 indent_size = 2
+
+[*.yml]
+indent_size = 2
+
+[*.yaml]
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -11,8 +11,9 @@ trim_trailing_whitespace = true
 max_line_length = 100
 
 [*.md]
+indent_size = 2
 max_line_length = off
 trim_trailing_whitespace = false
 
-[*.{json,ts,vue,scss,css,html,js,yml,yaml}]
+[*.{json,yml,yaml,ts,vue,scss,css,html,js,cjs,mjs,gltf,prettierrc}]
 indent_size = 2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       CLICKHOUSE_USER: default
       CLICKHOUSE_PASSWORD: default
     healthcheck:
-      test: ['CMD', 'clickhouse-client', '--query', 'SELECT 1']
+      test: ['CMD-SHELL', 'clickhouse-client --query "SELECT 1"']
       interval: 3s
       timeout: 5s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
+name: labrinth
 services:
   postgres_db:
     image: postgres:alpine
+    container_name: labrinth-postgres
     volumes:
       - db-data:/var/lib/postgresql/data
     ports:
@@ -16,6 +18,7 @@ services:
       retries: 3
   meilisearch:
     image: getmeili/meilisearch:v1.12.0
+    container_name: labrinth-meilisearch
     restart: on-failure
     ports:
       - '7700:7700'
@@ -31,6 +34,7 @@ services:
       retries: 3
   redis:
     image: redis:alpine
+    container_name: labrinth-redis
     restart: on-failure
     ports:
       - '6379:6379'
@@ -43,6 +47,7 @@ services:
       retries: 3
   clickhouse:
     image: clickhouse/clickhouse-server
+    container_name: labrinth-clickhouse
     ports:
       - '8123:8123'
     environment:


### PR DESCRIPTION
There is nothing interesting to describe here other than what's stated in the different commit titles. Giving containers a name in `docker-compose.yml` is useful for being able to referring to those by a well-known name in e.g. `.env` files, which will be leveraged in an incoming PR.