### PR TITLE
refactor(app): reduce tech debt by eliminating `wry` fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9328,6 +9328,8 @@ dependencies = [
  "url",
  "urlencoding",
  "uuid 1.18.1",
+ "webview2-com",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -11677,8 +11679,3 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
 ]
-
-[[patch.unused]]
-name = "wry"
-version = "0.52.1"
-source = "git+https://github.com/modrinth/wry?rev=f2ce0b0#f2ce0b0105d9d94f482c4f8ecffb4f3c3c325b40"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,6 +182,7 @@ webp = { version = "0.3.0", default-features = false }
 whoami = "1.6.0"
 windows = "0.61.3"
 windows-core = "0.61.2"
+webview2-com = "0.38.0" # Should be updated in lockstep with wry
 winreg = "0.55.0"
 woothee = "0.13.0"
 yaserde = "0.12.0"
@@ -227,9 +228,6 @@ redundant_type_annotations = "warn"
 todo = "warn"
 unnested_or_patterns = "warn"
 wildcard_dependencies = "warn"
-
-[patch.crates-io]
-wry = { git = "https://github.com/modrinth/wry", rev = "f2ce0b0" }
 
 # Optimize for speed and reduce size on release builds
 [profile.release]

--- a/apps/app/Cargo.toml
+++ b/apps/app/Cargo.toml
@@ -51,6 +51,10 @@ native-dialog.workspace = true
 [target.'cfg(target_os = "linux")'.dependencies]
 tauri-plugin-updater = { workspace = true, optional = true }
 
+[target.'cfg(windows)'.dependencies]
+webview2-com.workspace = true
+windows-core.workspace = true
+
 [features]
 # by default Tauri runs in production mode
 # when `tauri dev` runs it is executed with `cargo run --no-default-features` if `devPath` is an URL


### PR DESCRIPTION
## Overview

We currently maintain our [own fork of `wry`](https://github.com/modrinth/wry) with three significant changes:

- [A change for injecting initialization scripts in every frame of the ads webview](https://github.com/tauri-apps/wry/commit/e88d4a10286f58902f50d5dc6c11363220a8be10), which can now be achieved using the standard [`WebviewWindowBuilder#initialization_script_for_all_frames` method](https://docs.rs/tauri/latest/tauri/webview/struct.WebviewWindowBuilder.html#method.initialization_script_for_all_frames).
- [A change for ensuring that the ads webview remains muted on Windows platforms](https://github.com/tauri-apps/wry/commit/cdbf9384263db4e692e22dcf9bf6085e334a10f3), which can be replaced by obtaining the native platform webview object via Tauri's [`Webview#with_webview` method](https://docs.rs/tauri/latest/tauri/webview/struct.Webview.html#method.with_webview) and calling the corresponding [native API](https://docs.rs/webview2-com/latest/webview2_com/Microsoft/Web/WebView2/Win32/struct.ICoreWebView2_8.html#method.SetIsMuted).
- [A change for blocking popup windows from opening](https://github.com/tauri-apps/wry/commit/51907c61541f2e389856f07773a32bac04f9a843), which can be replaced by the standard [`WebviewBuilder#on_new_window` method](https://docs.rs/tauri/latest/tauri/webview/struct.WebviewBuilder.html#method.on_new_window).

Since all these changes can now be implemented using standard APIs that don't require forking, and our `wry` fork is no longer being used in the latest release version (someone updated our `Cargo.lock` to use a newer upstream version, causing a build warning about the unused patch), this PR implements these changes using the discussed standard APIs, eliminating the maintenance burden of keeping our fork up to date, and preventing such patching failures from going unnoticed in the future.