### PR TITLE
fix(app): make MC <1.12.2 downloadable again

### DIFF
--- a/packages/app-lib/src/util/platform.rs
+++ b/packages/app-lib/src/util/platform.rs
@@ -1,65 +1,6 @@
 //! Platform-related code
 use daedalus::minecraft::{Os, OsRule};
 
-// OS detection
-pub trait OsExt {
-    /// Get the OS of the current system
-    fn native() -> Self;
-
-    /// Gets the OS + Arch of the current system
-    fn native_arch(java_arch: &str) -> Self;
-
-    /// Gets the OS from an OS + Arch
-    fn get_os(&self) -> Self;
-}
-
-impl OsExt for Os {
-    fn native() -> Self {
-        match std::env::consts::OS {
-            "windows" => Self::Windows,
-            "macos" => Self::Osx,
-            "linux" => Self::Linux,
-            _ => Self::Unknown,
-        }
-    }
-
-    fn native_arch(java_arch: &str) -> Self {
-        if std::env::consts::OS == "windows" {
-            if java_arch == "aarch64" {
-                Os::WindowsArm64
-            } else {
-                Os::Windows
-            }
-        } else if std::env::consts::OS == "linux" {
-            if java_arch == "aarch64" {
-                Os::LinuxArm64
-            } else if java_arch == "arm" {
-                Os::LinuxArm32
-            } else {
-                Os::Linux
-            }
-        } else if std::env::consts::OS == "macos" {
-            if java_arch == "aarch64" {
-                Os::OsxArm64
-            } else {
-                Os::Osx
-            }
-        } else {
-            Os::Unknown
-        }
-    }
-
-    fn get_os(&self) -> Self {
-        match self {
-            Os::OsxArm64 => Os::Osx,
-            Os::LinuxArm32 => Os::Linux,
-            Os::LinuxArm64 => Os::Linux,
-            Os::WindowsArm64 => Os::Windows,
-            _ => self.clone(),
-        }
-    }
-}
-
 // Bit width
 #[cfg(target_pointer_width = "64")]
 pub const ARCH_WIDTH: &str = "64";


### PR DESCRIPTION
PR #4270 modified the internal `fetch` function used by the application to download version artifacts in a way that 4xx HTTP errors also caused an abnormal return, instead of just 5xx errors. That was a good change, but it had the unintended side effect of exposing our faulty logic elsewhere of trying to download non-native JAR library artifacts when only native artifacts are appropriate, at least according to the PrismLauncher source code I've read. Such a download always returned a 404 error, but because such error was considered successful, a dummy library file was still created and things worked seemingly fine.

These changes bring the Modrinth App behavior in this regard more in line with PrismLauncher's, avoiding downloading non-native artifacts for dependencies that have native artifacts available. (Reference: https://github.com/PrismLauncher/PrismLauncher/blob/8b5e91920dda7324ad3db98f56b209bba0f4e57d/launcher/minecraft/Library.cpp#L163)

I've tested these changes to work successfully with a variety old Minecraft versions, including Fabric 1.14, vanilla 1.8.9, vanilla 1.13.2, Forge 1.12.2, vanilla 1.19, and vanilla 1.2.5.

Fixes #4464.