### PR TITLE
fix: use ref rather than direct val

### DIFF
--- a/apps/frontend/src/app.vue
+++ b/apps/frontend/src/app.vue
@@ -17,7 +17,7 @@ const config = useRuntimeConfig()
 
 provideNotificationManager(new FrontendNotificationManager())
 
-const client = createModrinthClient(auth.value, {
+const client = createModrinthClient(auth, {
 	apiBaseUrl: config.public.apiBaseUrl.replace('/v2/', '/'),
 	archonBaseUrl: config.public.pyroBaseUrl.replace('/v2/', '/'),
 	rateLimitKey: config.rateLimitKey,

--- a/apps/frontend/src/helpers/api.ts
+++ b/apps/frontend/src/helpers/api.ts
@@ -8,9 +8,10 @@ import {
 	NuxtModrinthClient,
 	VerboseLoggingFeature,
 } from '@modrinth/api-client'
+import type { Ref } from 'vue'
 
 export function createModrinthClient(
-	auth: { token: string | undefined },
+	auth: Ref<{ token: string | undefined }>,
 	config: { apiBaseUrl: string; archonBaseUrl: string; rateLimitKey?: string },
 ): NuxtModrinthClient {
 	const optionalFeatures = [
@@ -23,7 +24,7 @@ export function createModrinthClient(
 		rateLimitKey: config.rateLimitKey,
 		features: [
 			new AuthFeature({
-				token: async () => auth.token,
+				token: async () => auth.value.token,
 			} as AuthConfig),
 			new CircuitBreakerFeature({
 				storage: new NuxtCircuitBreakerStorage(),


### PR DESCRIPTION
Fixes the `Authorization` header being missing from API requests through the api client, because the `AuthFeature` token function captures a stale reference to the auth object that gets replaced during initialization.