### PR TITLE
fix: blacklist filter not working at all

### DIFF
--- a/apps/labrinth/src/search/mod.rs
+++ b/apps/labrinth/src/search/mod.rs
@@ -273,7 +273,12 @@ pub async fn search_for_project(
                         for (facet_inner_index, facet) in
                             facet_inner_list.iter().enumerate()
                         {
-                            filter_string.push_str(&facet.replace(':', " = "));
+                            let formatted_facet = if facet.contains("!=") {
+                                facet.replace("!=", " != ")
+                            } else {
+                                facet.replace(':', " = ")
+                            };
+                            filter_string.push_str(&formatted_facet);
                             if facet_inner_index != (facet_inner_list.len() - 1)
                             {
                                 filter_string.push_str(" AND ")


### PR DESCRIPTION
The search blacklist filter was broken because it incorrectly formatted the != operator. When blacklisting something like "fabric", it would convert `categories!=fabric` to `categories! = fabric` which is invalid MeiliSearch syntax, causing the filter to silently fail.

Fixed by properly handling != as a separate case from the : operator.

so, i have no way of testing the website. but if someone can back up my claims it would be cool.