### PR TITLE
feat(labrinth): overhaul malware scanner report storage and routes

### DIFF
--- a/apps/frontend/nuxt.config.ts
+++ b/apps/frontend/nuxt.config.ts
@@ -149,7 +149,7 @@ export default defineNuxtConfig({
 				(state.errors ?? []).length === 0
 			) {
 				console.log(
-					'Tags already recently generated. Delete apps/frontend/generated/state.json to force regeneration.',
+					'Tags already recently generated. Delete apps/src/frontend/generated/state.json to force regeneration.',
 				)
 				return
 			}

--- a/apps/labrinth/.env.docker-compose
+++ b/apps/labrinth/.env.docker-compose
@@ -123,7 +123,7 @@ PYRO_API_KEY=none
 BREX_API_URL=https://platform.brexapis.com/v2/
 BREX_API_KEY=none
 
-DELPHI_URL=none
+DELPHI_URL=http://labrinth-delphi:8001
 DELPHI_SLACK_WEBHOOK=none
 
 ARCHON_URL=none

--- a/apps/labrinth/.env.local
+++ b/apps/labrinth/.env.local
@@ -123,7 +123,7 @@ PYRO_API_KEY=none
 BREX_API_URL=https://platform.brexapis.com/v2/
 BREX_API_KEY=none
 
-DELPHI_URL=none
+DELPHI_URL=http://delphi:8001
 DELPHI_SLACK_WEBHOOK=none
 
 ARCHON_URL=none

--- a/apps/labrinth/.sqlx/query-0080a101c9ae040adbaadf9e46fbc457a08e70dcde320c6852074819e41f8ad9.json
+++ b/apps/labrinth/.sqlx/query-0080a101c9ae040adbaadf9e46fbc457a08e70dcde320c6852074819e41f8ad9.json
@@ -1,0 +1,24 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO delphi_report_issue_java_classes (issue_id, internal_class_name, decompiled_source)\n            VALUES ($1, $2, $3)\n            ON CONFLICT (issue_id, internal_class_name) DO UPDATE SET decompiled_source = $3\n            RETURNING id\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "0080a101c9ae040adbaadf9e46fbc457a08e70dcde320c6852074819e41f8ad9"
+}

--- a/apps/labrinth/.sqlx/query-0ed2e6e3149352d12a673fddc50f9530c311eef084abb6fce35de5f37d79bcea.json
+++ b/apps/labrinth/.sqlx/query-0ed2e6e3149352d12a673fddc50f9530c311eef084abb6fce35de5f37d79bcea.json
@@ -1,0 +1,34 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT\n            version_id AS \"version_id: crate::database::models::DBVersionId\",\n            versions.mod_id AS \"project_id: crate::database::models::DBProjectId\",\n            files.url AS \"url\"\n        FROM files INNER JOIN versions ON files.version_id = versions.id\n        WHERE files.id = $1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "version_id: crate::database::models::DBVersionId",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "project_id: crate::database::models::DBProjectId",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 2,
+        "name": "url",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "0ed2e6e3149352d12a673fddc50f9530c311eef084abb6fce35de5f37d79bcea"
+}

