### PR TITLE
Update openapi spec to fix invalid json

### DIFF
--- a/apps/docs/public/openapi.yaml
+++ b/apps/docs/public/openapi.yaml
@@ -703,8 +703,8 @@ components:
               description: All gallery images attached to the project
               example:
                 [
-                  https://cdn.modrinth.com/data/AABBCCDD/images/009b7d8d6e8bf04968a29421117c59b3efe2351a.png,
-                  https://cdn.modrinth.com/data/AABBCCDD/images/c21776867afb6046fdc3c21dbcf5cc50ae27a236.png,
+                  'https://cdn.modrinth.com/data/AABBCCDD/images/009b7d8d6e8bf04968a29421117c59b3efe2351a.png',
+                  'https://cdn.modrinth.com/data/AABBCCDD/images/c21776867afb6046fdc3c21dbcf5cc50ae27a236.png',
                 ]
               items:
                 type: string


### PR DESCRIPTION
At least in some parsers (eg `ruamel.yaml` and `pyyaml`) , the colons here caused the openapi spec to fail to parse