### PR TITLE
fix: reports of a version provide a broken link

### DIFF
--- a/apps/frontend/src/components/ui/moderation/ModerationDelphiReportCard.vue
+++ b/apps/frontend/src/components/ui/moderation/ModerationDelphiReportCard.vue
@@ -175,7 +175,7 @@ const quickActions: OverflowMenuOption[] = [
 ]
 
 const versionUrl = computed(() => {
-	return `/${props.report.project.project_type}/${props.report.project.slug}/versions/${props.report.version.id}`
+	return `/${props.report.project.project_type}/${props.report.project.slug}/version/${props.report.version.id}`
 })
 </script>
 

--- a/apps/frontend/src/components/ui/moderation/ModerationReportCard.vue
+++ b/apps/frontend/src/components/ui/moderation/ModerationReportCard.vue
@@ -259,7 +259,7 @@ const reportItemUrl = computed(() => {
 		case 'project':
 			return `/${props.report.project?.project_type}/${props.report.project?.slug}`
 		case 'version':
-			return `/${props.report.project?.project_type}/${props.report.project?.slug}/versions/${props.report.version?.id}`
+			return `/${props.report.project?.project_type}/${props.report.project?.slug}/version/${props.report.version?.id}`
 		default:
 			return `/${props.report.item_type}/${props.report.id}`
 	}


### PR DESCRIPTION
Previously, clicking the view button of a report of a version would lead to a 404 due to a typo in the returned versionUrl.  
This fixes that by directing to project/version/id.