--- a/apps/labrinth/.sqlx/query-10a332091be118f580d50ceb7a8724e9a4d5b9765d52305f99f859f939c2e854.json
+++ b/apps/labrinth/.sqlx/query-10a332091be118f580d50ceb7a8724e9a4d5b9765d52305f99f859f939c2e854.json
@@ -1,0 +1,63 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                INSERT INTO delphi_report_issues (report_id, issue_type, status)\n                VALUES ($1, $2, $3)\n                ON CONFLICT (report_id, issue_type) DO UPDATE SET status = $3\n                RETURNING id\n                ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        {
+          "Custom": {
+            "name": "delphi_report_issue_type",
+            "kind": {
+              "Enum": [
+                "reflection_indirection",
+                "xor_obfuscation",
+                "included_libraries",
+                "suspicious_binaries",
+                "corrupt_classes",
+                "suspicious_classes",
+                "url_usage",
+                "classloader_usage",
+                "processbuilder_usage",
+                "runtime_exec_usage",
+                "jni_usage",
+                "main_method",
+                "native_loading",
+                "malformed_jar",
+                "nested_jar_too_deep",
+                "failed_decompilation",
+                "analysis_failure",
+                "malware_easyforme",
+                "malware_simplyloader",
+                "unknown"
+              ]
+            }
+          }
+        },
+        {
+          "Custom": {
+            "name": "delphi_report_issue_status",
+            "kind": {
+              "Enum": [
+                "pending",
+                "approved",
+                "rejected"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "10a332091be118f580d50ceb7a8724e9a4d5b9765d52305f99f859f939c2e854"
+}

--- a/apps/labrinth/.sqlx/query-8f1f75d9c52a5a340aae2b3fd863153f5e9796b55ae753ab57b14f37708b400d.json
+++ b/apps/labrinth/.sqlx/query-8f1f75d9c52a5a340aae2b3fd863153f5e9796b55ae753ab57b14f37708b400d.json
@@ -1,0 +1,24 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO delphi_reports (file_id, delphi_version, artifact_url)\n            VALUES ($1, $2, $3)\n            ON CONFLICT (file_id, delphi_version) DO UPDATE SET\n                delphi_version = $2, artifact_url = $3, created = CURRENT_TIMESTAMP\n            RETURNING id\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Int4",
+        "Varchar"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "8f1f75d9c52a5a340aae2b3fd863153f5e9796b55ae753ab57b14f37708b400d"
+}

--- a/apps/labrinth/.sqlx/query-c1cd83ddcd112e46477a195e8bed0a1658c6ddf7a486082cdb847fab06150328.json
+++ b/apps/labrinth/.sqlx/query-c1cd83ddcd112e46477a195e8bed0a1658c6ddf7a486082cdb847fab06150328.json
@@ -1,0 +1,164 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                delphi_report_issues.id AS \"id\", report_id,\n                issue_type AS \"issue_type: DelphiReportIssueType\",\n                delphi_report_issues.status as \"status: DelphiReportIssueStatus\",\n\n                file_id, delphi_version, artifact_url, created,\n                json_array(SELECT to_jsonb(delphi_report_issue_java_classes)\n                    FROM delphi_report_issue_java_classes\n                    WHERE issue_id = delphi_report_issues.id\n                ) AS \"classes: sqlx::types::Json<Vec<DBDelphiReportIssueJavaClass>>\",\n                versions.mod_id AS \"project_id?\", mods.published AS \"project_published?\"\n            FROM delphi_report_issues\n            INNER JOIN delphi_reports ON delphi_reports.id = report_id\n            LEFT OUTER JOIN files ON files.id = file_id\n            LEFT OUTER JOIN versions ON versions.id = files.version_id\n            LEFT OUTER JOIN mods ON mods.id = versions.mod_id\n            WHERE\n                (issue_type = $1 OR $1 IS NULL)\n                AND (delphi_report_issues.status = $2 OR $2 IS NULL)\n            ORDER BY\n                CASE WHEN $3 = 'created_asc' THEN delphi_reports.created ELSE TO_TIMESTAMP(0) END ASC,\n                CASE WHEN $3 = 'created_desc' THEN delphi_reports.created ELSE TO_TIMESTAMP(0) END DESC,\n                CASE WHEN $3 = 'pending_status_first' THEN delphi_report_issues.status ELSE 'pending'::delphi_report_issue_status END ASC\n            OFFSET $5\n            LIMIT $4\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "report_id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 2,
+        "name": "issue_type: DelphiReportIssueType",
+        "type_info": {
+          "Custom": {
+            "name": "delphi_report_issue_type",
+            "kind": {
+              "Enum": [
+                "reflection_indirection",
+                "xor_obfuscation",
+                "included_libraries",
+                "suspicious_binaries",
+                "corrupt_classes",
+                "suspicious_classes",
+                "url_usage",
+                "classloader_usage",
+                "processbuilder_usage",
+                "runtime_exec_usage",
+                "jni_usage",
+                "main_method",
+                "native_loading",
+                "malformed_jar",
+                "nested_jar_too_deep",
+                "failed_decompilation",
+                "analysis_failure",
+                "malware_easyforme",
+                "malware_simplyloader",
+                "unknown"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 3,
+        "name": "status: DelphiReportIssueStatus",
+        "type_info": {
+          "Custom": {
+            "name": "delphi_report_issue_status",
+            "kind": {
+              "Enum": [
+                "pending",
+                "approved",
+                "rejected"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "file_id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 5,
+        "name": "delphi_version",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 6,
+        "name": "artifact_url",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "created",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 8,
+        "name": "classes: sqlx::types::Json<Vec<DBDelphiReportIssueJavaClass>>",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 9,
+        "name": "project_id?",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 10,
+        "name": "project_published?",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        {
+          "Custom": {
+            "name": "delphi_report_issue_type",
+            "kind": {
+              "Enum": [
+                "reflection_indirection",
+                "xor_obfuscation",
+                "included_libraries",
+                "suspicious_binaries",
+                "corrupt_classes",
+                "suspicious_classes",
+                "url_usage",
+                "classloader_usage",
+                "processbuilder_usage",
+                "runtime_exec_usage",
+                "jni_usage",
+                "main_method",
+                "native_loading",
+                "malformed_jar",
+                "nested_jar_too_deep",
+                "failed_decompilation",
+                "analysis_failure",
+                "malware_easyforme",
+                "malware_simplyloader",
+                "unknown"
+              ]
+            }
+          }
+        },
+        {
+          "Custom": {
+            "name": "delphi_report_issue_status",
+            "kind": {
+              "Enum": [
+                "pending",
+                "approved",
+                "rejected"
+              ]
+            }
+          }
+        },
+        "Text",
+        "Int8",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      null,
+      true,
+      true
+    ]
+  },
+  "hash": "c1cd83ddcd112e46477a195e8bed0a1658c6ddf7a486082cdb847fab06150328"
+}

--- a/apps/labrinth/.sqlx/query-fe571872262fe7d119b4b6eb1e55d818fde0499d8e5a08e9e22bee42014877f3.json
+++ b/apps/labrinth/.sqlx/query-fe571872262fe7d119b4b6eb1e55d818fde0499d8e5a08e9e22bee42014877f3.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT MAX(delphi_version) FROM delphi_reports",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "max",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "fe571872262fe7d119b4b6eb1e55d818fde0499d8e5a08e9e22bee42014877f3"
+}

--- a/apps/labrinth/migrations/20250810155316_delphi-reports.sql
+++ b/apps/labrinth/migrations/20250810155316_delphi-reports.sql
@@ -1,0 +1,64 @@
+CREATE TYPE delphi_report_issue_status AS ENUM ('pending', 'approved', 'rejected');
+
+CREATE TYPE delphi_report_issue_type AS ENUM (
+	'reflection_indirection',
+	'xor_obfuscation',
+	'included_libraries',
+	'suspicious_binaries',
+	'corrupt_classes',
+	'suspicious_classes',
+	'url_usage',
+	'classloader_usage',
+	'processbuilder_usage',
+	'runtime_exec_usage',
+	'jni_usage',
+	'main_method',
+	'native_loading',
+	'malformed_jar',
+	'nested_jar_too_deep',
+	'failed_decompilation',
+	'analysis_failure',
+	'malware_easyforme',
+	'malware_simplyloader',
+	'unknown'
+);
+
+-- A Delphi analysis report for a project version
+CREATE TABLE delphi_reports (
+	id BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+	file_id BIGINT REFERENCES files (id)
+		ON DELETE SET NULL
+		ON UPDATE CASCADE,
+	delphi_version INTEGER NOT NULL,
+	artifact_url VARCHAR(2048) NOT NULL,
+	created TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	UNIQUE (file_id, delphi_version)
+);
+CREATE INDEX delphi_version ON delphi_reports (delphi_version);
+
+-- An issue found in a Delphi report. Every issue belongs to a report,
+-- and a report can have zero, one, or more issues attached to it
+CREATE TABLE delphi_report_issues (
+	id BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+	report_id BIGINT NOT NULL REFERENCES delphi_reports (id)
+		ON DELETE CASCADE
+		ON UPDATE CASCADE,
+	issue_type DELPHI_REPORT_ISSUE_TYPE NOT NULL,
+	status DELPHI_REPORT_ISSUE_STATUS NOT NULL,
+	UNIQUE (report_id, issue_type)
+);
+CREATE INDEX delphi_report_issue_by_status_and_type ON delphi_report_issues (status, issue_type);
+
+-- A Java class affected by a Delphi report issue. Every affected
+-- Java class belongs to a specific issue, and an issue can have zero,
+-- one, or more affected classes. (Some issues may be artifact-wide,
+-- or otherwise not really specific to any particular class.)
+CREATE TABLE delphi_report_issue_java_classes (
+	id BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+	issue_id BIGINT NOT NULL REFERENCES delphi_report_issues (id)
+		ON DELETE CASCADE
+		ON UPDATE CASCADE,
+	internal_class_name TEXT NOT NULL,
+	decompiled_source TEXT NOT NULL,
+	UNIQUE (issue_id, internal_class_name)
+);

--- a/apps/labrinth/src/database/models/delphi_report_item.rs
+++ b/apps/labrinth/src/database/models/delphi_report_item.rs
@@ -1,0 +1,334 @@
+use std::{
+    fmt::{self, Display, Formatter},
+    ops::Deref,
+};
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::database::models::{
+    DBFileId, DBProjectId, DatabaseError, DelphiReportId, DelphiReportIssueId,
+    DelphiReportIssueJavaClassId,
+};
+
+/// A Delphi malware analysis report for a project version file.
+///
+/// Malware analysis reports usually belong to a specific project file,
+/// but they can get orphaned if the versions they belong to are deleted.
+/// Thus, deleting versions does not delete these reports.
+#[derive(Serialize)]
+pub struct DBDelphiReport {
+    pub id: DelphiReportId,
+    pub file_id: Option<DBFileId>,
+    /// A sequential, monotonically increasing version number for the
+    /// Delphi version that generated this report.
+    pub delphi_version: i32,
+    pub artifact_url: String,
+    pub created: DateTime<Utc>,
+}
+
+impl DBDelphiReport {
+    pub async fn upsert(
+        &self,
+        transaction: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    ) -> Result<DelphiReportId, DatabaseError> {
+        Ok(DelphiReportId(sqlx::query_scalar!(
+            "
+            INSERT INTO delphi_reports (file_id, delphi_version, artifact_url)
+            VALUES ($1, $2, $3)
+            ON CONFLICT (file_id, delphi_version) DO UPDATE SET
+                delphi_version = $2, artifact_url = $3, created = CURRENT_TIMESTAMP
+            RETURNING id
+            ",
+            self.file_id as Option<DBFileId>,
+            self.delphi_version,
+            self.artifact_url,
+        )
+        .fetch_one(&mut **transaction)
+        .await?))
+    }
+}
+
+/// An issue found in a Delphi report. Every issue belongs to a report,
+/// and a report can have zero, one, or more issues attached to it.
+#[derive(Deserialize, Serialize)]
+pub struct DBDelphiReportIssue {
+    pub id: DelphiReportIssueId,
+    pub report_id: DelphiReportId,
+    pub issue_type: DelphiReportIssueType,
+    pub status: DelphiReportIssueStatus,
+}
+
+/// An status a Delphi report issue can have.
+#[derive(
+    Deserialize, Serialize, Debug, Clone, Copy, PartialEq, Eq, Hash, sqlx::Type,
+)]
+#[serde(rename_all = "snake_case")]
+#[sqlx(type_name = "delphi_report_issue_status")]
+#[sqlx(rename_all = "snake_case")]
+pub enum DelphiReportIssueStatus {
+    /// The issue is pending review by the moderation team.
+    Pending,
+    /// The issue has been approved (i.e., reviewed as a valid, true positive).
+    /// The affected artifact has thus been verified to be potentially malicious.
+    Approved,
+    /// The issue has been rejected (i.e., reviewed as a false positive).
+    /// The affected artifact has thus been verified to be clean, other issues
+    /// with it notwithstanding.
+    Rejected,
+}
+
+impl Display for DelphiReportIssueStatus {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        self.serialize(f)
+    }
+}
+
+/// An order in which Delphi report issues can be sorted during queries.
+#[derive(Deserialize, Serialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum DelphiReportListOrder {
+    CreatedAsc,
+    CreatedDesc,
+    PendingStatusFirst,
+}
+
+impl Display for DelphiReportListOrder {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        self.serialize(f)
+    }
+}
+
+/// A result returned from a Delphi report issue query, slightly
+/// denormalized with related entity information for ease of
+/// consumption by clients.
+#[derive(Serialize)]
+pub struct DelphiReportIssueResult {
+    pub issue: DBDelphiReportIssue,
+    pub report: DBDelphiReport,
+    pub java_classes: Vec<DBDelphiReportIssueJavaClass>,
+    pub project_id: Option<DBProjectId>,
+    pub project_published: Option<DateTime<Utc>>,
+}
+
+impl DBDelphiReportIssue {
+    pub async fn upsert(
+        &self,
+        transaction: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    ) -> Result<DelphiReportIssueId, DatabaseError> {
+        Ok(DelphiReportIssueId(
+            sqlx::query_scalar!(
+                "
+                INSERT INTO delphi_report_issues (report_id, issue_type, status)
+                VALUES ($1, $2, $3)
+                ON CONFLICT (report_id, issue_type) DO UPDATE SET status = $3
+                RETURNING id
+                ",
+                self.report_id as DelphiReportId,
+                self.issue_type as DelphiReportIssueType,
+                self.status as DelphiReportIssueStatus,
+            )
+            .fetch_one(&mut **transaction)
+            .await?,
+        ))
+    }
+
+    pub async fn find_all_by(
+        ty: Option<DelphiReportIssueType>,
+        status: Option<DelphiReportIssueStatus>,
+        order_by: Option<DelphiReportListOrder>,
+        count: Option<u16>,
+        offset: Option<i64>,
+        exec: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
+    ) -> Result<Vec<DelphiReportIssueResult>, DatabaseError> {
+        Ok(sqlx::query!(
+            r#"
+            SELECT
+                delphi_report_issues.id AS "id", report_id,
+                issue_type AS "issue_type: DelphiReportIssueType",
+                delphi_report_issues.status as "status: DelphiReportIssueStatus",
+
+                file_id, delphi_version, artifact_url, created,
+                json_array(SELECT to_jsonb(delphi_report_issue_java_classes)
+                    FROM delphi_report_issue_java_classes
+                    WHERE issue_id = delphi_report_issues.id
+                ) AS "classes: sqlx::types::Json<Vec<DBDelphiReportIssueJavaClass>>",
+                versions.mod_id AS "project_id?", mods.published AS "project_published?"
+            FROM delphi_report_issues
+            INNER JOIN delphi_reports ON delphi_reports.id = report_id
+            LEFT OUTER JOIN files ON files.id = file_id
+            LEFT OUTER JOIN versions ON versions.id = files.version_id
+            LEFT OUTER JOIN mods ON mods.id = versions.mod_id
+            WHERE
+                (issue_type = $1 OR $1 IS NULL)
+                AND (delphi_report_issues.status = $2 OR $2 IS NULL)
+            ORDER BY
+                CASE WHEN $3 = 'created_asc' THEN delphi_reports.created ELSE TO_TIMESTAMP(0) END ASC,
+                CASE WHEN $3 = 'created_desc' THEN delphi_reports.created ELSE TO_TIMESTAMP(0) END DESC,
+                CASE WHEN $3 = 'pending_status_first' THEN delphi_report_issues.status ELSE 'pending'::delphi_report_issue_status END ASC
+            OFFSET $5
+            LIMIT $4
+            "#,
+            ty as Option<DelphiReportIssueType>,
+            status as Option<DelphiReportIssueStatus>,
+            order_by.map(|order_by| order_by.to_string()),
+            count.map(|count| count as i64),
+            offset,
+        )
+        .map(|row| DelphiReportIssueResult {
+            issue: DBDelphiReportIssue {
+                id: DelphiReportIssueId(row.id),
+                report_id: DelphiReportId(row.report_id),
+                issue_type: row.issue_type,
+                status: row.status,
+            },
+            report: DBDelphiReport {
+                id: DelphiReportId(row.report_id),
+                file_id: row.file_id.map(DBFileId),
+                delphi_version: row.delphi_version,
+                artifact_url: row.artifact_url,
+                created: row.created,
+            },
+            java_classes: row
+                .classes
+                .into_iter()
+                .flat_map(|class_list| class_list.0)
+                .collect(),
+            project_id: row.project_id.map(DBProjectId),
+            project_published: row.project_published,
+        })
+        .fetch_all(exec)
+        .await?)
+    }
+}
+
+/// A type of issue found by Delphi for an artifact.
+#[derive(
+    Deserialize, Serialize, Debug, Clone, Copy, PartialEq, Eq, Hash, sqlx::Type,
+)]
+#[serde(rename_all = "snake_case")]
+#[sqlx(type_name = "delphi_report_issue_type")]
+#[sqlx(rename_all = "snake_case")]
+pub enum DelphiReportIssueType {
+    ReflectionIndirection,
+    XorObfuscation,
+    IncludedLibraries,
+    SuspiciousBinaries,
+    CorruptClasses,
+    SuspiciousClasses,
+
+    UrlUsage,
+    ClassloaderUsage,
+    ProcessbuilderUsage,
+    RuntimeExecUsage,
+    #[serde(rename = "jni_usage")]
+    #[sqlx(rename = "jni_usage")]
+    JNIUsage,
+
+    MainMethod,
+    NativeLoading,
+
+    MalformedJar,
+    NestedJarTooDeep,
+    FailedDecompilation,
+    #[serde(alias = "ANALYSIS FAILURE!")]
+    AnalysisFailure,
+
+    MalwareEasyforme,
+    MalwareSimplyloader,
+
+    /// An issue reported by Delphi but not known by labrinth yet.
+    #[serde(other)]
+    Unknown,
+}
+
+impl Display for DelphiReportIssueType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        self.serialize(f)
+    }
+}
+
+/// A Java class affected by a Delphi report issue. Every affected
+/// Java class belongs to a specific issue, and an issue can have zero,
+/// one, or more affected classes. (Some issues may be artifact-wide,
+/// or otherwise not really specific to any particular class.)
+#[derive(Debug, Deserialize, Serialize)]
+pub struct DBDelphiReportIssueJavaClass {
+    pub id: DelphiReportIssueJavaClassId,
+    pub issue_id: DelphiReportIssueId,
+    pub internal_class_name: InternalJavaClassName,
+    pub decompiled_source: DecompiledJavaClassSource,
+}
+
+impl DBDelphiReportIssueJavaClass {
+    pub async fn upsert(
+        &self,
+        transaction: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    ) -> Result<DelphiReportIssueJavaClassId, DatabaseError> {
+        Ok(DelphiReportIssueJavaClassId(sqlx::query_scalar!(
+            "
+            INSERT INTO delphi_report_issue_java_classes (issue_id, internal_class_name, decompiled_source)
+            VALUES ($1, $2, $3)
+            ON CONFLICT (issue_id, internal_class_name) DO UPDATE SET decompiled_source = $3
+            RETURNING id
+            ",
+            self.issue_id as DelphiReportIssueId,
+            self.internal_class_name.0,
+            self.decompiled_source.0,
+        )
+        .fetch_one(&mut **transaction)
+        .await?))
+    }
+}
+
+/// A [Java class name] with dots replaced by forward slashes (/).
+///
+/// Because class names are usually the [binary names] passed to a classloader, top level interfaces and classes
+/// have a binary name that matches its canonical, fully qualified name, such canonical names are prefixed by the
+/// package path the class is in, and packages usually match the directory structure within a JAR for typical
+/// classloaders, this usually (but not necessarily) corresponds to the path to the class file within its JAR.
+///
+/// [Java class name]: https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/Class.html#getName()
+/// [binary names]: https://docs.oracle.com/javase/specs/jls/se21/html/jls-13.html#jls-13.1
+#[derive(
+    Deserialize, Serialize, Debug, Clone, PartialEq, Eq, Hash, sqlx::Type,
+)]
+#[serde(transparent)]
+#[sqlx(transparent)]
+pub struct InternalJavaClassName(String);
+
+impl Deref for InternalJavaClassName {
+    type Target = String;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Display for InternalJavaClassName {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// The decompiled source code of a Java class.
+#[derive(
+    Deserialize, Serialize, Debug, Clone, PartialEq, Eq, Hash, sqlx::Type,
+)]
+#[serde(transparent)]
+#[sqlx(transparent)]
+pub struct DecompiledJavaClassSource(String);
+
+impl Deref for DecompiledJavaClassSource {
+    type Target = String;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Display for DecompiledJavaClassSource {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}

--- a/apps/labrinth/src/database/models/ids.rs
+++ b/apps/labrinth/src/database/models/ids.rs
@@ -137,8 +137,8 @@ macro_rules! db_id_interface {
     };
 }
 
