### PR TITLE
tweak(labrinth): skip versions with unsupported loader fields on project-wide fields change

### DIFF
--- a/apps/labrinth/src/routes/v3/projects.rs
+++ b/apps/labrinth/src/routes/v3/projects.rs
@@ -880,7 +880,7 @@ pub async fn project_edit(
         )
         .await?
         {
-            super::versions::version_edit_helper(
+            match super::versions::version_edit_helper(
                 req.clone(),
                 (VersionId::from(version.inner.id),),
                 pool.clone(),
@@ -891,7 +891,16 @@ pub async fn project_edit(
                 },
                 session_queue.clone(),
             )
-            .await?;
+            .await
+            {
+                // An `InvalidInput` error being returned from this route when only
+                // editing the loader fields means that such fields are not valid for
+                // the loaders defined for this version, which is a common case for
+                // projects with heterogeneous loaders across versions and is best
+                // handled with opportunistic update semantics
+                Ok(_) | Err(ApiError::InvalidInput(_)) => continue,
+                err => return err,
+            }
         }
     }
 


### PR DESCRIPTION
## Overview

Currently, the v3 project PATCH route returns an error if a loader field that is not support by all project version loaders is modified. On its own, that behavior makes sense: you cannot set a loader field for a version whose loader does not support it, and an error enforces that invariant.

In practice, however, many projects include versions with heterogeneous loaders (data packs, Fabric mods, etc.), and aborting the entire operation as soon as an incompatible field is encountered results in a poor experience for frontend developers and, consequently, for users.

This PR improves how Labrinth handles such cases by ignoring errors that arise due to attempting to set an incompatible loader field value during the v3 project edit route. Instead, the specified field is applied successfully to as many compatible versions as possible. This opportunistic behavior better aligns with the expectations of frontend developers and users.

## Testing

I have verified that these changes allow the route to successfully set a project's environment, which is implemented as a per-version loader field, even when the project contains a mix of loaders, some of which support the field and some of which do not.