### PR TITLE
chore: revert back to stable Rust toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,9 +1,2 @@
 [toolchain]
-channel = "nightly-2025-09-18"
-profile = "default"
-components = [
-	"rust-analyzer",
-	# use cranelift in debug builds to improve compile times
-	# also see `.cargo/config.toml`
-	"rustc-codegen-cranelift-preview"
-]
+channel = "1.89.0"


### PR DESCRIPTION
PR #3960 reverted the Cranelift usage introduced in #4388 due to its codegen not being up to standard when compiling some pieces of code under some platforms. However, it didn't revert the switch to a nightly Rust toolchain, which is now unnecessary, and produces unnecessary drift between what's declared in the `rust-toolchain.toml` and the Docker image manifests, causing inefficiencies.

These changes bring back the usage of stable Rust for the time being to correct those inefficiencies.