### PR TITLE
fix: remove client side sorting of files

### DIFF
--- a/apps/frontend/src/components/ui/servers/FileItem.vue
+++ b/apps/frontend/src/components/ui/servers/FileItem.vue
@@ -78,8 +78,8 @@ import {
 } from '@modrinth/assets'
 import { ButtonStyled } from '@modrinth/ui'
 import { computed, ref, shallowRef } from 'vue'
-import { renderToString } from 'vue/server-renderer'
 import { useRoute, useRouter } from 'vue-router'
+import { renderToString } from 'vue/server-renderer'
 
 import {
 	UiServersIconsCodeFileIcon,
@@ -143,7 +143,7 @@ const codeExtensions = Object.freeze([
 	'go',
 ])
 
-const textExtensions = Object.freeze(['txt', 'md', 'log', 'cfg', 'conf', 'properties', 'ini'])
+const textExtensions = Object.freeze(['txt', 'md', 'log', 'cfg', 'conf', 'properties', 'ini', 'sk'])
 const imageExtensions = Object.freeze(['png', 'jpg', 'jpeg', 'gif', 'svg', 'webp'])
 const supportedArchiveExtensions = Object.freeze(['zip'])
 const units = Object.freeze(['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB'])

--- a/apps/frontend/src/components/ui/servers/FileItem.vue
+++ b/apps/frontend/src/components/ui/servers/FileItem.vue
@@ -78,8 +78,8 @@ import {
 } from '@modrinth/assets'
 import { ButtonStyled } from '@modrinth/ui'
 import { computed, ref, shallowRef } from 'vue'
-import { useRoute, useRouter } from 'vue-router'
 import { renderToString } from 'vue/server-renderer'
+import { useRoute, useRouter } from 'vue-router'
 
 import {
 	UiServersIconsCodeFileIcon,

--- a/apps/frontend/src/pages/servers/manage/[id]/files.vue
+++ b/apps/frontend/src/pages/servers/manage/[id]/files.vue
@@ -393,13 +393,13 @@ const fetchDirectoryContents = async (): Promise<DirectoryResponse> => {
 
 		if (currentPage.value === 1) {
 			return {
-				items: applyDefaultSort(data.items),
+				items: data.items,
 				total: data.total,
 			}
 		}
 
 		return {
-			items: [...(directoryData.value?.items || []), ...applyDefaultSort(data.items)],
+			items: [...(directoryData.value?.items || []), ...data.items],
 			total: data.total,
 		}
 	} catch (error) {
@@ -725,15 +725,6 @@ const handleCreateError = (error: any) => {
 			})
 		}
 	}
-}
-
-const applyDefaultSort = (items: DirectoryItem[]) => {
-	return items.sort((a: any, b: any) => {
-		if (a.type === 'directory' && b.type !== 'directory') return -1
-		if (a.type !== 'directory' && b.type === 'directory') return 1
-
-		return a.name.localeCompare(b.name)
-	})
 }
 
 const handleSort = (field: string) => {


### PR DESCRIPTION
This PR fixes the pagination issues on the files page of the server panel by relying on the backend's initial sorted file list rather than unessecarily sorting the files again for no reason.

Backend already sorts directories first, then files, with case-insensitive alphabetical ordering before paginating. Re-sorting on the client caused item order to shift across pages, making items appear missing until further scrolling.