### PR TITLE
Fix IntelliJ import

### DIFF
--- a/.idea/code.iml
+++ b/.idea/code.iml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/apps/daedalus_client/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/packages/daedalus/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/apps/app-playground/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/apps/app/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/apps/labrinth/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/apps/labrinth/tests" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/packages/app-lib/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/packages/ariadne/src" isTestSource="false" />
+      <excludeFolder url="file://$MODULE_DIR$/target" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/code.iml" filepath="$PROJECT_DIR$/.idea/code.iml" />
+    </modules>
+  </component>
+</project>


### PR DESCRIPTION
#4193 removed files that are critical to IntelliJ successfully importing the project. Without these files, IntelliJ will ignore all the Rust code and only import the Java code.