### PR TITLE
fix(app-lib): stricter mrpack override file path validation

### DIFF
--- a/packages/app-lib/src/state/profiles.rs
+++ b/packages/app-lib/src/state/profiles.rs
@@ -225,10 +225,14 @@ impl ProjectType {
         }
     }
 
-    pub fn get_from_parent_folder(path: &Path) -> Option<Self> {
-        // Get parent folder
-        let path = path.parent()?.file_name()?;
-        match path.to_str()? {
+    pub fn get_from_parent_folder(path: impl AsRef<Path>) -> Option<Self> {
+        match path
+            .as_ref()
+            .parent()?
+            .file_name()?
+            .to_str()
+            .unwrap_or_default()
+        {
             "mods" => Some(ProjectType::Mod),
             "datapacks" => Some(ProjectType::DataPack),
             "resourcepacks" => Some(ProjectType::ResourcePack),


### PR DESCRIPTION
## Overview

PR #4482 improved how `.mrpack` files get their files to download validated by the Modrinth App. However, this additional validation did not cover files within the `overrides` or `client-overrides` folders in the `.mrpack` ZIP archive, leaving a vulnerability unaddressed.

This update extends the use of the validating `SafeRelativeUtf8UnixPathBuf` struct introduced in the aforementioned PR to these override files, knocking down the last known vulnerability in `.mrpack` format parsing by the Modrinth App. Additionally, I've refactored the related code to reduce indentation and improve readability, and fixed a minor display issue affecting how the override extraction process was shown.

A big thanks to the several community members who brought this issue to our attention.