-macro_rules! short_id_type {
-    ($name:ident) => {
+macro_rules! id_type {
+    ($name:ident as $type:ty) => {
         #[derive(
             Copy,
             Clone,
@@ -151,7 +151,7 @@ macro_rules! short_id_type {
             Hash,
         )]
         #[sqlx(transparent)]
-        pub struct $name(pub i32);
+        pub struct $name(pub $type);
     };
 }
 
@@ -261,14 +261,17 @@ db_id_interface!(
     generator: generate_version_id @ "versions",
 );
 
-short_id_type!(CategoryId);
-short_id_type!(GameId);
-short_id_type!(LinkPlatformId);
-short_id_type!(LoaderFieldEnumId);
-short_id_type!(LoaderFieldEnumValueId);
-short_id_type!(LoaderFieldId);
-short_id_type!(LoaderId);
-short_id_type!(NotificationActionId);
-short_id_type!(ProjectTypeId);
-short_id_type!(ReportTypeId);
-short_id_type!(StatusId);
+id_type!(CategoryId as i32);
+id_type!(GameId as i32);
+id_type!(LinkPlatformId as i32);
+id_type!(LoaderFieldEnumId as i32);
+id_type!(LoaderFieldEnumValueId as i32);
+id_type!(LoaderFieldId as i32);
+id_type!(LoaderId as i32);
+id_type!(NotificationActionId as i32);
+id_type!(ProjectTypeId as i32);
+id_type!(ReportTypeId as i32);
+id_type!(StatusId as i32);
+id_type!(DelphiReportId as i64);
+id_type!(DelphiReportIssueId as i64);
+id_type!(DelphiReportIssueJavaClassId as i64);

--- a/apps/labrinth/src/database/models/mod.rs
+++ b/apps/labrinth/src/database/models/mod.rs
@@ -3,6 +3,7 @@ use thiserror::Error;
 pub mod categories;
 pub mod charge_item;
 pub mod collection_item;
+pub mod delphi_report_item;
 pub mod flow_item;
 pub mod friend_item;
 pub mod ids;

--- a/apps/labrinth/src/database/models/version_item.rs
+++ b/apps/labrinth/src/database/models/version_item.rs
@@ -6,6 +6,7 @@ use crate::database::models::loader_fields::{
 };
 use crate::database::redis::RedisPool;
 use crate::models::projects::{FileType, VersionStatus};
+use crate::routes::internal::delphi::DelphiRunParameters;
 use chrono::{DateTime, Utc};
 use dashmap::{DashMap, DashSet};
 use futures::TryStreamExt;
@@ -162,6 +163,15 @@ impl VersionFileBuilder {
             )
             .execute(&mut **transaction)
             .await?;
+        }
+
+        if let Err(err) = crate::routes::internal::delphi::run(
+            &mut **transaction,
+            DelphiRunParameters { file_id },
+        )
+        .await
+        {
+            tracing::error!("Error submitting new file to Delphi: {err}");
         }
 
         Ok(file_id)

