### PR TITLE
feat(labrinth): hide orgs without a purpose, re-enable organization creation

### DIFF
--- a/apps/frontend/src/components/ui/OrganizationCreateModal.vue
+++ b/apps/frontend/src/components/ui/OrganizationCreateModal.vue
@@ -1,14 +1,7 @@
 <template>
 	<NewModal ref="modal" header="Creating an organization">
 		<div class="flex flex-col gap-3">
-			<Admonition
-				v-if="disabled"
-				class="max-w-[30rem]"
-				:type="'info'"
-				header="Organization creation temporarily disabled"
-				body="Due to abuse, we've temporarily disabled the creation of new organizations. We're working hard to restore this feature, thank you for your patience."
-			/>
-			<div class="flex flex-col gap-2" :class="{ 'opacity-50': disabled }">
+			<div class="flex flex-col gap-2">
 				<label for="name">
 					<span class="text-lg font-semibold text-contrast">
 						Name
@@ -22,11 +15,10 @@
 					maxlength="64"
 					:placeholder="`Enter organization name...`"
 					autocomplete="off"
-					:disabled="disabled"
 					@input="updateSlug"
 				/>
 			</div>
-			<div class="flex flex-col gap-2" :class="{ 'opacity-50': disabled }">
+			<div class="flex flex-col gap-2">
 				<label for="slug">
 					<span class="text-lg font-semibold text-contrast">
 						URL
@@ -41,12 +33,11 @@
 						type="text"
 						maxlength="64"
 						autocomplete="off"
-						:disabled="disabled"
 						@input="setManualSlug"
 					/>
 				</div>
 			</div>
-			<div class="flex flex-col gap-2" :class="{ 'opacity-50': disabled }">
+			<div class="flex flex-col gap-2">
 				<label for="additional-information" class="flex flex-col gap-1">
 					<span class="text-lg font-semibold text-contrast">
 						Summary
@@ -55,21 +46,16 @@
 					<span>A sentence or two that describes your organization.</span>
 				</label>
 				<div class="textarea-wrapper">
-					<textarea
-						id="additional-information"
-						v-model="description"
-						:disabled="disabled"
-						maxlength="256"
-					/>
+					<textarea id="additional-information" v-model="description" maxlength="256" />
 				</div>
 			</div>
-			<p class="m-0 max-w-[30rem]" :class="{ 'opacity-50': disabled }">
+			<p class="m-0 max-w-[30rem]">
 				You will be the owner of this organization, but you can invite other members and transfer
 				ownership at any time.
 			</p>
 			<div class="flex gap-2">
 				<ButtonStyled color="brand">
-					<button :disabled="disabled" @click="createOrganization">
+					<button @click="createOrganization">
 						<PlusIcon aria-hidden="true" />
 						Create organization
 					</button>
@@ -87,7 +73,7 @@
 
 <script setup lang="ts">
 import { PlusIcon, XIcon } from '@modrinth/assets'
-import { Admonition, ButtonStyled, injectNotificationManager, NewModal } from '@modrinth/ui'
+import { ButtonStyled, injectNotificationManager, NewModal } from '@modrinth/ui'
 import { ref } from 'vue'
 
 const router = useNativeRouter()
@@ -98,8 +84,6 @@ const slug = ref<string>('')
 const description = ref<string>('')
 const manualSlug = ref<boolean>(false)
 const modal = ref<InstanceType<typeof NewModal>>()
-
-const disabled = ref(true)
 
 async function createOrganization(): Promise<void> {
 	startLoading()

--- a/apps/labrinth/.env.local
+++ b/apps/labrinth/.env.local
@@ -129,7 +129,7 @@ PYRO_API_KEY=none
 BREX_API_URL=https://platform.brexapis.com/v2/
 BREX_API_KEY=none
 
-DELPHI_URL=none
+DELPHI_URL=http://localhost:59999
 DELPHI_SLACK_WEBHOOK=none
 
 AVALARA_1099_API_URL=https://www.track1099.com/api

--- a/apps/labrinth/.sqlx/query-eb792d5033d7079fe3555593d8731f8853235275e4d5614636b5db524a4920d5.json
+++ b/apps/labrinth/.sqlx/query-eb792d5033d7079fe3555593d8731f8853235275e4d5614636b5db524a4920d5.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT TRUE FROM mods WHERE organization_id = $1 AND status IN ('public', 'archived') LIMIT 1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "?column?",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "eb792d5033d7079fe3555593d8731f8853235275e4d5614636b5db524a4920d5"
+}

