### PR TITLE
Add frontend support for Geyser Extension plugin loader

### DIFF
--- a/packages/ui/src/utils/search.ts
+++ b/packages/ui/src/utils/search.ts
@@ -93,6 +93,8 @@ export interface SortType {
 	name: string
 }
 
+const PLUGIN_PLATFORMS = ['bungeecord', 'waterfall', 'velocity', 'geyser']
+
 export function useSearch(
 	projectTypes: Ref<ProjectType[]>,
 	tags: Ref<Tags>,
@@ -298,7 +300,7 @@ export function useSearch(
 					.filter(
 						(loader) =>
 							loader.supported_project_types.includes('plugin') &&
-							!['bungeecord', 'waterfall', 'velocity'].includes(loader.name),
+							!PLUGIN_PLATFORMS.includes(loader.name),
 					)
 					.map((loader) => {
 						return {
@@ -324,7 +326,7 @@ export function useSearch(
 				supports_negative_filter: true,
 				searchable: false,
 				options: tags.value.loaders
-					.filter((loader) => ['bungeecord', 'waterfall', 'velocity'].includes(loader.name))
+					.filter((loader) => PLUGIN_PLATFORMS.includes(loader.name))
 					.map((loader) => {
 						return {
 							id: loader.name,

--- a/packages/utils/utils.ts
+++ b/packages/utils/utils.ts
@@ -191,6 +191,8 @@ export const formatCategory = (name) => {
 		return 'Resource Pack'
 	} else if (name === 'vanilla') {
 		return 'Vanilla Shader'
+	} else if (name === 'geyser') {
+		return 'Geyser Extension'
 	}
 	return capitalizeString(name)
 }


### PR DESCRIPTION
Need @triphora to add plugin loader 'geyser' with this SVG after this is merged:
```svg
<svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5" viewBox="0 0 24 24"><path d="M-29.359 21.58s.347-4.964-2.603-9.503l3.419 1.511 2.032-4.165s.407 5.006.717 6.82l4.201-2.269s-3.582 5.066-3.339 7.726" style="fill:none;stroke:currentColor;stroke-width:1.81px" transform="matrix(1.04036 0 0 1.1631 40.307 -2.368)"/><path d="M-28.662 13.511s-.605-4.431-3.127-5.772c-.957-.256-1.802 1.129-2.839.953-.783-.134-.92-1.322.118-2.625 1.253-1.572 3.754-3.239 7.51-3.133s7.899 2.025 8.029 4.378c-.139 1.765-2.05.754-2.05.754s-2.885-1.535-4.801 7.697" style="fill:none;stroke:currentColor;stroke-width:1.81px" transform="matrix(1.04036 0 0 1.1631 40.432 -2.278)"/><path d="M-33.825 10.737s-1.006.602-1.867 2.089" style="fill:none;stroke:currentColor;stroke-width:1.81px" transform="matrix(1.0317 -.13393 .14973 1.15343 36.882 -5.8)"/><path d="M-21.195 10.385s1.378.38 1.947 1.615" style="fill:none;stroke:currentColor;stroke-width:1.81px" transform="matrix(1.04036 0 0 1.1631 41.36 -1.513)"/></svg>
```