--- a/apps/labrinth/src/routes/internal/admin.rs
+++ b/apps/labrinth/src/routes/internal/admin.rs
@@ -1,13 +1,10 @@
 use crate::auth::validate::get_user_record_from_bearer_token;
-use crate::database::models::thread_item::ThreadMessageBuilder;
 use crate::database::redis::RedisPool;
 use crate::models::analytics::Download;
 use crate::models::ids::ProjectId;
 use crate::models::pats::Scopes;
-use crate::models::threads::MessageBody;
 use crate::queue::analytics::AnalyticsQueue;
 use crate::queue::maxmind::MaxMindIndexer;
-use crate::queue::moderation::AUTOMOD_ID;
 use crate::queue::session::AuthQueue;
 use crate::routes::ApiError;
 use crate::search::SearchConfig;
@@ -17,17 +14,14 @@ use actix_web::{HttpRequest, HttpResponse, patch, post, web};
 use serde::Deserialize;
 use sqlx::PgPool;
 use std::collections::HashMap;
-use std::fmt::Write;
 use std::net::Ipv4Addr;
 use std::sync::Arc;
-use tracing::info;
 
 pub fn config(cfg: &mut web::ServiceConfig) {
     cfg.service(
         web::scope("admin")
             .service(count_download)
-            .service(force_reindex)
-            .service(delphi_result_ingest),
+            .service(force_reindex),
     );
 }
 
