### PR TITLE
chore(vscode): use Rust analyzer `rustfmt` for formatting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,5 +26,8 @@
 	},
 	"[css]": {
 		"editor.defaultFormatter": "esbenp.prettier-vscode"
+	},
+	"[rust]": {
+		"editor.defaultFormatter": "rust-lang.rust-analyzer"
 	}
 }


### PR DESCRIPTION
The Visual Studio Code settings in our repository currently set Prettier as the default formatter for all file types, including Rust source files. However, since Prettier doesn't properly support Rust, formatting commands for Rust files are broken by default. Only the Rust Analyzer extension can format them properly via `rustfmt`.

This PR configures Rust Analyzer as the default formatter for Rust files, thereby restoring proper formatting functionality in Visual Studio Code by default.