### PR TITLE
Include MAXIMIZED state in window state management

### DIFF
--- a/apps/app/src/main.rs
+++ b/apps/app/src/main.rs
@@ -155,7 +155,8 @@ fn main() {
                 // Use *only* POSITION and SIZE state flags, because saving VISIBLE causes the `visible: false` to not take effect
                 .with_state_flags(
                     tauri_plugin_window_state::StateFlags::POSITION
-                        | tauri_plugin_window_state::StateFlags::SIZE,
+                        | tauri_plugin_window_state::StateFlags::SIZE
+                        | tauri_plugin_window_state::StateFlags::MAXIMIZED,
                 )
                 .build(),
         )


### PR DESCRIPTION
This pull request introduces a change to include the MAXIMIZED state flag in the window state handling. This ensures that the window's maximized state is properly recognized and managed.