### PR TITLE
fix(app-lib): cache most Modrinth data for the intended time

### DIFF
--- a/packages/app-lib/src/state/cache.rs
+++ b/packages/app-lib/src/state/cache.rs
@@ -80,11 +80,12 @@ impl CacheValueType {
         }
     }
 
+    /// Returns the expiry time for entries of this type of cache item, in seconds.
     pub fn expiry(&self) -> i64 {
         match self {
-            CacheValueType::File => 60 * 60 * 24 * 30, // 30 days
-            CacheValueType::FileHash => 60 * 60 * 24 * 30, // 30 days
-            _ => 60 * 60 * 30,                         // 30 minutes
+            CacheValueType::File => 30 * 24 * 60 * 60, // 30 days
+            CacheValueType::FileHash => 30 * 24 * 60 * 60, // 30 days
+            _ => 30 * 60,                              // 30 minutes
         }
     }
 


### PR DESCRIPTION
## Overview

For more than a year, the app has been caching all data, except for project files and their hashes (including projects, versions, users, teams, organizations, loader and Minecraft manifests, categories, report types, loaders, game versions, donation platforms, file updates, and search results), 60 times longer than intended.

Instead of expiring after 30 minutes, cached data persisted for 1,800 minutes (1 day and 6 hours) due to a typo in how minutes were converted to seconds when calculating cache expiry times.

This issue has been the root cause of many recurring issues related to caching, particularly those reported by users eager to try new Minecraft versions soon after their release. This PR corrects such typo, which should, among others:

Resolve #4499.
Resolve #4496.
Resolve #3529.
Resolve #3067.
Resolve #4462.

Needless to say, the intended 30 minute cache expiry time should provide a more seamless experience for users, reducing their chance of being exposed to stale data for a significant amount of time.

## Testing

I have verified that these changes cause the app to request fresh game version data 30 minutes after the previous fetch was cached.  

Additionally, I inspected the response from the https://api.modrinth.com/v2/tag/game_version endpoint and confirmed that Cloudflare is not caching it, which means that Cloudflare caching behavior should not cause clients to receive stale data either (though an interesting discussion point would be whether we should cache it a little, even if it's only for a few minutes, to alleviate load on upstream servers). I came to this conclusion by looking at the [`cf-cache-status: DYNAMIC`](https://developers.cloudflare.com/cache/concepts/cache-responses/#dynamic) header attached to the response.