### PR TITLE
Support longer "Sort by" for i18n on home page

### DIFF
--- a/apps/frontend/src/pages/index.vue
+++ b/apps/frontend/src/pages/index.vue
@@ -982,10 +982,14 @@ const creatorFeatureMessages = defineMessages({
 							display: flex;
 							gap: 0.75rem;
 							align-items: center;
-							min-width: 12.25rem;
+
+							.label {
+								white-space: nowrap;
+							}
 
 							.selector {
-								max-width: 8rem;
+								min-width: 8rem;
+								white-space: nowrap;
 							}
 
 							@media screen and (max-width: 500px) {


### PR DESCRIPTION
Before:
<img width="560" height="100" alt="before" src="https://github.com/user-attachments/assets/a0a192dc-43e2-41cc-bdf5-c2ae01da1cc7" />

After:
<img width="560" height="100" alt="after" src="https://github.com/user-attachments/assets/d912c59e-d9ca-4ba1-a99b-42a6bd251a58" />
