### PR TITLE
fix: project review links briefly 404s

### DIFF
--- a/apps/frontend/src/components/ui/moderation/ModerationQueueCard.vue
+++ b/apps/frontend/src/components/ui/moderation/ModerationQueueCard.vue
@@ -204,7 +204,7 @@ function openProjectForReview() {
 		name: 'type-id',
 		params: {
 			type: 'project',
-			id: props.queueEntry.project.id,
+			id: props.queueEntry.project.slug || props.queueEntry.project.id,
 		},
 		state: {
 			showChecklist: true,


### PR DESCRIPTION
fix by using slug right away instead of id which then redirects to using slug anyways