### PR TITLE
feat: split wrapper command on linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1342,9 +1342,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "cfg_aliases"
@@ -9024,6 +9024,7 @@ dependencies = [
  "base64 0.22.1",
  "bytemuck",
  "bytes",
+ "cfg-if",
  "chardetng",
  "chrono",
  "daedalus",
@@ -9062,6 +9063,7 @@ dependencies = [
  "serde_with",
  "sha1_smol",
  "sha2",
+ "shlex",
  "sqlx",
  "sysinfo",
  "tauri",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ bitflags = "2.9.1"
 bytemuck = "1.23.1"
 bytes = "1.10.1"
 censor = "0.3.0"
+cfg-if = "1.0.3"
 chardetng = "0.1.17"
 chrono = "0.4.41"
 clap = "4.5.43"
@@ -137,6 +138,7 @@ serde-xml-rs = "0.8.1" # Also an XML (de)serializer, consider dropping yaserde i
 sha1 = "0.10.6"
 sha1_smol = { version = "1.0.1", features = ["std"] }
 sha2 = "0.10.9"
+shlex = "1.3.0"
 spdx = "0.10.9"
 sqlx = { version = "0.8.6", default-features = false }
 sysinfo = { version = "0.36.1", default-features = false }

--- a/packages/app-lib/Cargo.toml
+++ b/packages/app-lib/Cargo.toml
@@ -36,6 +36,7 @@ rgb.workspace = true
 phf.workspace = true
 itertools.workspace = true
 derive_more = { workspace = true, features = ["display"] }
+cfg-if.workspace = true
 
 chrono = { workspace = true, features = ["serde"] }
 daedalus.workspace = true
@@ -115,6 +116,9 @@ ariadne.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 winreg.workspace = true
+
+[target.'cfg(unix)'.dependencies]
+shlex.workspace = true
 
 [build-dependencies]
 dotenvy.workspace = true


### PR DESCRIPTION
This allows specifying multiple commands, and arguments, as the wrapper command (i.e `gamemoderun mangohud --dlsym`) without having to create a separate script.
**Note**: this will break for people who have a space or quotes in their wrapper command (which could happen if they have a custom script with a space in the path)