--- a/apps/labrinth/src/auth/checks.rs
+++ b/apps/labrinth/src/auth/checks.rs
@@ -384,7 +384,7 @@ pub async fn is_visible_organization(
     .unwrap_or(false);
 
     let visible = has_public_or_archived_projects
-        || members.iter().filter(|member| member.accepted).count() >= 2
+        || members.iter().filter(|member| member.accepted).count() > 1
         || viewing_user.as_ref().is_some_and(|viewing_user| {
             viewing_user.role.is_mod()
                 || members

--- a/apps/labrinth/src/auth/checks.rs
+++ b/apps/labrinth/src/auth/checks.rs
@@ -374,7 +374,9 @@ pub async fn is_visible_organization(
         DBTeamMember::get_from_team_full(organization.team_id, pool, redis)
             .await?;
 
-    let has_public_or_archived_projects = sqlx::query_scalar!(
+    // This is meant to match the same projects as the `Project::is_searchable` method, but we're not using
+    // it here because that'd entail pulling in all projects for the organization
+    let has_searchable_projects = sqlx::query_scalar!(
         "SELECT TRUE FROM mods WHERE organization_id = $1 AND status IN ('public', 'archived') LIMIT 1",
         organization.id as database::models::ids::DBOrganizationId
     )
@@ -383,7 +385,7 @@ pub async fn is_visible_organization(
     .flatten()
     .unwrap_or(false);
 
-    let visible = has_public_or_archived_projects
+    let visible = has_searchable_projects
         || members.iter().filter(|member| member.accepted).count() > 1
         || viewing_user.as_ref().is_some_and(|viewing_user| {
             viewing_user.role.is_mod()

--- a/apps/labrinth/src/models/v3/projects.rs
+++ b/apps/labrinth/src/models/v3/projects.rs
@@ -524,9 +524,13 @@ impl ProjectStatus {
     }
 
     // Project can be displayed in search
-    // IMPORTANT: if this is changed, make sure to update the `mods_searchable_ids_gist`
-    // index in the DB to keep random project queries fast (see the
-    // `20250609134334_spatial-random-project-index.sql` migration)
+    // IMPORTANT: if this is changed, make sure to:
+    // - update the `mods_searchable_ids_gist`
+    //   index in the DB to keep random project queries fast (see the
+    //   `20250609134334_spatial-random-project-index.sql` migration).
+    // - update the `is_visible_organization` function in
+    //   `apps/labrinth/src/auth/checks.rs`, which duplicates this logic
+    //   in a SQL query for efficiency.
     pub fn is_searchable(&self) -> bool {
         matches!(self, ProjectStatus::Approved | ProjectStatus::Archived)
     }

--- a/apps/labrinth/src/routes/v3/teams.rs
+++ b/apps/labrinth/src/routes/v3/teams.rs
@@ -1,4 +1,4 @@
-use crate::auth::checks::is_visible_project;
+use crate::auth::checks::{is_visible_organization, is_visible_project};
 use crate::auth::get_user_from_headers;
 use crate::database::DBProject;
 use crate::database::models::notification_item::NotificationBuilder;
@@ -134,18 +134,21 @@ pub async fn team_members_get_organization(
         crate::database::models::DBOrganization::get(&string, &**pool, &redis)
             .await?;
 
-    if let Some(organization) = organization_data {
-        let current_user = get_user_from_headers(
-            &req,
-            &**pool,
-            &redis,
-            &session_queue,
-            Scopes::ORGANIZATION_READ,
-        )
-        .await
-        .map(|x| x.1)
-        .ok();
+    let current_user = get_user_from_headers(
+        &req,
+        &**pool,
+        &redis,
+        &session_queue,
+        Scopes::ORGANIZATION_READ,
+    )
+    .await
+    .map(|x| x.1)
+    .ok();
 
+    if let Some(organization) = organization_data
+        && is_visible_organization(&organization, &current_user, &pool, &redis)
+            .await?
+    {
         let members_data = DBTeamMember::get_from_team_full(
             organization.team_id,
             &**pool,

--- a/apps/labrinth/tests/scopes.rs
+++ b/apps/labrinth/tests/scopes.rs
@@ -22,6 +22,7 @@ use common::environment::{
 use common::{database::*, scopes::ScopeTest};
 use labrinth::models::ids::ProjectId;
 use labrinth::models::pats::Scopes;
+use labrinth::models::teams::ProjectPermissions;
 use serde_json::json;
 // For each scope, we (using test_scope):
 // - create a PAT with a given set of scopes for a function
@@ -1093,6 +1094,7 @@ pub async fn organization_scopes() {
                 .await
                 .unwrap();
             let organization_id = success["id"].as_str().unwrap();
+            let organization_team_id = success["team_id"].as_str().unwrap();
 
             // Patch organization
             let organization_edit = Scopes::ORGANIZATION_WRITE;
@@ -1153,6 +1155,27 @@ pub async fn organization_scopes() {
                 .test(req_gen, organization_project_edit)
                 .await
                 .unwrap();
+
+            // Add two members to the organization
+            api.add_user_to_team(
+                organization_team_id,
+                FRIEND_USER_ID,
+                Some(ProjectPermissions::all()),
+                None,
+                USER_USER_PAT,
+            )
+            .await;
+            api.join_team(organization_team_id, FRIEND_USER_PAT).await;
+
+            api.add_user_to_team(
+                organization_team_id,
+                ENEMY_USER_ID,
+                Some(ProjectPermissions::all()),
+                None,
+                USER_USER_PAT,
+            )
+            .await;
+            api.join_team(organization_team_id, ENEMY_USER_PAT).await;
 
             // Organization reads
             let organization_read = Scopes::ORGANIZATION_READ;

--- a/apps/labrinth/tests/teams.rs
+++ b/apps/labrinth/tests/teams.rs
@@ -176,7 +176,7 @@ async fn test_get_team_organization() {
                 &test_env.dummy.organization_zeta.organization_id;
             let zeta_team_id = &test_env.dummy.organization_zeta.team_id;
 
-            // A non-member of the team should get basic info but not be able to see private data
+            // A non-member of the team should get basic team info
             let members = api
                 .get_team_members_deserialized_common(
                     zeta_team_id,
@@ -186,15 +186,6 @@ async fn test_get_team_organization() {
             assert_eq!(members.len(), 1);
             assert_eq!(members[0].user.id.0, USER_USER_ID_PARSED as u64);
             assert!(members[0].permissions.is_none());
-
-            let members = api
-                .get_organization_members_deserialized_common(
-                    zeta_organization_id,
-                    FRIEND_USER_PAT,
-                )
-                .await;
-            assert_eq!(members.len(), 1);
-            assert_eq!(members[0].user.id.0, USER_USER_ID_PARSED as u64);
 
             // A non-accepted member of the team should:
             // - not be able to see private data about the team, but see all members including themselves
@@ -257,15 +248,6 @@ async fn test_get_team_organization() {
             let members = api
                 .get_team_members_deserialized_common(
                     zeta_team_id,
-                    ENEMY_USER_PAT,
-                )
-                .await;
-            assert_eq!(members.len(), 1); // Only USER_USER_ID should be in the team
-
-            // enemy team check via association
-            let members = api
-                .get_organization_members_deserialized_common(
-                    zeta_organization_id,
                     ENEMY_USER_PAT,
                 )
                 .await;

--- a/packages/utils/changelog.ts
+++ b/packages/utils/changelog.ts
@@ -11,6 +11,12 @@ export type VersionEntry = {
 
 const VERSIONS: VersionEntry[] = [
 	{
+		date: `2025-09-26T13:00:00+02:00`,
+		product: 'web',
+		body: `### Improvements
+- Re-enabled the creation of Organizations.`,
+	},
+	{
 		date: `2025-09-25T19:15:00-07:00`,
 		product: 'web',
 		body: `### Improvements


### PR DESCRIPTION
## Overview

Bad actors have recently ramped up their abuse of the organization creation feature. This appears to be for SEO spam purposes, and it has become a problem to the point of having a significant impact on the Modrinth platform, forcing us to temporarily disable organization creation and take measures against it.

This PR is the first of those measures: it makes organizations not publicly visible until they fulfill a set of criteria that demonstrates they serve a legitimate purpose.

Because this PR makes spam organizations virtually useless, as they won't be publicly visible anymore, we expect malicious activities related to them to decrease significantly. For this reason, I've decided to re-enable the organization creation frontend as a part of it, minimizing disruption to legitimate users.