### PR TITLE
fix(app): make Modrinth account SSO logins from the app work

### DIFF
--- a/apps/frontend/src/composables/auth.js
+++ b/apps/frontend/src/composables/auth.js
@@ -109,7 +109,7 @@ export const getAuthUrl = (provider, redirect = '/dashboard') => {
 	const route = useNativeRoute()
 
 	const fullURL = route.query.launcher
-		? 'https://launcher-files.modrinth.com'
+		? getLauncherRedirectUrl(route)
 		: `${config.public.siteUrl}/auth/sign-in?redirect=${redirect}`
 
 	return `${config.public.apiBaseUrl}auth/init?provider=${provider}&url=${encodeURIComponent(fullURL)}`
@@ -130,4 +130,13 @@ export const removeAuthProvider = async (provider) => {
 	await useAuth(auth.value.token)
 
 	stopLoading()
+}
+
+export const getLauncherRedirectUrl = (route) => {
+	const usesLocalhostRedirectionScheme =
+		['4', '6'].includes(route.query.ipver) && Number(route.query.port) < 65536
+
+	return usesLocalhostRedirectionScheme
+		? `http://${route.query.ipver === '4' ? '127.0.0.1' : '[::1]'}:${route.query.port}`
+		: `https://launcher-files.modrinth.com`
 }

--- a/apps/labrinth/.env.docker-compose
+++ b/apps/labrinth/.env.docker-compose
@@ -51,7 +51,7 @@ RATE_LIMIT_IGNORE_IPS='["127.0.0.1"]'
 
 WHITELISTED_MODPACK_DOMAINS='["cdn.modrinth.com", "github.com", "raw.githubusercontent.com"]'
 
-ALLOWED_CALLBACK_URLS='["localhost", ".modrinth.com", "127.0.0.1"]'
+ALLOWED_CALLBACK_URLS='["localhost", ".modrinth.com", "127.0.0.1", "[::1]"]'
 
 GITHUB_CLIENT_ID=none
 GITHUB_CLIENT_SECRET=none

--- a/apps/labrinth/.env.local
+++ b/apps/labrinth/.env.local
@@ -51,7 +51,7 @@ RATE_LIMIT_IGNORE_IPS='["127.0.0.1"]'
 
 WHITELISTED_MODPACK_DOMAINS='["cdn.modrinth.com", "github.com", "raw.githubusercontent.com"]'
 
-ALLOWED_CALLBACK_URLS='["localhost", ".modrinth.com", "127.0.0.1"]'
+ALLOWED_CALLBACK_URLS='["localhost", ".modrinth.com", "127.0.0.1", "[::1]"]'
 
 GITHUB_CLIENT_ID=none
 GITHUB_CLIENT_SECRET=none


### PR DESCRIPTION
## Overview

@triphora brought to my attention a support ticket where a user reported being unable to log in to their Modrinth account in the latest version of the Modrinth App when using an external SSO provider, GitHub, due to them being redirected to a non-existent web page.

While investigating, I discovered that the frontend code responsible for computing the redirect URL for SSO login providers was still returning the URL used by previous app versions, `https://launcher-files.modrinth.com`. However, newer app versions complete the login flow by receiving the auth token through a localhost URL. As a result, the authentication flow for SSO logins could not complete, leaving users stuck on an R2 bucket error page.

This PR updates the frontend logic so that redirect URLs for SSO logins are generated in the same way as for simple username-and-password logins. I have tested the behavior end to end to ensure that no regressions were introduced for the simple login flow, and proper query parameters are generated for SSO provider redirects.

This should resolve #4191. Fixes a regression introduced in #4033.

## :warning: Important Labrinth deployment note

The `ALLOWED_CALLBACK_URLS` environment variable must be updated to include both the `127.0.0.1` and `[::1]` hosts. Otherwise, SSO auth provider redirects to the local app server won't work.