### PR TITLE
fix: correct parameter name for create function in profile helper

### DIFF
--- a/apps/app-frontend/src/helpers/profile.js
+++ b/apps/app-frontend/src/helpers/profile.js
@@ -18,7 +18,7 @@ import { install_to_existing_profile } from '@/helpers/pack.js'
     - icon is a path to an image file, which will be copied into the profile directory
 */
 
-export async function create(name, gameVersion, modloader, loaderVersion, iconPath, skipInstall) {
+export async function create(name, gameVersion, modloader, loaderVersion, icon, skipInstall) {
 	//Trim string name to avoid "Unable to find directory"
 	name = name.trim()
 	return await invoke('plugin:profile-create|profile_create', {
@@ -26,7 +26,7 @@ export async function create(name, gameVersion, modloader, loaderVersion, iconPa
 		gameVersion,
 		modloader,
 		loaderVersion,
-		iconPath,
+		icon,
 		skipInstall,
 	})
 }


### PR DESCRIPTION
Issue: Backend and front-end names were different, causing icon to not be passed on correctly, meaning icons weren't saved and displayed.

This closes #4743