@@ -161,100 +155,5 @@ pub async fn force_reindex(
     use crate::search::indexing::index_projects;
     let redis = redis.get_ref();
     index_projects(pool.as_ref().clone(), redis.clone(), &config).await?;
-    Ok(HttpResponse::NoContent().finish())
-}
-
-#[derive(Deserialize)]
-pub struct DelphiIngest {
-    pub url: String,
-    pub project_id: crate::models::ids::ProjectId,
-    pub version_id: crate::models::ids::VersionId,
-    pub issues: HashMap<String, HashMap<String, String>>,
-}
-
-#[post("/_delphi", guard = "admin_key_guard")]
-pub async fn delphi_result_ingest(
-    pool: web::Data<PgPool>,
-    redis: web::Data<RedisPool>,
-    body: web::Json<DelphiIngest>,
-) -> Result<HttpResponse, ApiError> {
-    if body.issues.is_empty() {
-        info!("No issues found for file {}", body.url);
-        return Ok(HttpResponse::NoContent().finish());
-    }
-
-    let webhook_url = dotenvy::var("DELPHI_SLACK_WEBHOOK")?;
-
-    let project = crate::database::models::DBProject::get_id(
-        body.project_id.into(),
-        &**pool,
-        &redis,
-    )
-    .await?
-    .ok_or_else(|| {
-        ApiError::InvalidInput(format!(
-            "Project {} does not exist",
-            body.project_id
-        ))
-    })?;
-
-    let mut header = format!("Suspicious traces found at {}", body.url);
-
-    for (issue, trace) in &body.issues {
-        for (path, code) in trace {
-            write!(
-                &mut header,
-                "\n issue {issue} found at file {path}: \n ```\n{code}\n```"
-            )
-            .unwrap();
-        }
-    }
-
-    crate::util::webhook::send_slack_webhook(
-        body.project_id,
-        &pool,
-        &redis,
-        webhook_url,
-        Some(header),
-    )
-    .await
-    .ok();
-
-    let mut thread_header = format!(
-        "Suspicious traces found at [version {}](https://modrinth.com/project/{}/version/{})",
-        body.version_id, body.project_id, body.version_id
-    );
-
-    for (issue, trace) in &body.issues {
-        for path in trace.keys() {
-            write!(
-                &mut thread_header,
-                "\n\n- issue {issue} found at file {path}"
-            )
-            .unwrap();
-        }
-
-        if trace.is_empty() {
-            write!(&mut thread_header, "\n\n- issue {issue} found").unwrap();
-        }
-    }
-
-    let mut transaction = pool.begin().await?;
-    ThreadMessageBuilder {
-        author_id: Some(crate::database::models::DBUserId(AUTOMOD_ID)),
-        body: MessageBody::Text {
-            body: thread_header,
-            private: true,
-            replying_to: None,
-            associated_images: vec![],
-        },
-        thread_id: project.thread_id,
-        hide_identity: false,
-    }
-    .insert(&mut transaction)
-    .await?;
-
-    transaction.commit().await?;
-
     Ok(HttpResponse::NoContent().finish())
 }

