### PR TITLE
tweak(path-util): addendum to #4482

### DIFF
--- a/packages/path-util/Cargo.toml
+++ b/packages/path-util/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 
 [dependencies]
 typed-path.workspace = true
-serde = { workspace = true, features = ["derive"] }
+serde.workspace = true
 derive_more = { workspace = true, features = ["display", "deref"] }
 itertools.workspace = true
 

--- a/packages/path-util/src/lib.rs
+++ b/packages/path-util/src/lib.rs
@@ -3,7 +3,9 @@ use serde::{
     Deserialize, Deserializer, Serialize, Serializer,
     de::value::StringDeserializer,
 };
-use typed_path::{Utf8Component, Utf8TypedPathBuf, Utf8UnixPathBuf};
+use typed_path::{
+    Utf8Component, Utf8TypedPathBuf, Utf8UnixComponent, Utf8UnixPathBuf,
+};
 
 #[derive(
     Eq, PartialEq, Hash, Debug, Clone, derive_more::Display, derive_more::Deref,
@@ -25,53 +27,24 @@ impl<'de> Deserialize<'de> for SafeRelativeUtf8UnixPathBuf {
             ));
         };
 
-        // At this point, we may have a pseudo-Unix path like `my\directory`, which we should reject
-        // to guarantee consistent cross-platform behavior when interpreting component separators
-        if path.as_str().contains('\\') {
-            return Err(serde::de::Error::custom(
-                "File path must not contain backslashes",
-            ));
-        }
-
         let mut path_components = path.components().peekable();
 
         if path_components.peek().is_none() {
             return Err(serde::de::Error::custom("File path cannot be empty"));
         }
 
-        // All components should be normal: a file or directory name, not `/`, `.`, or `..`
-        if path_components.any(|component| !component.is_normal()) {
-            return Err(serde::de::Error::custom(
-                "File path cannot contain any special component or prefix",
-            ));
-        }
-
-        if path_components.any(|component| {
-            let file_name = component.as_str().to_ascii_uppercase();
-
-            // Windows reserves some special DOS device names in every directory, which may be optionally
-            // followed by an extension or alternate data stream name and be case insensitive. Trying to
-            // write, read, or delete these files is usually not that useful even for malware, since they
-            // mostly refer to console and printer devices, but it's best to avoid them entirely anyway.
-            // References:
-            // https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions
-            // https://devblogs.microsoft.com/oldnewthing/20031022-00/?p=42073
-            // https://github.com/wine-mirror/wine/blob/01269452e0fbb1f081d506bd64996590a553e2b9/dlls/ntdll/path.c#L66
-            const RESERVED_WINDOWS_DEVICE_NAMES: &[&str] = &[
-                "CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4",
-                "COM5", "COM6", "COM7", "COM8", "COM9", "COM¹", "COM²", "COM³",
-                "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8",
-                "LPT9", "LPT¹", "LPT²", "LPT³", "CONIN$", "CONOUT$",
-            ];
-
-            RESERVED_WINDOWS_DEVICE_NAMES.iter().any(|name| {
-                file_name == *name
-                    || file_name.starts_with(&format!("{name}."))
-                    || file_name.starts_with(&format!("{name}:"))
-            })
+        // All components should be normal: a file or directory name, not `/`, `.`, or `..`,
+        // and not refer to any reserved Windows device name. Also, at this point we may have
+        // a pseudo-Unix path like `my\directory`, which we should reject by filtering out
+        // backslashes to guarantee consistent cross-platform behavior when interpreting component
+        // separators
+        if path_components.all(|component| {
+            component.is_normal()
+                && !component.as_str().contains('\\')
+                && !is_reserved_windows_device_name(&component)
         }) {
             return Err(serde::de::Error::custom(
-                "File path contains a reserved Windows device name",
+                "File path cannot contain any special component, prefix, reserved Windows device name, or backslashes",
             ));
         }
 
@@ -90,9 +63,13 @@ impl Serialize for SafeRelativeUtf8UnixPathBuf {
             return Err(serde::ser::Error::custom("File path cannot be empty"));
         }
 
-        if path_components.any(|component| !component.is_normal()) {
+        if path_components.all(|component| {
+            component.is_normal()
+                && !component.as_str().contains('\\')
+                && !is_reserved_windows_device_name(&component)
+        }) {
             return Err(serde::ser::Error::custom(
-                "File path cannot contain any special component or prefix",
+                "File path cannot contain any special component, prefix, reserved Windows device name, or backslashes",
             ));
         }
 
@@ -109,4 +86,30 @@ impl TryFrom<String> for SafeRelativeUtf8UnixPathBuf {
     fn try_from(s: String) -> Result<Self, Self::Error> {
         Self::deserialize(StringDeserializer::new(s))
     }
+}
+
+fn is_reserved_windows_device_name(component: &Utf8UnixComponent) -> bool {
+    let file_name = component.as_str().to_ascii_uppercase();
+
+    // Windows reserves some special DOS device names in every directory, which may be optionally
+    // followed by an extension or alternate data stream name and be case insensitive. Trying to
+    // write, read, or delete these files is usually not that useful even for malware, since they
+    // mostly refer to console and printer devices, but it's best to avoid them entirely anyway.
+    // References:
+    // https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions
+    // https://devblogs.microsoft.com/oldnewthing/20031022-00/?p=42073
+    // https://github.com/wine-mirror/wine/blob/01269452e0fbb1f081d506bd64996590a553e2b9/dlls/ntdll/path.c#L66
+    const RESERVED_WINDOWS_DEVICE_NAMES: &[&str] = &[
+        "CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4", "COM5",
+        "COM6", "COM7", "COM8", "COM9", "COM¹", "COM²", "COM³", "LPT1", "LPT2",
+        "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9", "LPT¹", "LPT²",
+        "LPT³", "CONIN$", "CONOUT$",
+    ];
+
+    RESERVED_WINDOWS_DEVICE_NAMES.iter().any(|name| {
+        file_name.starts_with(name)
+            && (file_name[name.len()..].is_empty()
+                || file_name[name.len()..].starts_with('.')
+                || file_name[name.len()..].starts_with(':'))
+    })
 }


### PR DESCRIPTION
These changes improve on those introduced in #4482 in two ways:

- The serialization logic for `SafeRelativeUtf8UnixPathBuf` now more closely mirrors the deserialization checks, reducing the chance that a generated path will fail to deserialize. While unlikely in practice, catching such theoretical cases earlier improves the experience for users and developers.
- After deeper testing on a clean Windows 10 VM, I found that reserved device names can have both an extension and an alternate data stream appended, not just one or the other. These changes handle that case more gracefully.