### PR TITLE
Move skin preview directional light

### DIFF
--- a/packages/ui/src/components/skin/SkinPreviewRenderer.vue
+++ b/packages/ui/src/components/skin/SkinPreviewRenderer.vue
@@ -88,7 +88,7 @@
 			/>
 
 			<TresAmbientLight :intensity="2" />
-			<TresDirectionalLight :position="[2, 4, 3]" :intensity="1.2" :cast-shadow="true" />
+			<TresDirectionalLight :position="[-3, 4, -2]" :intensity="1.2" :cast-shadow="true" />
 		</TresCanvas>
 
 		<div


### PR DESCRIPTION
Moved the directional light to the front of the 3D preview, so the shadow borders became more distinguishable

Before/After:
<img width="224" height="398" alt="before" src="https://github.com/user-attachments/assets/2905820a-2bb1-404a-9e1c-4f241fec6bf7" /> <img width="224" height="398" alt="after" src="https://github.com/user-attachments/assets/b01f5e15-3498-479d-8e6c-954fd2662e7b" />

It also looks more similar to front-lighted 2D previews:
<img width="194" height="205" src="https://github.com/user-attachments/assets/985dbb62-989d-4450-9f12-340c732d09dc" />
