### PR TITLE
Improve nags translation strings

### DIFF
--- a/apps/frontend/src/components/ui/moderation/ModerationProjectNags.vue
+++ b/apps/frontend/src/components/ui/moderation/ModerationProjectNags.vue
@@ -139,7 +139,7 @@ const messages = defineMessages({
 	resubmitForReviewDesc: {
 		id: 'project-moderation-nags.resubmit-for-review-desc',
 		defaultMessage:
-			"Your project has been {status} by Modrinth's staff. In most cases, you can resubmit for review after addressing the staff's message.",
+			"Your project has been {status, select, rejected {rejected} withheld {withheld} other {{status}}} by Modrinth's staff. In most cases, you can resubmit for review after addressing the staff's message.",
 	},
 	visitModerationPage: {
 		id: 'project-moderation-nags.visit-moderation-page',

--- a/apps/frontend/src/locales/en-US/index.json
+++ b/apps/frontend/src/locales/en-US/index.json
@@ -1251,7 +1251,7 @@
     "message": "Resubmit for review"
   },
   "project-moderation-nags.resubmit-for-review-desc": {
-    "message": "Your project has been {status} by Modrinth's staff. In most cases, you can resubmit for review after addressing the staff's message."
+    "message": "Your project has been {status, select, rejected {rejected} withheld {withheld} other {{status}}} by Modrinth's staff. In most cases, you can resubmit for review after addressing the staff's message."
   },
   "project-moderation-nags.submit-checklist-tooltip": {
     "message": "You must complete the required steps in the publishing checklist!"

--- a/packages/moderation/src/data/nags/core.ts
+++ b/packages/moderation/src/data/nags/core.ts
@@ -1,4 +1,3 @@
-import { formatProjectType } from '@modrinth/utils'
 import { defineMessage, useVIntl } from '@vintl/vintl'
 
 import type { Nag, NagContext } from '../../types/nags'
@@ -8,7 +7,7 @@ export const coreNags: Nag[] = [
 		id: 'moderator-feedback',
 		title: defineMessage({
 			id: 'nags.moderator-feedback.title',
-			defaultMessage: 'Review moderator feedback',
+			defaultMessage: 'Review feedback',
 		}),
 		description: defineMessage({
 			id: 'nags.moderator-feedback.description',
@@ -100,23 +99,15 @@ export const coreNags: Nag[] = [
 		}),
 		description: (context: NagContext) => {
 			const { formatMessage } = useVIntl()
-			const projectType = formatProjectType(context.project.project_type).toLowerCase()
-			let msg = ''
-			if (context.project.project_type === 'resourcepack') {
-				msg =
-					', except for audio or localization packs. If this describes your pack, please select the appropriate tag'
-			}
-			const resourcepackMessage = msg
 
 			return formatMessage(
 				defineMessage({
 					id: 'nags.upload-gallery-image.description',
 					defaultMessage:
-						'At least one gallery image is required to showcase the content of your {type}{resourcepackMessage}.',
+						'At least one gallery image is required to showcase the content of your {type, select, resourcepack {resource pack, except for audio or localization packs. If this describes your pack, please select the appropriate tag} shader {shader} other {project}}.',
 				}),
 				{
-					type: projectType,
-					resourcepackMessage: resourcepackMessage,
+					type: context.project.project_type,
 				},
 			)
 		},
@@ -232,10 +223,10 @@ export const coreNags: Nag[] = [
 			return formatMessage(
 				defineMessage({
 					id: 'nags.select-environments.description',
-					defaultMessage: `Select the environments your {projectType} functions on.`,
+					defaultMessage: `Select the environments your {type, select, mod {mod} modpack {modpack} other {project}} functions on.`,
 				}),
 				{
-					projectType: formatProjectType(context.project.project_type).toLowerCase(),
+					type: context.project.project_type,
 				},
 			)
 		},
@@ -272,10 +263,11 @@ export const coreNags: Nag[] = [
 			return formatMessage(
 				defineMessage({
 					id: 'nags.select-license.description',
-					defaultMessage: 'Select the license your {projectType} is distributed under.',
+					defaultMessage:
+						'Select the license your {type, select, mod {mod} modpack {modpack} resourcepack {resource pack} shader {shader} plugin {plugin} datapack {data pack} other {project}} is distributed under.',
 				}),
 				{
-					projectType: formatProjectType(context.project.project_type).toLowerCase(),
+					type: context.project.project_type,
 				},
 			)
 		},

--- a/packages/moderation/src/data/nags/description.ts
+++ b/packages/moderation/src/data/nags/description.ts
@@ -127,7 +127,7 @@ export const descriptionNags: Nag[] = [
 				defineMessage({
 					id: 'nags.description-too-short.description',
 					defaultMessage:
-						'Your description is {length} readable characters. At least {minChars} characters is recommended to create a clear and informative description.',
+						'Your description is {length, plural, one {# readable character} other {# readable characters}}. At least {minChars, plural, one {# character} other {# characters}} is recommended to create a clear and informative description.',
 				}),
 				{
 					length: readableLength,
@@ -198,7 +198,7 @@ export const descriptionNags: Nag[] = [
 				defineMessage({
 					id: 'nags.summary-too-short.description',
 					defaultMessage:
-						'Your summary is {length} characters. At least {minChars} characters is recommended to create an informative and enticing summary.',
+						'Your summary is {length, plural, one {# character} other {# characters}}. At least {minChars, plural, one {# character} other {# characters}} is recommended to create an informative and enticing summary.',
 				}),
 				{
 					length: context.project.description?.length || 0,
@@ -292,7 +292,7 @@ export const descriptionNags: Nag[] = [
 		description: defineMessage({
 			id: 'nags.title-contains-technical-info.description',
 			defaultMessage:
-				"Keeping your project's Name clean and makes it memorable easier to find. Version and loader information is automatically displayed alongside your project.",
+				"Keeping your project's Name clean makes it memorable and easier to find. Version and loader information is automatically displayed alongside your project.",
 		}),
 		status: 'warning',
 		shouldShow: (context: NagContext) => {

--- a/packages/moderation/src/data/nags/links.ts
+++ b/packages/moderation/src/data/nags/links.ts
@@ -1,4 +1,3 @@
-import { formatProjectType } from '@modrinth/utils'
 import { defineMessage, useVIntl } from '@vintl/vintl'
 
 import type { Nag, NagContext } from '../../types/nags'
@@ -218,10 +217,10 @@ export const linksNags: Nag[] = [
 				defineMessage({
 					id: 'nags.gpl-license-source-required.description',
 					defaultMessage:
-						'Your {projectType} uses a license which requires source code to be available. Please provide a source code link or sources file for each additional version, or consider using a different license.',
+						'Your {type, select, mod {mod} plugin {plugin} other {project}} uses a license which requires source code to be available. Please provide a source code link or sources file for each additional version, or consider using a different license.',
 				}),
 				{
-					projectType: formatProjectType(context.project.project_type).toLowerCase(),
+					type: context.project.project_type,
 				},
 			)
 		},

--- a/packages/moderation/src/data/nags/tags.ts
+++ b/packages/moderation/src/data/nags/tags.ts
@@ -39,7 +39,7 @@ export const tagsNags: Nag[] = [
 				defineMessage({
 					id: 'nags.too-many-tags.description',
 					defaultMessage:
-						"You've selected {tagCount} tags. Consider reducing to {maxTagCount} or fewer to make sure your project appears in relevant search results.",
+						"You've selected {tagCount, plural, one {# tag} other {# tags}}. Consider reducing to {maxTagCount} or fewer to make sure your project appears in relevant search results.",
 				}),
 				{
 					tagCount,
@@ -82,7 +82,7 @@ export const tagsNags: Nag[] = [
 				defineMessage({
 					id: 'nags.multiple-resolution-tags.description',
 					defaultMessage:
-						"You've selected {count} resolution tags ({tags}). Resource packs should typically only have one resolution tag that matches their primary resolution.",
+						"You've selected {count, plural, one {# resolution tag} other {# resolution tags}} ({tags}). Resource packs should typically only have one resolution tag that matches their primary resolution.",
 				}),
 				{
 					count: resolutionTags.length,
@@ -129,7 +129,7 @@ export const tagsNags: Nag[] = [
 				defineMessage({
 					id: 'nags.all-tags-selected.description',
 					defaultMessage:
-						"You've selected all {totalAvailableTags} available tags. This defeats the purpose of tags, which are meant to help users find relevant projects. Please select only the tags that are relevant to your project.",
+						"You've selected all {totalAvailableTags, plural, one {# available tag} other {# available tags}}. This defeats the purpose of tags, which are meant to help users find relevant projects. Please select only the tags that are relevant to your project.",
 				}),
 				{
 					totalAvailableTags,

--- a/packages/moderation/src/locales/en-US/index.json
+++ b/packages/moderation/src/locales/en-US/index.json
@@ -18,13 +18,13 @@
     "defaultMessage": "Add external links"
   },
   "nags.all-tags-selected.description": {
-    "defaultMessage": "You've selected all {totalAvailableTags} available tags. This defeats the purpose of tags, which are meant to help users find relevant projects. Please select only the tags that are relevant to your project."
+    "defaultMessage": "You've selected all {totalAvailableTags, plural, one {# available tag} other {# available tags}}. This defeats the purpose of tags, which are meant to help users find relevant projects. Please select only the tags that are relevant to your project."
   },
   "nags.all-tags-selected.title": {
     "defaultMessage": "Select accurate tags"
   },
   "nags.description-too-short.description": {
-    "defaultMessage": "Your description is {length} readable characters. At least {minChars} characters is recommended to create a clear and informative description."
+    "defaultMessage": "Your description is {length, plural, one {# readable character} other {# readable characters}}. At least {minChars, plural, one {# character} other {# characters}} is recommended to create a clear and informative description."
   },
   "nags.description-too-short.title": {
     "defaultMessage": "Expand the description"
@@ -54,7 +54,7 @@
     "defaultMessage": "Visit gallery page"
   },
   "nags.gpl-license-source-required.description": {
-    "defaultMessage": "Your {projectType} uses a license which requires source code to be available. Please provide a source code link or sources file for each additional version, or consider using a different license."
+    "defaultMessage": "Your {type, select, mod {mod} plugin {plugin} other {project}} uses a license which requires source code to be available. Please provide a source code link or sources file for each additional version, or consider using a different license."
   },
   "nags.gpl-license-source-required.title": {
     "defaultMessage": "Provide source code"
@@ -114,22 +114,22 @@
     "defaultMessage": "Review and address all concerns from the moderation team before resubmitting."
   },
   "nags.moderator-feedback.title": {
-    "defaultMessage": "Review moderator feedback"
+    "defaultMessage": "Review feedback"
   },
   "nags.multiple-resolution-tags.description": {
-    "defaultMessage": "You've selected {count} resolution tags ({tags}). Resource packs should typically only have one resolution tag that matches their primary resolution."
+    "defaultMessage": "You've selected {count, plural, one {# resolution tag} other {# resolution tags}} ({tags}). Resource packs should typically only have one resolution tag that matches their primary resolution."
   },
   "nags.multiple-resolution-tags.title": {
     "defaultMessage": "Select correct resolution"
   },
   "nags.select-environments.description": {
-    "defaultMessage": "Select the environments your {projectType} functions on."
+    "defaultMessage": "Select the environments your {type, select, mod {mod} modpack {modpack} other {project}} functions on."
   },
   "nags.select-environments.title": {
     "defaultMessage": "Select environments"
   },
   "nags.select-license.description": {
-    "defaultMessage": "Select the license your {projectType} is distributed under."
+    "defaultMessage": "Select the license your {type, select, mod {mod} modpack {modpack} resourcepack {resource pack} shader {shader} plugin {plugin} datapack {data pack} other {project}} is distributed under."
   },
   "nags.select-license.title": {
     "defaultMessage": "Select a license"
@@ -171,25 +171,25 @@
     "defaultMessage": "Clear up the summary"
   },
   "nags.summary-too-short.description": {
-    "defaultMessage": "Your summary is {length} characters. At least {minChars} characters is recommended to create an informative and enticing summary."
+    "defaultMessage": "Your summary is {length, plural, one {# character} other {# characters}}. At least {minChars, plural, one {# character} other {# characters}} is recommended to create an informative and enticing summary."
   },
   "nags.summary-too-short.title": {
     "defaultMessage": "Expand the summary"
   },
   "nags.title-contains-technical-info.description": {
-    "defaultMessage": "Keeping your project's Name clean and makes it memorable easier to find. Version and loader information is automatically displayed alongside your project."
+    "defaultMessage": "Keeping your project's Name clean makes it memorable and easier to find. Version and loader information is automatically displayed alongside your project."
   },
   "nags.title-contains-technical-info.title": {
     "defaultMessage": "Clean up the name"
   },
   "nags.too-many-tags.description": {
-    "defaultMessage": "You've selected {tagCount} tags. Consider reducing to {maxTagCount} or fewer to make sure your project appears in relevant search results."
+    "defaultMessage": "You've selected {tagCount, plural, one {# tag} other {# tags}}. Consider reducing to {maxTagCount} or fewer to make sure your project appears in relevant search results."
   },
   "nags.too-many-tags.title": {
     "defaultMessage": "Select accurate tags"
   },
   "nags.upload-gallery-image.description": {
-    "defaultMessage": "At least one gallery image is required to showcase the content of your {type}{resourcepackMessage}."
+    "defaultMessage": "At least one gallery image is required to showcase the content of your {type, select, resourcepack {resource pack, except for audio or localization packs. If this describes your pack, please select the appropriate tag} shader {shader} other {project}}."
   },
   "nags.upload-gallery-image.title": {
     "defaultMessage": "Upload a gallery image"


### PR DESCRIPTION
- Made project types and statuses translatable inside nag descriptions
- Added `{..., plural, ...}` where needed
- Replaced "Review moderator feedback" with "Review feedback" to fit into one line as other nag titles
- Fixed "Keeping your project's Name clean <ins>and</ins> makes it memorabl<ins>e e</ins>asier to find."