### PR TITLE
Readd `MODRINTH_EXTERNAL_UPDATE_PROVIDER`

### DIFF
--- a/apps/app-frontend/src/App.vue
+++ b/apps/app-frontend/src/App.vue
@@ -453,7 +453,7 @@ const availableUpdate = ref(null)
 const updateSize = ref(null)
 async function checkUpdates() {
 	if (!(await areUpdatesEnabled())) {
-		console.log('Skipping update check as updates are disabled in this build')
+		console.log('Skipping update check as updates are disabled in this build or environment')
 		return
 	}
 

--- a/apps/app/src/main.rs
+++ b/apps/app/src/main.rs
@@ -67,6 +67,7 @@ fn is_dev() -> bool {
 #[tauri::command]
 fn are_updates_enabled() -> bool {
     cfg!(feature = "updater")
+        && env::var("MODRINTH_EXTERNAL_UPDATE_PROVIDER").is_err()
 }
 
 #[cfg(feature = "updater")]


### PR DESCRIPTION
#3960 mistakenly removed `MODRINTH_EXTERNAL_UPDATE_PROVIDER`. This PR brings it back.