### PR TITLE
Fix user deletion with new notifications_deliveries table for real

### DIFF
--- a/apps/labrinth/src/database/models/user_item.rs
+++ b/apps/labrinth/src/database/models/user_item.rs
@@ -561,16 +561,6 @@ impl DBUser {
 
             sqlx::query!(
                 "
-                DELETE FROM notifications
-                WHERE user_id = $1
-                ",
-                id as DBUserId,
-            )
-            .execute(&mut **transaction)
-            .await?;
-
-            sqlx::query!(
-                "
                 DELETE FROM notifications_actions
                  WHERE notification_id = ANY($1)
                 ",
@@ -585,6 +575,16 @@ impl DBUser {
                 WHERE notification_id = ANY($1)
                 ",
                 &notifications
+            )
+            .execute(&mut **transaction)
+            .await?;
+
+            sqlx::query!(
+                "
+                DELETE FROM notifications
+                WHERE user_id = $1
+                ",
+                id as DBUserId,
             )
             .execute(&mut **transaction)
             .await?;


### PR DESCRIPTION
Maybe this will work? I dunno but users are still saying they're getting errors deleting accs. In theory it shouldn't matter if the transaction all gets committed at the same time, though, right? I can't really test this so I would like someone to tell me whether this will actually make a difference.
