### PR TITLE
Fix inconsistent PAT display order

### DIFF
--- a/apps/frontend/src/pages/settings/pats.vue
+++ b/apps/frontend/src/pages/settings/pats.vue
@@ -334,7 +334,7 @@ const loading = ref(false)
 const { data: pats, refresh } = await useAsyncData('pat', () => useBaseFetch('pat'))
 const displayPats = computed(() => {
 	return pats.value.toSorted((a, b) => new Date(b.created) - new Date(a.created))
-});
+})
 
 async function createPat() {
 	startLoading()


### PR DESCRIPTION
Closes #4661

This fixes the Personal access tokens list under Settings > Personal Access Tokens to display the PATs in order of creation, instead of being in a random order every page load.