### PR TITLE
fix(labrinth): hide hidden orgs from user profiles

### DIFF
--- a/apps/labrinth/src/routes/v3/users.rs
+++ b/apps/labrinth/src/routes/v3/users.rs
@@ -3,8 +3,8 @@ use std::{collections::HashMap, sync::Arc};
 use super::{ApiError, oauth_clients::get_user_clients};
 use crate::{
     auth::{
-        filter_visible_collections, filter_visible_projects,
-        get_user_from_headers,
+        checks::is_visible_organization, filter_visible_collections,
+        filter_visible_projects, get_user_from_headers,
     },
     database::{models::DBUser, redis::RedisPool},
     file_hosting::{FileHost, FileHostPublicity},
@@ -315,6 +315,10 @@ pub async fn orgs_list(
         }
 
         for data in organizations_data {
+            if !is_visible_organization(&data, &user, &pool, &redis).await? {
+                continue;
+            }
+
             let members_data =
                 team_groups.remove(&data.team_id).unwrap_or(vec![]);
             let logged_in = user


### PR DESCRIPTION
## Overview

This is a follow-up to PR #4426. I initially didn't consider the organizations an user belongs to as worth hiding, but given that user profiles can be public, I suppose there technically is a way to exploit them for SEO abuse. Overall, it also seems more consistent to hide them here too.