### PR TITLE
Use Nightly + Cranelift for dev, only fail on warnings in CI

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -14,13 +14,3 @@ rustflags = ["--cfg", "tokio_unstable", "-C", "link-args=/STACK:16777220"]
 
 [target.x86_64-pc-windows-msvc]
 linker = "rust-lld"
-
-[target.x86_64-unknown-linux-gnu]
-linker = "/usr/bin/clang"
-rustflags = [
-	"--cfg",
-	"tokio_unstable",
-	# Use mold linker to improve linking times
-	"-C",
-	"link-arg=--ld-path=/usr/bin/mold"
-]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,9 +1,26 @@
+# Enable Cranelift for debug builds, improving iterative compile times
+[unstable]
+codegen-backend = true
+
+[profile.dev]
+codegen-backend = "cranelift"
+
+[build]
+rustflags = ["--cfg", "tokio_unstable"]
+
 # Windows has stack overflows when calling from Tauri, so we increase the default stack size used by the compiler
 [target.'cfg(windows)']
-rustflags = ["-C", "link-args=/STACK:16777220", "--cfg", "tokio_unstable"]
+rustflags = ["--cfg", "tokio_unstable", "-C", "link-args=/STACK:16777220"]
 
 [target.x86_64-pc-windows-msvc]
 linker = "rust-lld"
 
-[build]
-rustflags = ["--cfg", "tokio_unstable"]
+[target.x86_64-unknown-linux-gnu]
+linker = "/usr/bin/clang"
+rustflags = [
+	"--cfg",
+	"tokio_unstable",
+	# Use mold linker to improve linking times
+	"-C",
+	"link-arg=--ld-path=/usr/bin/mold"
+]

--- a/.github/workflows/turbo-ci.yml
+++ b/.github/workflows/turbo-ci.yml
@@ -18,6 +18,11 @@ jobs:
       FORCE_COLOR: 3
       # Make cargo nextest successfully ignore projects without tests
       NEXTEST_NO_TESTS: pass
+      # Fail on warnings in CI
+      # (but don't do this in the root `Cargo.toml`,
+      # since we don't want warnings to become errors
+      # while developing)
+      RUSTFLAGS: -Dwarnings
 
     steps:
       - name: 📥 Check out code

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -218,10 +218,6 @@ todo = "warn"
 unnested_or_patterns = "warn"
 wildcard_dependencies = "warn"
 
-# [workspace.lints.rust]
-# # Turn warnings into errors by default
-# warnings = "deny"
-
 [patch.crates-io]
 wry = { git = "https://github.com/modrinth/wry", rev = "f2ce0b0" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -218,9 +218,9 @@ todo = "warn"
 unnested_or_patterns = "warn"
 wildcard_dependencies = "warn"
 
-[workspace.lints.rust]
-# Turn warnings into errors by default
-warnings = "deny"
+# [workspace.lints.rust]
+# # Turn warnings into errors by default
+# warnings = "deny"
 
 [patch.crates-io]
 wry = { git = "https://github.com/modrinth/wry", rev = "f2ce0b0" }

--- a/apps/labrinth/src/database/models/version_item.rs
+++ b/apps/labrinth/src/database/models/version_item.rs
@@ -1010,7 +1010,7 @@ mod tests {
 
     #[test]
     fn test_version_sorting() {
-        let versions = vec![
+        let versions = [
             get_version(4, None, months_ago(6)),
             get_version(3, None, months_ago(7)),
             get_version(2, Some(1), months_ago(6)),

--- a/apps/labrinth/src/routes/v2/version_creation.rs
+++ b/apps/labrinth/src/routes/v2/version_creation.rs
@@ -73,12 +73,6 @@ pub struct InitialVersionData {
     pub ordering: Option<i32>,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
-struct InitialFileData {
-    #[serde(default = "HashMap::new")]
-    pub file_types: HashMap<String, Option<FileType>>,
-}
-
 // under `/api/v1/version`
 #[post("version")]
 pub async fn version_create(

--- a/packages/app-lib/src/state/cache.rs
+++ b/packages/app-lib/src/state/cache.rs
@@ -519,11 +519,14 @@ impl CacheValue {
     }
 }
 
-#[derive(Deserialize, Serialize, PartialEq, Eq, Debug, Copy, Clone)]
+#[derive(
+    Deserialize, Serialize, PartialEq, Eq, Debug, Copy, Clone, Default,
+)]
 #[serde(rename_all = "snake_case")]
 pub enum CacheBehaviour {
     /// Serve expired data. If fetch fails / launcher is offline, errors are ignored
     /// and expired data is served
+    #[default]
     StaleWhileRevalidateSkipOffline,
     // Serve expired data, revalidate in background
     StaleWhileRevalidate,
@@ -531,12 +534,6 @@ pub enum CacheBehaviour {
     MustRevalidate,
     // Ignore cache- always fetch updated data from origin
     Bypass,
-}
-
-impl Default for CacheBehaviour {
-    fn default() -> Self {
-        Self::StaleWhileRevalidateSkipOffline
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,14 +1,8 @@
 [toolchain]
 channel = "nightly-2025-09-18"
+profile = "default"
 components = [
-	# standard components
-	"rustc",
-	"cargo",
-	"rustfmt",
-	"rust-std",
-	"rust-docs",
-	"rust-src",
-	"clippy",
+	"rust-analyzer",
 	# use cranelift in debug builds to improve compile times
 	# also see `.cargo/config.toml`
 	"rustc-codegen-cranelift-preview"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,8 @@
 [toolchain]
-channel = "1.89.0"
+channel = "nightly"
+
+components = [
+	# use cranelift in debug builds to improve compile times
+	# also see `.cargo/config.toml`
+	"rustc-codegen-cranelift-preview"
+]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,14 @@
 [toolchain]
-channel = "nightly"
-
+channel = "nightly-2025-09-18"
 components = [
+	# standard components
+	"rustc",
+	"cargo",
+	"rustfmt",
+	"rust-std",
+	"rust-docs",
+	"rust-src",
+	"clippy",
 	# use cranelift in debug builds to improve compile times
 	# also see `.cargo/config.toml`
 	"rustc-codegen-cranelift-preview"


### PR DESCRIPTION
Cranelift has much faster incremental recompiles, which helps when iterating on labrinth features.

Warnings are currently denied in the root Cargo.toml, which is good for rigorous CI but is annoying when quickly prototyping features and you don't mind some dead code or unused imports. This PR keeps warnings as warnings, but passes `-Dwarnings` in the CI test run to fail on warnings there.