### PR TITLE
Revert decimal rounding order, fix profile settings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -228,7 +228,7 @@ wry = { git = "https://github.com/modrinth/wry", rev = "f2ce0b0" }
 opt-level = "s"   # Optimize for binary size
 strip = true      # Remove debug symbols
 lto = true        # Enables link to optimizations
-panic = "abort"   # Strip expensive panic clean-up logic
+panic = "unwind"   # Strip expensive panic clean-up logic
 codegen-units = 1 # Compile crates one after another so the compiler can optimize better
 
 [profile.dev.package.sqlx-macros]

--- a/apps/labrinth/src/routes/v3/payouts.rs
+++ b/apps/labrinth/src/routes/v3/payouts.rs
@@ -1028,7 +1028,9 @@ async fn get_user_balance(
         });
 
     Ok(UserBalance {
-        available: (available - withdrawn - fees).round_dp(16),
+        available: available.round_dp(16)
+            - withdrawn.round_dp(16)
+            - fees.round_dp(16),
         withdrawn_lifetime: withdrawn.round_dp(16),
         withdrawn_ytd: withdrawn_this_year.round_dp(16),
         pending,


### PR DESCRIPTION
This reverts the order of rounding in the `GET /v3/payout/balance` route handler back to what it was previously, since it appears to be causing crashes in labrinth although I'm not sure why. Obscure `rust_decimal` bug? Looking at its source code I don't find that theory very far-stretched. 

Also switched the `release` profile panic mode to `unwind` because `exit(2)`ing your production backend on error isn't a good idea actually

While looking at the `release` profile settings I noticed the other configuration options are set to questionable values. `opt-level = "s"`? But still using fat LTO + 1 codegen unit? Thin LTO (or even LTO off) + num_cpus codegen unit will likely offer nearly identical performance (especially for the type of application labrinth is) for fairly faster builds. And why opt-level = "s" in the first place? Can be addressed in a subsequent PR.