### PR TITLE
perf(Dockerfile): improve Docker cache mounts usage

### DIFF
--- a/apps/daedalus_client/Dockerfile
+++ b/apps/daedalus_client/Dockerfile
@@ -5,15 +5,14 @@ FROM rust:1.89.0 AS build
 WORKDIR /usr/src/daedalus
 COPY . .
 RUN --mount=type=cache,target=/usr/src/daedalus/target \
-  --mount=type=cache,target=/usr/local/cargo/git/db \
-  --mount=type=cache,target=/usr/local/cargo/registry \
-  cargo build --release --package daedalus_client
+	--mount=type=cache,target=/usr/local/cargo,from=rust:1.89.0,source=/usr/local/cargo \
+	cargo build --release --package daedalus_client
 
 FROM build AS artifacts
 
 RUN --mount=type=cache,target=/usr/src/daedalus/target \
-  mkdir /daedalus \
-  && cp /usr/src/daedalus/target/release/daedalus_client /daedalus/daedalus_client
+	mkdir /daedalus \
+	&& cp /usr/src/daedalus/target/release/daedalus_client /daedalus/daedalus_client
 
 FROM debian:bookworm-slim
 
@@ -23,8 +22,8 @@ LABEL org.opencontainers.image.description="Modrinth game metadata query client"
 LABEL org.opencontainers.image.licenses=MIT
 
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends ca-certificates openssl \
-  && rm -rf /var/lib/apt/lists/*
+	&& apt-get install -y --no-install-recommends ca-certificates openssl \
+	&& rm -rf /var/lib/apt/lists/*
 
 COPY --from=artifacts /daedalus /daedalus
 

--- a/apps/labrinth/Dockerfile
+++ b/apps/labrinth/Dockerfile
@@ -6,17 +6,16 @@ WORKDIR /usr/src/labrinth
 COPY . .
 ARG GIT_HASH
 RUN --mount=type=cache,target=/usr/src/labrinth/target \
-  --mount=type=cache,target=/usr/local/cargo/git/db \
-  --mount=type=cache,target=/usr/local/cargo/registry \
-  SQLX_OFFLINE=true cargo build --profile release-labrinth --package labrinth
+	--mount=type=cache,target=/usr/local/cargo,from=rust:1.89.0,source=/usr/local/cargo \
+	SQLX_OFFLINE=true cargo build --profile release-labrinth --package labrinth
 
 FROM build AS artifacts
 
 RUN --mount=type=cache,target=/usr/src/labrinth/target \
-  mkdir /labrinth \
-  && cp /usr/src/labrinth/target/release-labrinth/labrinth /labrinth/labrinth \
-  && cp -r /usr/src/labrinth/apps/labrinth/migrations /labrinth \
-  && cp -r /usr/src/labrinth/apps/labrinth/assets /labrinth
+	mkdir /labrinth \
+	&& cp /usr/src/labrinth/target/release-labrinth/labrinth /labrinth/labrinth \
+	&& cp -r /usr/src/labrinth/apps/labrinth/migrations /labrinth \
+	&& cp -r /usr/src/labrinth/apps/labrinth/assets /labrinth
 
 FROM debian:bookworm-slim
 
@@ -26,8 +25,8 @@ LABEL org.opencontainers.image.description="Modrinth API"
 LABEL org.opencontainers.image.licenses=AGPL-3.0-only
 
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends ca-certificates dumb-init curl \
-  && rm -rf /var/lib/apt/lists/*
+	&& apt-get install -y --no-install-recommends ca-certificates dumb-init curl \
+	&& rm -rf /var/lib/apt/lists/*
 
 COPY --from=artifacts /labrinth /labrinth
 


### PR DESCRIPTION
As described in https://hackmd.io/jgkoQ24YRW6i0xWd73S64A#Using-Docker-cache-mounts, cache mounts need to be used with a fairly specific syntax for caching of previously build Rust artifacts to be as effective as it can be.

I've tested these changes to be effective at reducing the time it takes for a Docker build to complete when a hot build cache is available.