### PR TITLE
"Create" modal i18n capitalization

### DIFF
--- a/apps/frontend/src/components/ui/create/CreateLimitAlert.vue
+++ b/apps/frontend/src/components/ui/create/CreateLimitAlert.vue
@@ -4,7 +4,7 @@
 		:type="hasHitLimit ? 'critical' : 'warning'"
 		:header="
 			hasHitLimit
-				? formatMessage(messages.limitReached, { type: capitalizeString(typeName.singular) })
+				? capitalizeString(formatMessage(messages.limitReached, { type: typeName.singular }))
 				: formatMessage(messages.approachingLimit, { type: typeName.singular, current, max })
 		"
 		class="mb-4"

--- a/apps/frontend/src/components/ui/create/ProjectCreateModal.vue
+++ b/apps/frontend/src/components/ui/create/ProjectCreateModal.vue
@@ -53,6 +53,7 @@
 					v-model="visibility"
 					:items="visibilities"
 					:format-label="(x) => x.display"
+					:capitalize="false"
 					:disabled="hasHitLimit"
 				/>
 			</div>


### PR DESCRIPTION
- Replaced `"{capitalize(type)} limit reached"` with `capitalize("{type} limit reached")` so the variable can be anywhere in the translation
- Made `:capitalize="false"` for the visibility chips because they are already capitalized by `(x) => x.display`. This allows several-word translations without capitalizing every word (e.g. `Not listed`)