### PR TITLE
Support missing ClickHouse connection

### DIFF
--- a/apps/labrinth/src/clickhouse/fetch.rs
+++ b/apps/labrinth/src/clickhouse/fetch.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use crate::{models::ids::ProjectId, routes::ApiError};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -25,7 +23,7 @@ pub async fn fetch_playtimes(
     start_date: DateTime<Utc>,
     end_date: DateTime<Utc>,
     resolution_minute: u32,
-    client: Arc<clickhouse::Client>,
+    client: &clickhouse::Client,
 ) -> Result<Vec<ReturnIntervals>, ApiError> {
     let query = client
         .query(
@@ -56,12 +54,12 @@ pub async fn fetch_views(
     start_date: DateTime<Utc>,
     end_date: DateTime<Utc>,
     resolution_minutes: u32,
-    client: Arc<clickhouse::Client>,
+    client: &clickhouse::Client,
 ) -> Result<Vec<ReturnIntervals>, ApiError> {
     let query = client
         .query(
             "
-            SELECT  
+            SELECT
                 toUnixTimestamp(toStartOfInterval(recorded, toIntervalMinute(?))) AS time,
                 project_id AS id,
                 count(1) AS total
@@ -86,12 +84,12 @@ pub async fn fetch_downloads(
     start_date: DateTime<Utc>,
     end_date: DateTime<Utc>,
     resolution_minutes: u32,
-    client: Arc<clickhouse::Client>,
+    client: &clickhouse::Client,
 ) -> Result<Vec<ReturnIntervals>, ApiError> {
     let query = client
         .query(
             "
-            SELECT  
+            SELECT
                 toUnixTimestamp(toStartOfInterval(recorded, toIntervalMinute(?))) AS time,
                 project_id as id,
                 count(1) AS total
@@ -113,7 +111,7 @@ pub async fn fetch_countries_downloads(
     projects: Vec<ProjectId>,
     start_date: DateTime<Utc>,
     end_date: DateTime<Utc>,
-    client: Arc<clickhouse::Client>,
+    client: &clickhouse::Client,
 ) -> Result<Vec<ReturnCountry>, ApiError> {
     let query = client
         .query(
@@ -140,7 +138,7 @@ pub async fn fetch_countries_views(
     projects: Vec<ProjectId>,
     start_date: DateTime<Utc>,
     end_date: DateTime<Utc>,
-    client: Arc<clickhouse::Client>,
+    client: &clickhouse::Client,
 ) -> Result<Vec<ReturnCountry>, ApiError> {
     let query = client
         .query(

--- a/apps/labrinth/src/queue/analytics.rs
+++ b/apps/labrinth/src/queue/analytics.rs
@@ -52,7 +52,7 @@ impl AnalyticsQueue {
 
     pub async fn index(
         &self,
-        client: clickhouse::Client,
+        client: Option<clickhouse::Client>,
         redis: &RedisPool,
         pool: &PgPool,
     ) -> Result<(), ApiError> {
@@ -64,6 +64,11 @@ impl AnalyticsQueue {
 
         let playtime_queue = self.playtime_queue.clone();
         self.playtime_queue.clear();
+
+        let Some(client) = client else {
+            // If ClickHouse isn't available, skip indexing silently
+            return Ok(());
+        };
 
         if !playtime_queue.is_empty() {
             let mut playtimes = client.insert("playtime")?;

--- a/apps/labrinth/src/queue/payouts.rs
+++ b/apps/labrinth/src/queue/payouts.rs
@@ -736,8 +736,12 @@ pub async fn make_aditude_request(
 
 pub async fn process_payout(
     pool: &PgPool,
-    client: &clickhouse::Client,
+    client: Option<&clickhouse::Client>,
 ) -> Result<(), ApiError> {
+    let Some(client) = client else {
+        return Ok(());
+    };
+
     sqlx::query!(
         "
         UPDATE payouts

--- a/apps/labrinth/src/routes/v3/analytics_get.rs
+++ b/apps/labrinth/src/routes/v3/analytics_get.rs
@@ -71,7 +71,7 @@ pub struct FetchedPlaytime {
 }
 pub async fn playtimes_get(
     req: HttpRequest,
-    clickhouse: web::Data<clickhouse::Client>,
+    clickhouse: web::Data<Option<clickhouse::Client>>,
     data: web::Query<GetData>,
     session_queue: web::Data<AuthQueue>,
     pool: web::Data<PgPool>,
@@ -106,14 +106,18 @@ pub async fn playtimes_get(
         filter_allowed_ids(project_ids, user, &pool, &redis, None).await?;
 
     // Get the views
-    let playtimes = crate::clickhouse::fetch_playtimes(
-        project_ids.unwrap_or_default(),
-        start_date,
-        end_date,
-        resolution_minutes,
-        clickhouse.into_inner(),
-    )
-    .await?;
+    let playtimes = if let Some(client) = clickhouse.get_ref().as_ref() {
+        crate::clickhouse::fetch_playtimes(
+            project_ids.unwrap_or_default(),
+            start_date,
+            end_date,
+            resolution_minutes,
+            client,
+        )
+        .await?
+    } else {
+        Vec::new()
+    };
 
     let mut hm = HashMap::new();
     for playtime in playtimes {
@@ -140,7 +144,7 @@ pub async fn playtimes_get(
 /// Either a list of project_ids or version_ids can be used, but not both. Unauthorized projects/versions will be filtered out.
 pub async fn views_get(
     req: HttpRequest,
-    clickhouse: web::Data<clickhouse::Client>,
+    clickhouse: web::Data<Option<clickhouse::Client>>,
     data: web::Query<GetData>,
     session_queue: web::Data<AuthQueue>,
     pool: web::Data<PgPool>,
@@ -175,14 +179,18 @@ pub async fn views_get(
         filter_allowed_ids(project_ids, user, &pool, &redis, None).await?;
 
     // Get the views
-    let views = crate::clickhouse::fetch_views(
-        project_ids.unwrap_or_default(),
-        start_date,
-        end_date,
-        resolution_minutes,
-        clickhouse.into_inner(),
-    )
-    .await?;
+    let views = if let Some(client) = clickhouse.get_ref().as_ref() {
+        crate::clickhouse::fetch_views(
+            project_ids.unwrap_or_default(),
+            start_date,
+            end_date,
+            resolution_minutes,
+            client,
+        )
+        .await?
+    } else {
+        Vec::new()
+    };
 
     let mut hm = HashMap::new();
     for views in views {
@@ -209,7 +217,7 @@ pub async fn views_get(
 /// Either a list of project_ids or version_ids can be used, but not both. Unauthorized projects/versions will be filtered out.
 pub async fn downloads_get(
     req: HttpRequest,
-    clickhouse: web::Data<clickhouse::Client>,
+    clickhouse: web::Data<Option<clickhouse::Client>>,
     data: web::Query<GetData>,
     session_queue: web::Data<AuthQueue>,
     pool: web::Data<PgPool>,
@@ -245,14 +253,18 @@ pub async fn downloads_get(
             .await?;
 
     // Get the downloads
-    let downloads = crate::clickhouse::fetch_downloads(
-        project_ids.unwrap_or_default(),
-        start_date,
-        end_date,
-        resolution_minutes,
-        clickhouse.into_inner(),
-    )
-    .await?;
+    let downloads = if let Some(client) = clickhouse.get_ref().as_ref() {
+        crate::clickhouse::fetch_downloads(
+            project_ids.unwrap_or_default(),
+            start_date,
+            end_date,
+            resolution_minutes,
+            client,
+        )
+        .await?
+    } else {
+        Vec::new()
+    };
 
     let mut hm = HashMap::new();
     for downloads in downloads {
@@ -418,7 +430,7 @@ pub async fn revenue_get(
 /// For this endpoint, provided dates are a range to aggregate over, not specific days to fetch
 pub async fn countries_downloads_get(
     req: HttpRequest,
-    clickhouse: web::Data<clickhouse::Client>,
+    clickhouse: web::Data<Option<clickhouse::Client>>,
     data: web::Query<GetData>,
     session_queue: web::Data<AuthQueue>,
     pool: web::Data<PgPool>,
@@ -450,13 +462,17 @@ pub async fn countries_downloads_get(
         filter_allowed_ids(project_ids, user, &pool, &redis, None).await?;
 
     // Get the countries
-    let countries = crate::clickhouse::fetch_countries_downloads(
-        project_ids.unwrap_or_default(),
-        start_date,
-        end_date,
-        clickhouse.into_inner(),
-    )
-    .await?;
+    let countries = if let Some(client) = clickhouse.get_ref().as_ref() {
+        crate::clickhouse::fetch_countries_downloads(
+            project_ids.unwrap_or_default(),
+            start_date,
+            end_date,
+            client,
+        )
+        .await?
+    } else {
+        Vec::new()
+    };
 
     let mut hm = HashMap::new();
     for views in countries {
@@ -491,7 +507,7 @@ pub async fn countries_downloads_get(
 /// For this endpoint, provided dates are a range to aggregate over, not specific days to fetch
 pub async fn countries_views_get(
     req: HttpRequest,
-    clickhouse: web::Data<clickhouse::Client>,
+    clickhouse: web::Data<Option<clickhouse::Client>>,
     data: web::Query<GetData>,
     session_queue: web::Data<AuthQueue>,
     pool: web::Data<PgPool>,
@@ -523,13 +539,17 @@ pub async fn countries_views_get(
         filter_allowed_ids(project_ids, user, &pool, &redis, None).await?;
 
     // Get the countries
-    let countries = crate::clickhouse::fetch_countries_views(
-        project_ids.unwrap_or_default(),
-        start_date,
-        end_date,
-        clickhouse.into_inner(),
-    )
-    .await?;
+    let countries = if let Some(client) = clickhouse.get_ref().as_ref() {
+        crate::clickhouse::fetch_countries_views(
+            project_ids.unwrap_or_default(),
+            start_date,
+            end_date,
+            client,
+        )
+        .await?
+    } else {
+        Vec::new()
+    };
 
     let mut hm = HashMap::new();
     for views in countries {

--- a/apps/labrinth/tests/common/mod.rs
+++ b/apps/labrinth/tests/common/mod.rs
@@ -30,7 +30,7 @@ pub async fn setup(db: &database::TemporaryDatabase) -> LabrinthConfig {
     let search_config = db.search_config.clone();
     let file_host: Arc<dyn file_hosting::FileHost + Send + Sync> =
         Arc::new(file_hosting::MockHost::new());
-    let mut clickhouse = clickhouse::init_client().await.unwrap();
+    let clickhouse = Some(clickhouse::init_client().await.unwrap());
 
     let maxmind_reader =
         Arc::new(queue::maxmind::MaxMindIndexer::new().await.unwrap());
@@ -42,7 +42,7 @@ pub async fn setup(db: &database::TemporaryDatabase) -> LabrinthConfig {
         pool.clone(),
         redis_pool.clone(),
         search_config,
-        &mut clickhouse,
+        clickhouse,
         file_host.clone(),
         maxmind_reader,
         stripe_client,


### PR DESCRIPTION
This lets labrinth handle not being able to connect to ClickHouse. Useful for staging/local environments.

If the `CLICKHOUSE_HARD_FAIL` environment variable is set, labrinth will crash if a ClickHouse connection cannot be established.

cursor/gpt-5 wrote most of this