### PR TITLE
fix: temporarily disable vintl for all langs apart from en-US

### DIFF
--- a/apps/frontend/nuxt.config.ts
+++ b/apps/frontend/nuxt.config.ts
@@ -31,7 +31,7 @@ const favicons = {
  * Preferably only the locales that reach a certain threshold of complete
  * translations would be included in this array.
  */
-const enabledLocales: string[] = []
+// const enabledLocales: string[] = []
 
 /**
  * Overrides for the categories of the certain locales.
@@ -179,7 +179,7 @@ export default defineNuxtConfig({
 		async 'vintl:extendOptions'(opts) {
 			opts.locales ??= []
 
-			const isProduction = getDomain() === 'https://modrinth.com'
+			// const isProduction = getDomain() === 'https://modrinth.com'
 
 			const resolveCompactNumberDataImport = await (async () => {
 				const compactNumberLocales: string[] = []


### PR DESCRIPTION
- Significantly improves build times, at least until we migrate to a different i18n system.
- Doesn't need this change applied to app as the app only has `en-US` set up anyways.