### PR TITLE
tweak(labrinth): create Clickhouse tables with a TTL for staging env

### DIFF
--- a/apps/labrinth/src/clickhouse/mod.rs
+++ b/apps/labrinth/src/clickhouse/mod.rs
@@ -74,9 +74,9 @@ pub async fn init_client_with_database(
                 headers Array(Tuple(String, String))
             )
             ENGINE = {engine}
+            {ttl}
             PRIMARY KEY (project_id, recorded, ip)
             SETTINGS index_granularity = 8192
-            {ttl}
             "
         ))
         .execute()
@@ -101,9 +101,9 @@ pub async fn init_client_with_database(
                 headers Array(Tuple(String, String))
             )
             ENGINE = {engine}
+            {ttl}
             PRIMARY KEY (project_id, recorded, ip)
             SETTINGS index_granularity = 8192
-            {ttl}
             "
         ))
         .execute()
@@ -126,9 +126,9 @@ pub async fn init_client_with_database(
                 parent UInt64
             )
             ENGINE = {engine}
+            {ttl}
             PRIMARY KEY (project_id, recorded, user_id)
             SETTINGS index_granularity = 8192
-            {ttl}
             "
         ))
         .execute()


### PR DESCRIPTION
## Overview

This PR supersedes #4167 and implements the approach I outlined in https://github.com/modrinth/code/pull/4167#pullrequestreview-3125342716 to handle our disk space usage problems in the staging environment in a better way.

Specifically, Labrinth now checks whether it is initializing a staging Clickhouse database, identified by the `staging_analytics` name. If so, it creates [Clickhouse tables with a 1-day TTL](https://clickhouse.com/docs/engines/table-engines/mergetree-family/mergetree#table_engine-mergetree-ttl), ensuring that old data rows are automatically discarded. The existing Clickhouse tables in the staging environment have already been manually migrated to use this TTL.

Since data in the staging environment is not expected to be long-lived, especially that living on Clickhouse, setting a short TTL for these tables represents a balanced tradeoff between environment parity, data persistence, and storage costs.

## Testing

I have tested that these changes had the expected effect on a local environment.
