### PR TITLE
Prevent white flash while loading app

### DIFF
--- a/apps/app/src/main.rs
+++ b/apps/app/src/main.rs
@@ -191,6 +191,11 @@ fn main() {
         .plugin(
             tauri_plugin_window_state::Builder::default()
                 .with_filename("app-window-state.json")
+                // Use *only* POSITION and SIZE state flags, because saving VISIBLE causes the `visible: false` to not take effect
+                .with_state_flags(
+                    tauri_plugin_window_state::StateFlags::POSITION
+                        | tauri_plugin_window_state::StateFlags::SIZE,
+                )
                 .build(),
         )
         .setup(|app| {

--- a/apps/app/tauri.conf.json
+++ b/apps/app/tauri.conf.json
@@ -67,7 +67,7 @@
         "width": 1280,
         "minHeight": 700,
         "minWidth": 1100,
-        "visible": true,
+        "visible": false,
         "zoomHotkeysEnabled": false,
         "decorations": false
       }


### PR DESCRIPTION
I'd rather wait 500ms than see blank white for 500ms

It was a heck of a pain to implement since i tried so many things, turned out tauri-plugin-window-state was interefering
don't worry, i didn't just remove "the problem" :3

I whitelisted window POSITION and SIZE to get saved, but not the VISIBLE state, so that the the window can start with `visible: false`
the frontend was alr calling `show_window` after mounting which sets `visible` back to `true`, but since `visible` was `true` from the start, that was a useless invoke (except for `window.set_focus()` maybe)

Seeing this in prod would be much appreciated, or anything else that would remove the white flash, this may not be the best way

<details><summary>hmmm</summary>
<p>

"may" is the keyword :3

</p>
</details> 