### PR TITLE
tweak(labrinth/auth): improve Modrinth auth callback error message

### DIFF
--- a/apps/labrinth/src/auth/templates/error.html
+++ b/apps/labrinth/src/auth/templates/error.html
@@ -12,9 +12,10 @@
 			<h2>{{ code }}</h2>
 			<p>An error has occurred during the authentication process.</p>
 			<p>
-				Try closing this window and signing in again. Join
-				<a href="https://discord.modrinth.com">our Discord server</a> to get help if this error
-				persists after three attempts.
+				If you're not sure how to resolve this issue, try closing this window and signing in again.
+				If the problem persists after three attempts, please visit
+				<a href="https://support.modrinth.com">our support page</a> for assistance. The debug
+				information below may help you or our support team diagnose and fix the problem.
 			</p>
 			<p><b>Debug information:</b> {{ message }}</p>
 		</div>


### PR DESCRIPTION
[As one Discord user vividly described it](https://discord.com/channels/734077874708938864/734077874708938867/1411512531914063963):

> Can someone from Modrinth Team push the devs to change the message on this error to redirect people to the official support page instead of this Discord Server? It's dumb that this error message tells them to join here, and then we all tell them to go to the support page.
>
> <details>
> <summary>Error screenshot</summary>
> <img width="413" height="706" alt="Modrinth auth callback error page screenshot" src="https://github.com/user-attachments/assets/b48551e8-33c2-446a-b25d-da69f588b885" />
> </details>

Therefore, this PR tweaks the wording of that error message to help prevent "dumb" situations for users, directing them to the support page instead. They are also briefly suggested to consider the debug information attached in the message to help resolve the situation more efficiently for all parties involved.