### PR TITLE
fix: fix amount precision issue when withdraw

### DIFF
--- a/packages/muralpay/src/lib.rs
+++ b/packages/muralpay/src/lib.rs
@@ -161,7 +161,6 @@ pub struct WalletDetails {
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct TokenAmount {
-    #[serde(with = "rust_decimal::serde::float")]
     pub token_amount: Decimal,
     pub token_symbol: String,
 }
@@ -170,7 +169,6 @@ pub struct TokenAmount {
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct FiatAmount {
-    #[serde(with = "rust_decimal::serde::float")]
     pub fiat_amount: Decimal,
     pub fiat_currency_code: CurrencyCode,
 }


### PR DESCRIPTION
I encountered an error when attempting a withdrawal today.

Request Payload:

```json
{
  "amount": 22.85,
  "method": "muralpay",
  "method_id": "blockchain_usdc_polygon",
  "method_details": {
    "payout_details": {
      "type": "blockchain",
      "wallet_address": "***"
    },
    "recipient_info": {
      "type": "individual",
      "firstName": "***",
      "lastName": "***",
      "dateOfBirth": "***",
      "email": "***",
      "physicalAddress": {
        "address1": "***",
        "country": "***",
        "state": "***",
        "city": "***",
        "zip": "***"
      }
    }
  }
}
```

API Response:

```json
{
  "error": "request_error",
  "description": "ApiError {\n\t error_instance_id: ***,\n\t name: \"BadRequestException\",\n\t message: \"Bad Request Exception\",\n\t details: [\n\t\t \"payouts.0.amount.Token amount must have at most 2 decimal places.\",\n\t ],\n\t params: {},\n}"
}
```

When I withdrew an amount that can be accurately represented by a float (20 USD), the withdrawal was successful.

---

MuralPay requires that the amount must have at most 2 decimal places. However, the backend converts the amount to a `float` type during JSON serialization. Floats cannot accurately represent certain fractions and may introduce precision artifacts at the end of the number (e.g., $22.85$ becomes $22.849999999999998$). This PR (Pull Request) is intended to fix the issue.


