### PR TITLE
fix(labrinth): make orgs with a single user and only approved projects visible to non-logged-in people

### DIFF
--- a/apps/labrinth/.sqlx/query-829a4523233e957f8876d248a17ec04c245af41f43fa40aff9ee07e893dabf3a.json
+++ b/apps/labrinth/.sqlx/query-829a4523233e957f8876d248a17ec04c245af41f43fa40aff9ee07e893dabf3a.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT TRUE FROM mods WHERE organization_id = $1 AND status IN ('public', 'archived') LIMIT 1",
+  "query": "SELECT TRUE FROM mods WHERE organization_id = $1 AND status IN ('approved', 'archived') LIMIT 1",
   "describe": {
     "columns": [
       {
@@ -18,5 +18,5 @@
       null
     ]
   },
-  "hash": "eb792d5033d7079fe3555593d8731f8853235275e4d5614636b5db524a4920d5"
+  "hash": "829a4523233e957f8876d248a17ec04c245af41f43fa40aff9ee07e893dabf3a"
 }

--- a/apps/labrinth/src/auth/checks.rs
+++ b/apps/labrinth/src/auth/checks.rs
@@ -377,7 +377,7 @@ pub async fn is_visible_organization(
     // This is meant to match the same projects as the `Project::is_searchable` method, but we're not using
     // it here because that'd entail pulling in all projects for the organization
     let has_searchable_projects = sqlx::query_scalar!(
-        "SELECT TRUE FROM mods WHERE organization_id = $1 AND status IN ('public', 'archived') LIMIT 1",
+        "SELECT TRUE FROM mods WHERE organization_id = $1 AND status IN ('approved', 'archived') LIMIT 1",
         organization.id as database::models::ids::DBOrganizationId
     )
     .fetch_optional(pool)


### PR DESCRIPTION
I made a typo in https://github.com/modrinth/code/pull/4426, where a SQL query I introduced there mistakenly filtered for projects with a non-existent `public` status instead of `approved`. During testing, I used the more unusual `archived` status, so I didn't notice the issue at the time.

Should fix https://github.com/modrinth/code/issues/4543. I didn't test this change with production data, but given my analysis of the state of the affected organizations through the API I feel pretty confident it should be a proper fix.