### PR TITLE
Disable fuzzy links to prevent unintended linkage when referring to files or version numbers that may appear like domains or IP addresses

### DIFF
--- a/packages/utils/parse.ts
+++ b/packages/utils/parse.ts
@@ -140,6 +140,11 @@ export const md = (options = {}) => {
 			return self.renderToken(tokens, idx, options)
 		}
 
+	md.linkify.set({
+		fuzzyLink: false,
+		fuzzyIP: false,
+	})
+
 	md.renderer.rules.link_open = function (tokens, idx, options, env, self) {
 		const token = tokens[idx]
 		const index = token.attrIndex('href')


### PR DESCRIPTION
Closes #1832