### PR TITLE
Unnecessary space before a dot

### DIFF
--- a/apps/frontend/src/pages/dashboard/revenue/index.vue
+++ b/apps/frontend/src/pages/dashboard/revenue/index.vue
@@ -117,8 +117,7 @@
 			<p>
 				Tremendous payments are sent to your Modrinth email. To change/set your Modrinth email,
 				visit
-				<nuxt-link class="text-link" to="/settings/account">here</nuxt-link>
-				.
+				<nuxt-link class="text-link" to="/settings/account">here</nuxt-link>.
 			</p>
 			<h3>Venmo</h3>
 			<p>Enter your Venmo username below to enable withdrawing to your Venmo balance.</p>


### PR DESCRIPTION
In the Revenue page, there is an unnecessary space in the "Tramendous" text. More info in #4223 .