### PR TITLE
devex: skip services + env + db steps in CI if not needed

### DIFF
--- a/.github/workflows/turbo-ci.yml
+++ b/.github/workflows/turbo-ci.yml
@@ -70,18 +70,32 @@ jobs:
       - name: 🧰 Install dependencies
         run: pnpm install
 
+      - name: ⚙️ Set app environment
+        working-directory: packages/app-lib
+        run: cp .env.staging .env
+
+      # check if labrinth tests will actually run (cache miss)
+      - name: 🔍 Check if labrinth tests need to run
+        id: check-labrinth
+        run: |
+          LABRINTH_TEST_STATUS=$(pnpm turbo run test --filter=@modrinth/labrinth --dry-run=json | jq -r '.tasks[] | select(.task == "test") | .cache.status')
+          echo "Labrinth test cache status: $LABRINTH_TEST_STATUS"
+          if [ "$LABRINTH_TEST_STATUS" = "HIT" ]; then
+            echo "needs_services=false" >> $GITHUB_OUTPUT
+          else
+            echo "needs_services=true" >> $GITHUB_OUTPUT
+          fi
+
       - name: ⚙️ Start services
+        if: steps.check-labrinth.outputs.needs_services == 'true'
         run: docker compose up --wait
 
       - name: ⚙️ Setup labrinth environment and database
+        if: steps.check-labrinth.outputs.needs_services == 'true'
         working-directory: apps/labrinth
         run: |
           cp .env.local .env
           sqlx database setup
-
-      - name: ⚙️ Set app environment
-        working-directory: packages/app-lib
-        run: cp .env.staging .env
 
       - name: 🔍 Lint and test
         run: pnpm run ci


### PR DESCRIPTION
- Skips the "⚙️ Start services" and "⚙️ Setup labrinth environment and database" tasks if they are not needed (aka labrinth tests dont need to run)
- Might only be 20s saved, but it adds up!