### PR TITLE
Fix larger gallery image uploading

### DIFF
--- a/apps/frontend/src/pages/[type]/[id]/gallery.vue
+++ b/apps/frontend/src/pages/[type]/[id]/gallery.vue
@@ -15,7 +15,7 @@
 							class="iconified-button raised-button"
 							prompt="Replace"
 							:accept="acceptFileTypes"
-							:max-size="524288000"
+							:max-size="5242880"
 							should-always-reset
 							aria-label="Replace image"
 							@change="
@@ -197,7 +197,7 @@
 		</div>
 		<div v-if="currentMember" class="card header-buttons">
 			<FileInput
-				:max-size="524288000"
+				:max-size="5242880"
 				:accept="acceptFileTypes"
 				prompt="Upload an image"
 				aria-label="Upload an image"

--- a/apps/labrinth/src/routes/v3/project_creation.rs
+++ b/apps/labrinth/src/routes/v3/project_creation.rs
@@ -503,8 +503,8 @@ async fn project_create_inner(
                 if let Some(item) = gallery_items.iter().find(|x| x.item == name) {
                     let data = read_from_field(
                         &mut field,
-                        2 * (1 << 20),
-                        "Gallery image exceeds the maximum of 2MiB.",
+                        5 * (1 << 20),
+                        "Gallery image exceeds the maximum of 5MiB.",
                     )
                     .await?;
 

--- a/apps/labrinth/src/routes/v3/projects.rs
+++ b/apps/labrinth/src/routes/v3/projects.rs
@@ -1739,8 +1739,8 @@ pub async fn add_gallery_item(
 
     let bytes = read_limited_from_payload(
         &mut payload,
-        2 * (1 << 20),
-        "Gallery image exceeds the maximum of 2MiB.",
+        5 * (1 << 20),
+        "Gallery image exceeds the maximum of 5MiB.",
     )
     .await?;
 


### PR DESCRIPTION
This reconciles a couple of differences between the frontend and backend regarding gallery image uploads.

- Frontend: The frontend thought that the limit should be 500 MiB for gallery images. This is obviously not right. It has been updated to 5 MiB.
- Backend: The backend has been rejecting anything between 2 MiB and 5 MiB, but this is inconsistent with prior usage, where the limit used to be 5 MiB. It has been updated to allow anything under 5 MiB.

Fixes #4291
