### PR TITLE
fix: broken amount logic for gift cards where min=max

### DIFF
--- a/apps/frontend/src/providers/creator-withdraw.ts
+++ b/apps/frontend/src/providers/creator-withdraw.ts
@@ -642,12 +642,16 @@ export function createWithdrawContext(
 				)
 
 				if (selectedMethod?.interval) {
+					const userMax = Math.floor(maxWithdrawAmount.value * 100) / 100
 					if (selectedMethod.interval.standard) {
 						const { min, max } = selectedMethod.interval.standard
-						if (amount < min || amount > max) return false
+						const effectiveMax = Math.min(userMax, max)
+						const effectiveMin = Math.min(min, effectiveMax)
+						if (amount < effectiveMin || amount > effectiveMax) return false
 					}
 					if (selectedMethod.interval.fixed) {
-						if (!selectedMethod.interval.fixed.values.includes(amount)) return false
+						const validValues = selectedMethod.interval.fixed.values.filter((v) => v <= userMax)
+						if (!validValues.includes(amount)) return false
 					}
 				}
 
@@ -711,7 +715,11 @@ export function createWithdrawContext(
 				)
 				if (selectedMethod?.interval?.standard) {
 					const { min, max } = selectedMethod.interval.standard
-					if (amount < min || amount > max) return false
+					// Use effective limits that account for user's available balance
+					const userMax = Math.floor(maxWithdrawAmount.value * 100) / 100
+					const effectiveMax = Math.min(userMax, max)
+					const effectiveMin = Math.min(min, effectiveMax)
+					if (amount < effectiveMin || amount > effectiveMax) return false
 				}
 
 				const accountDetails = withdrawData.value.providerData.accountDetails
@@ -736,7 +744,11 @@ export function createWithdrawContext(
 				)
 				if (selectedMethod?.interval?.standard) {
 					const { min, max } = selectedMethod.interval.standard
-					if (amount < min || amount > max) return false
+					// Use effective limits that account for user's available balance
+					const userMax = Math.floor(maxWithdrawAmount.value * 100) / 100
+					const effectiveMax = Math.min(userMax, max)
+					const effectiveMin = Math.min(min, effectiveMax)
+					if (amount < effectiveMin || amount > effectiveMax) return false
 				}
 
 				return !!withdrawData.value.stageValidation?.paypalDetails


### PR DESCRIPTION
- Fixes an issue with the frontend which causes `min=max` withdrawal methods to be broken.
- Treats them like interval withdrawal methods, a chip is shown instead. If the user can't afford the amount it shows the usual "You can't afford this withdrawal method" error.
- @aecsocket needs to fix backend in this PR - see slack