### PR TITLE
App update fixes

### DIFF
--- a/apps/app-frontend/src/App.vue
+++ b/apps/app-frontend/src/App.vue
@@ -282,7 +282,7 @@ async function setupApp() {
 
 		const version = await getVersion()
 		if (pending_update_toast_for_version === version) {
-			notifications.addNotification({
+			addNotification({
 				type: 'success',
 				title: formatMessage(messages.updateInstalledToastTitle, { version }),
 				text: formatMessage(messages.updateInstalledToastText),

--- a/apps/app-frontend/src/components/ui/UpdateToast.vue
+++ b/apps/app-frontend/src/components/ui/UpdateToast.vue
@@ -69,13 +69,13 @@ const messages = defineMessages({
 </script>
 <template>
 	<div
-		class="fixed card-shadow rounded-2xl top-[--top-bar-height] mt-6 right-6 p-4 z-10 w-[25rem] bg-bg-raised border-divider border-solid border-[2px]"
+		class="grid grid-cols-[min-content] fixed card-shadow rounded-2xl top-[--top-bar-height] mt-6 right-6 p-4 z-10 bg-bg-raised border-divider border-solid border-[2px]"
 		:class="{
 			'download-complete': progress === 1,
 		}"
 	>
-		<div class="flex">
-			<h2 class="text-base text-contrast font-semibold m-0 grow">
+		<div class="flex min-w-[25rem] gap-4">
+			<h2 class="whitespace-nowrap text-base text-contrast font-semibold m-0 grow">
 				{{
 					formatMessage(metered && progress === 1 ? messages.downloadCompleteTitle : messages.title)
 				}}

--- a/apps/app-frontend/src/components/ui/modal/AppSettingsModal.vue
+++ b/apps/app-frontend/src/components/ui/modal/AppSettingsModal.vue
@@ -148,7 +148,7 @@ const messages = defineMessages({
 					<div class="mb-3">
 						<template v-if="progress > 0 && progress < 1">
 							<p class="m-0 mb-2">
-								{{ formatMessage(messages.downloading, { downloadingVersion }) }}
+								{{ formatMessage(messages.downloading, { version: downloadingVersion }) }}
 							</p>
 							<ProgressBar :progress="progress" />
 						</template>


### PR DESCRIPTION
- Fixed the installed update notification wasn't shown  because `notifications` was undefined
   - It seems like `clickAction` is not implemented because clicking the notification doesn't open the changelog. I didn't fix this
- Fixed missing variable in `Downloading v{version}`
- Adapted the update toast width for longer buttons or titles
  - Before:
    <img width="600" height="300" src="https://github.com/user-attachments/assets/ea01b865-4e37-4360-81b2-dee55832e795" />
  - After:
    <img width="600" height="300" src="https://github.com/user-attachments/assets/feedcd58-4678-4ece-8b0b-38f8c0613900" />