--- a/apps/labrinth/src/routes/internal/delphi.rs
+++ b/apps/labrinth/src/routes/internal/delphi.rs
@@ -1,0 +1,265 @@
+use std::{collections::HashMap, fmt::Write, io, sync::LazyLock};
+
+use actix_web::{HttpResponse, get, post, put, web};
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+use sqlx::PgPool;
+use tracing::info;
+
+use crate::{
+    database::{
+        models::{
+            DBFileId, DelphiReportId, DelphiReportIssueId,
+            DelphiReportIssueJavaClassId,
+            delphi_report_item::{
+                DBDelphiReport, DBDelphiReportIssue,
+                DBDelphiReportIssueJavaClass, DecompiledJavaClassSource,
+                DelphiReportIssueStatus, DelphiReportIssueType,
+                DelphiReportListOrder, InternalJavaClassName,
+            },
+        },
+        redis::RedisPool,
+    },
+    routes::ApiError,
+    util::guards::admin_key_guard,
+};
+
+pub fn config(cfg: &mut web::ServiceConfig) {
+    cfg.service(
+        web::scope("delphi")
+            .service(ingest_report)
+            .service(_run)
+            .service(version)
+            .service(issues)
+            .service(update_issue),
+    );
+}
+
+#[derive(Deserialize)]
+struct DelphiReport {
+    pub url: String,
+    pub project_id: crate::models::ids::ProjectId,
+    #[serde(rename = "version_id")]
+    pub _version_id: crate::models::ids::VersionId,
+    pub file_id: crate::models::ids::FileId,
+    /// A sequential, monotonically increasing version number for the
+    /// Delphi version that generated this report.
+    pub delphi_version: i32,
+    pub issues: HashMap<
+        DelphiReportIssueType,
+        HashMap<InternalJavaClassName, DecompiledJavaClassSource>,
+    >,
+}
+
+impl DelphiReport {
+    async fn send_to_slack(
+        &self,
+        pool: &PgPool,
+        redis: &RedisPool,
+    ) -> Result<(), ApiError> {
+        let webhook_url = dotenvy::var("DELPHI_SLACK_WEBHOOK")?;
+
+        let mut message_header =
+            format!("⚠️ Suspicious traces found at {}", self.url);
+
+        for (issue, trace) in &self.issues {
+            for (path, code) in trace {
+                write!(
+                    &mut message_header,
+                    "\n issue {issue} found at file {path}:\n```\n{code}\n```"
+                )
+                .ok();
+            }
+        }
+
+        crate::util::webhook::send_slack_webhook(
+            self.project_id,
+            pool,
+            redis,
+            webhook_url,
+            Some(message_header),
+        )
+        .await
+    }
+}
+
+#[derive(Deserialize)]
+pub struct DelphiRunParameters {
+    pub file_id: crate::database::models::ids::DBFileId,
+}
+
+#[post("ingest", guard = "admin_key_guard")]
+async fn ingest_report(
+    pool: web::Data<PgPool>,
+    redis: web::Data<RedisPool>,
+    web::Json(report): web::Json<DelphiReport>,
+) -> Result<HttpResponse, ApiError> {
+    if report.issues.is_empty() {
+        info!("No issues found for file {}", report.url);
+        return Ok(HttpResponse::NoContent().finish());
+    }
+
+    report.send_to_slack(&pool, &redis).await.ok();
+
+    let mut transaction = pool.begin().await?;
+
+    let report_id = DBDelphiReport {
+        id: DelphiReportId(0), // This will be set by the database
+        file_id: Some(DBFileId(report.file_id.0 as i64)),
+        delphi_version: report.delphi_version,
+        artifact_url: report.url.clone(),
+        created: DateTime::<Utc>::MIN_UTC, // This will be set by the database
+    }
+    .upsert(&mut transaction)
+    .await?;
+
+    for (issue_type, issue_java_classes) in report.issues {
+        let issue_id = DBDelphiReportIssue {
+            id: DelphiReportIssueId(0), // This will be set by the database
+            report_id,
+            issue_type,
+            status: DelphiReportIssueStatus::Pending,
+        }
+        .upsert(&mut transaction)
+        .await?;
+
+        for (internal_class_name, decompiled_source) in issue_java_classes {
+            DBDelphiReportIssueJavaClass {
+                id: DelphiReportIssueJavaClassId(0), // This will be set by the database
+                issue_id,
+                internal_class_name,
+                decompiled_source,
+            }
+            .upsert(&mut transaction)
+            .await?;
+        }
+    }
+
+    transaction.commit().await?;
+
+    Ok(HttpResponse::NoContent().finish())
+}
+
+pub async fn run(
+    exec: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
+    run_parameters: DelphiRunParameters,
+) -> Result<HttpResponse, ApiError> {
+    let file_data = sqlx::query!(
+        r#"
+        SELECT
+            version_id AS "version_id: crate::database::models::DBVersionId",
+            versions.mod_id AS "project_id: crate::database::models::DBProjectId",
+            files.url AS "url"
+        FROM files INNER JOIN versions ON files.version_id = versions.id
+        WHERE files.id = $1
+        "#,
+        run_parameters.file_id.0
+    )
+    .fetch_one(exec)
+    .await?;
+
+    static DELPHI_CLIENT: LazyLock<reqwest::Client> =
+        LazyLock::new(reqwest::Client::new);
+
+    tracing::debug!(
+        "Running Delphi for project {}, version {}, file {}",
+        file_data.project_id.0,
+        file_data.version_id.0,
+        run_parameters.file_id.0
+    );
+
+    DELPHI_CLIENT
+        .post(dotenvy::var("DELPHI_URL")?)
+        .json(&serde_json::json!({
+            "url": file_data.url,
+            "project_id": file_data.project_id,
+            "version_id": file_data.version_id,
+            "file_id": run_parameters.file_id,
+        }))
+        .send()
+        .await
+        .and_then(|res| res.error_for_status())
+        .map_err(ApiError::Delphi)?;
+
+    Ok(HttpResponse::NoContent().finish())
+}
+
+#[post("run", guard = "admin_key_guard")]
+async fn _run(
+    pool: web::Data<PgPool>,
+    run_parameters: web::Query<DelphiRunParameters>,
+) -> Result<HttpResponse, ApiError> {
+    run(&**pool, run_parameters.into_inner()).await
+}
+
+#[get("version", guard = "admin_key_guard")]
+async fn version(pool: web::Data<PgPool>) -> Result<HttpResponse, ApiError> {
+    Ok(HttpResponse::Ok().json(
+        sqlx::query_scalar!("SELECT MAX(delphi_version) FROM delphi_reports")
+            .fetch_one(&**pool)
+            .await?,
+    ))
+}
+
+#[derive(Deserialize)]
+struct DelphiIssuesSearchOptions {
+    #[serde(rename = "type")]
+    ty: Option<DelphiReportIssueType>,
+    status: Option<DelphiReportIssueStatus>,
+    order_by: Option<DelphiReportListOrder>,
+    count: Option<u16>,
+    offset: Option<u64>,
+}
+
+#[get("issues", guard = "admin_key_guard")]
+async fn issues(
+    pool: web::Data<PgPool>,
+    search_options: web::Query<DelphiIssuesSearchOptions>,
+) -> Result<HttpResponse, ApiError> {
+    Ok(HttpResponse::Ok().json(
+        DBDelphiReportIssue::find_all_by(
+            search_options.ty,
+            search_options.status,
+            search_options.order_by,
+            search_options.count,
+            search_options
+                .offset
+                .map(|offset| offset.try_into())
+                .transpose()
+                .map_err(|err| {
+                    io::Error::other(format!("Invalid offset: {err}"))
+                })?,
+            &**pool,
+        )
+        .await?,
+    ))
+}
+
+#[put("issue/{issue_id}", guard = "admin_key_guard")]
+async fn update_issue(
+    pool: web::Data<PgPool>,
+    issue_id: web::Path<DelphiReportIssueId>,
+    web::Json(update_data): web::Json<DBDelphiReportIssue>,
+) -> Result<HttpResponse, ApiError> {
+    let new_id = issue_id.into_inner();
+
+    let mut transaction = pool.begin().await?;
+
+    let modified_same_issue = (DBDelphiReportIssue {
+        id: new_id, // Doesn't matter, upsert done for values of other fields
+        report_id: update_data.report_id,
+        issue_type: update_data.issue_type,
+        status: update_data.status,
+    })
+    .upsert(&mut transaction)
+    .await?
+        == new_id;
+
+    transaction.commit().await?;
+
+    if modified_same_issue {
+        Ok(HttpResponse::NoContent().finish())
+    } else {
+        Ok(HttpResponse::Created().finish())
+    }
+}

