### PR TITLE
Mark .editorconfig to use spaces for Rust code as the formatter does

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,13 +13,13 @@ max_line_length = 100
 indent_size = 2
 max_line_length = off
 
-[*.toml]
-indent_size = 2
-
-[*.json]
+[*.{toml,json}]
 indent_size = 2
 
 # YAML requires space indentation by spec
 [*.{yml,yaml}]
 indent_size = 2
+indent_style = space
+
+[*.rs]
 indent_style = space


### PR DESCRIPTION
`cargo fmt` uses spaces for indentation, so this PR makes .editorconfig also use spaces so that every file doesn't require reformatting on every commit.