### PR TITLE
Restart the app after updates if the updater didn't do it for us

### DIFF
--- a/.idea/code.iml
+++ b/.idea/code.iml
@@ -11,6 +11,7 @@
       <sourceFolder url="file://$MODULE_DIR$/apps/labrinth/tests" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/packages/app-lib/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/packages/ariadne/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/packages/path-util/src" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="inheritedJdk" />

--- a/apps/app/src/main.rs
+++ b/apps/app/src/main.rs
@@ -278,6 +278,7 @@ fn main() {
                                 .show()
                                 .unwrap();
                         }
+                        app.restart();
                     }
                 }
 


### PR DESCRIPTION
On Windows, the process will be forcefully exited after the update by `tauri-plugin-updater`, so no platform-specific checks are needed on our end.