--- a/apps/labrinth/src/routes/internal/mod.rs
+++ b/apps/labrinth/src/routes/internal/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod admin;
 pub mod billing;
+pub mod delphi;
 pub mod flows;
 pub mod gdpr;
 pub mod medal;
@@ -26,6 +27,7 @@ pub fn config(cfg: &mut actix_web::web::ServiceConfig) {
             .configure(billing::config)
             .configure(gdpr::config)
             .configure(statuses::config)
-            .configure(medal::config),
+            .configure(medal::config)
+            .configure(delphi::config),
     );
 }

--- a/apps/labrinth/src/routes/mod.rs
+++ b/apps/labrinth/src/routes/mod.rs
@@ -145,6 +145,8 @@ pub enum ApiError {
     RateLimitError(u128, u32),
     #[error("Error while interacting with payment processor: {0}")]
     Stripe(#[from] stripe::StripeError),
+    #[error("Error while interacting with Delphi: {0}")]
+    Delphi(reqwest::Error),
 }
 
 impl ApiError {
@@ -179,6 +181,7 @@ impl ApiError {
                 ApiError::Io(..) => "io_error",
                 ApiError::RateLimitError(..) => "ratelimit_error",
                 ApiError::Stripe(..) => "stripe_error",
+                ApiError::Delphi(..) => "delphi_error",
             },
             description: self.to_string(),
         }
@@ -216,6 +219,7 @@ impl actix_web::ResponseError for ApiError {
             ApiError::Io(..) => StatusCode::BAD_REQUEST,
             ApiError::RateLimitError(..) => StatusCode::TOO_MANY_REQUESTS,
             ApiError::Stripe(..) => StatusCode::FAILED_DEPENDENCY,
+            ApiError::Delphi(..) => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
 

--- a/apps/labrinth/src/routes/v3/project_creation.rs
+++ b/apps/labrinth/src/routes/v3/project_creation.rs
@@ -332,9 +332,6 @@ async fn project_create_inner(
     redis: &RedisPool,
     session_queue: &AuthQueue,
 ) -> Result<HttpResponse, CreateError> {
-    // The base URL for files uploaded to S3
-    let cdn_url = dotenvy::var("CDN_URL")?;
-
     // The currently logged in user
     let current_user = get_user_from_headers(
         &req,
@@ -566,7 +563,6 @@ async fn project_create_inner(
                 uploaded_files,
                 &mut created_version.files,
                 &mut created_version.dependencies,
-                &cdn_url,
                 &content_disposition,
                 project_id,
                 created_version.version_id.into(),


### PR DESCRIPTION
## Overview

This PR introduces a comprehensive overhaul of Labrinth's integration with our in-house malware scanner, codenamed Delphi, replacing the previous basic webhook-based approach, which handled Delphi scan reports by sending Slack messages and posting text messages to project threads, with a more scalable, strongly-typed, database-backed report storage system that other systems can interact with via new REST API routes.

The goal of this overhaul is to lay the groundwork for enhanced project reviewer workflows related to Delphi reports. Such workflows require reviewers to search, filter, and sort reports for review independently of their associated projects, re-run Delphi analysis on existing projects, and track the review status of specific reports. With a proper backend system in place to support those actions, we expect to boost productivity and overall platform health by making it more efficient to moderate large volumes of projects to a consistently high standard.

## :sparkles: New HTTP Routes

All routes listed below require authentication through a fixed admin key passed in the `Modrinth-Admin` header, which Labrinth reads from the `LABRINTH_ADMIN_KEY` environment variable. For the default local deployment environment included with this repository, the key is `feedbeef`.

- **`POST /_internal/delphi/ingest`**: Receives malware analysis reports from the Delphi scanner, stores them in the database for future querying, and sends Slack notifications for them. This route supersedes the previous `POST /_internal/admin/_delphi` endpoint.
  - ⚠️ The ingest report object format has been modified in a backwards-incompatible way to require new `file_id` and `delphi_version` fields. The `file_id` field enables reports to be linked to their specific file within a version, improving traceability. The `delphi_version` field allows reports to be classified by the Delphi version that generated them, which is useful for re-analyzing suspicious projects after deploying improved Delphi detection capabilities, for example.

- **`POST /_internal/delphi/run?file_id=<id>`**: Requests Delphi to re-analyze the specified version file. If the current Delphi version is newer than the version used for the file's last analysis, a new report linked to the same project but a different Delphi version is created. Otherwise, the existing report is updated in-place with the new run's findings, and statuses of both new and repeated issues are reset to pending review.
  - ⚠️ As expected from the previous route's changes, a new `file_id` field is now included in the Delphi trigger webhook payload, which Delphi should handle gracefully.

- **`GET /_internal/delphi/version`**: Retrieves the latest Delphi version used for any report stored in the database as a JSON number. Returns `null` if no Delphi reports have been generated yet.

- **`GET /_internal/delphi/issues?type=<Delphi issue type>&status=<pending|approved|rejected>&order_by=<created_asc|created_desc|pending_status_first>&count=<N>&offset=<N>`**: Returns a JSON list of Delphi issue objects matching the specified criteria in the requested order. All query parameters are optional; when omitted, Labrinth applies no filtering, sorting, or count limits to the result list, depending on what was omitted. The `offset` parameter enables pagination.

<details>
<summary>Example issue list</summary>

```json
[
	{
		"issue": {
			"id": 1,
			"report_id": 4,
			"issue_type": "corrupt_classes",
			"status": "pending"
		},
		"report": {
			"id": 4,
			"file_id": 10703179305503,
			"delphi_version": 42,
			"artifact_url": "http://file_url",
			"created": "2025-08-19T22:05:22.916108Z"
		},
		"java_classes": [
			{
				"id": 1,
				"issue_id": 1,
				"internal_class_name": "MyClass",
				"decompiled_source": "// source"
			},
			{
				"id": 2,
				"issue_id": 1,
				"internal_class_name": "MyClass2",
				"decompiled_source": "// source 2"
			}
		],
		"project_id": 175294464254935,
		"project_published": "2025-08-19T21:35:06.314180Z"
	},
	{
		"issue": {
			"id": 2,
			"report_id": 4,
			"issue_type": "xor_obfuscation",
			"status": "pending"
		},
		"report": {
			"id": 4,
			"file_id": 10703179305503,
			"delphi_version": 42,
			"artifact_url": "http://file_url",
			"created": "2025-08-19T22:05:22.916108Z"
		},
		"java_classes": [],
		"project_id": 175294464254935,
		"project_published": "2025-08-19T21:35:06.314180Z"
	}
]
```

</details>

- **`PUT /_internal/delphi/issue/<issue ID>`**: Updates the specified Delphi issue object if it exists, or creates a new one if it doesn't. Clients can determine whether an issue was created or modified by checking the response code: `201 Created` indicates a new issue was created, while `204 No Content` indicates an existing issue was updated. This endpoint is intended for operations like changing the moderation status of specific issues.