### PR TITLE
More IDEA files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,9 @@ node_modules
 
 # IDE - IntelliJ
 .idea/*
-!.idea/modules.xml
 !.idea/code.iml
+!.idea/gradle.xml
+!.idea/modules.xml
 
 # misc
 /.sass-cache

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ node_modules
 !.idea/code.iml
 !.idea/gradle.xml
 !.idea/modules.xml
+!.idea/vcs.xml
 
 # misc
 /.sass-cache

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
+  <component name="GradleSettings">
+    <option name="linkedExternalProjectsSettings">
+      <GradleProjectSettings>
+        <option name="externalProjectPath" value="$PROJECT_DIR$/packages/app-lib/java" />
+        <option name="gradleJvm" value="#JAVA_HOME" />
+        <option name="modules">
+          <set>
+            <option value="$PROJECT_DIR$/packages/app-lib/java" />
+          </set>
+        </option>
+      </GradleProjectSettings>
+    </option>
+  </component>
+</project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="GradleMigrationSettings" migrationVersion="1" />
-  <component name="GradleSettings">
-    <option name="linkedExternalProjectsSettings">
-      <GradleProjectSettings>
-        <option name="externalProjectPath" value="$PROJECT_DIR$/packages/app-lib/java" />
-        <option name="gradleJvm" value="#JAVA_HOME" />
-        <option name="modules">
-          <set>
-            <option value="$PROJECT_DIR$/packages/app-lib/java" />
-          </set>
-        </option>
-      </GradleProjectSettings>
-    </option>
-  </component>
+	<component name="GradleMigrationSettings" migrationVersion="1"/>
+	<component name="GradleSettings">
+		<option name="linkedExternalProjectsSettings">
+			<GradleProjectSettings>
+				<option name="externalProjectPath" value="$PROJECT_DIR$/packages/app-lib/java"/>
+				<option name="gradleJvm" value="#JAVA_HOME"/>
+				<option name="modules">
+					<set>
+						<option value="$PROJECT_DIR$/packages/app-lib/java"/>
+					</set>
+				</option>
+			</GradleProjectSettings>
+		</option>
+	</component>
 </project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,8 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectModuleManager">
-    <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/code.iml" filepath="$PROJECT_DIR$/.idea/code.iml" />
-    </modules>
-  </component>
+	<component name="ProjectModuleManager">
+		<modules>
+			<module fileurl="file://$PROJECT_DIR$/.idea/code.iml"
+					filepath="$PROJECT_DIR$/.idea/code.iml"/>
+			<module fileurl="file://$PROJECT_DIR$/.idea/modules/theseus.iml"
+					filepath="$PROJECT_DIR$/.idea/modules/theseus.iml"/>
+			<module fileurl="file://$PROJECT_DIR$/.idea/modules/theseus.main.iml"
+					filepath="$PROJECT_DIR$/.idea/modules/theseus.main.iml"/>
+			<module fileurl="file://$PROJECT_DIR$/.idea/modules/theseus.test.iml"
+					filepath="$PROJECT_DIR$/.idea/modules/theseus.test.iml"/>
+		</modules>
+	</component>
 </project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,11 +2,13 @@
 <project version="4">
 	<component name="CommitMessageInspectionProfile">
 		<profile version="1.0">
-			<inspection_tool class="CommitFormat" enabled="true" level="WARNING" enabled_by_default="true" />
-			<inspection_tool class="CommitNamingConvention" enabled="true" level="WARNING" enabled_by_default="true" />
+			<inspection_tool class="CommitFormat" enabled="true" level="WARNING"
+							 enabled_by_default="true"/>
+			<inspection_tool class="CommitNamingConvention" enabled="true" level="WARNING"
+							 enabled_by_default="true"/>
 		</profile>
 	</component>
 	<component name="VcsDirectoryMappings">
-		<mapping directory="" vcs="Git" />
+		<mapping directory="" vcs="Git"/>
 	</component>
 </project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+	<component name="CommitMessageInspectionProfile">
+		<profile version="1.0">
+			<inspection_tool class="CommitFormat" enabled="true" level="WARNING" enabled_by_default="true" />
+			<inspection_tool class="CommitNamingConvention" enabled="true" level="WARNING" enabled_by_default="true" />
+		</profile>
+	</component>
+	<component name="VcsDirectoryMappings">
+		<mapping directory="" vcs="Git" />
+	</component>
+</project>


### PR DESCRIPTION
This adds back `gradle.xml` and `vcs.xml` for hopefully even more successful importing and branch switching with IntelliJ. This PR also reformats the committed IDEA files with our `.editorconfig`.