### PR TITLE
fix: wsrv param rename

### DIFF
--- a/packages/utils/parse.ts
+++ b/packages/utils/parse.ts
@@ -87,6 +87,7 @@ export const configuredXss = new FilterXSS({
 
 				if (url.hostname.includes('wsrv.nl')) {
 					url.searchParams.delete('errorredirect')
+					url.searchParams.delete('default')
 				}
 
 				const allowedHostnames = [


### PR DESCRIPTION
wsrv depreacted `errorredirect ` in favor of  `default` so this adds `default` in addition to `errorredirect` to the checks