### PR TITLE
fix: vite dev server cf workers compatibility

### DIFF
--- a/apps/frontend/src/composables/fetch.js
+++ b/apps/frontend/src/composables/fetch.js
@@ -8,7 +8,8 @@ async function getRateLimitKey(config) {
 	if (!rateLimitKeyPromise) {
 		rateLimitKeyPromise = (async () => {
 			try {
-				const { env } = await import('cloudflare:workers')
+				const mod = 'cloudflare:workers'
+				const { env } = await import(/* @vite-ignore */ mod)
 				return await env.RATE_LIMIT_IGNORE_KEY?.get()
 			} catch {
 				return undefined

--- a/apps/frontend/src/helpers/api.ts
+++ b/apps/frontend/src/helpers/api.ts
@@ -15,8 +15,8 @@ import type { Ref } from 'vue'
 
 async function getRateLimitKeyFromSecretsStore(): Promise<string | undefined> {
 	try {
-		// @ts-expect-error only avail in workers env
-		const { env } = await import('cloudflare:workers')
+		const mod = 'cloudflare:workers'
+		const { env } = await import(/* @vite-ignore */ mod)
 		return await env.RATE_LIMIT_IGNORE_KEY?.get()
 	} catch {
 		// Not running in Cloudflare Workers environment


### PR DESCRIPTION
ugly, probably violates a geneva convention or two but does make Vite ignore the import error

there's also https://github.com/nitrojs/nitro-cloudflare-dev but I don't think that'll work for us