### PR TITLE
fix: open path util freezing app

### DIFF
--- a/apps/app/src/api/utils.rs
+++ b/apps/app/src/api/utils.rs
@@ -93,19 +93,17 @@ pub fn highlight_in_folder<R: Runtime>(
 }
 
 #[tauri::command]
-pub async fn open_path<R: Runtime>(
-    app: tauri::AppHandle<R>,
-    path: PathBuf,
-) {
+pub async fn open_path<R: Runtime>(app: tauri::AppHandle<R>, path: PathBuf) {
     tauri::async_runtime::spawn_blocking(move || {
-        if let Err(e) = app.opener().open_path(path.to_string_lossy(), None::<&str>) {
+        if let Err(e) =
+            app.opener().open_path(path.to_string_lossy(), None::<&str>)
+        {
             tracing::error!("Failed to open path: {}", e);
         }
     })
     .await
     .ok();
 }
-
 
 #[tauri::command]
 pub async fn show_launcher_logs_folder<R: Runtime>(app: tauri::AppHandle<R>) {


### PR DESCRIPTION
Addresses the following issues:
https://github.com/modrinth/code/issues/4701
https://github.com/modrinth/code/issues/4987

Unfortunately I was only able to reproduce the bug from opening a world folder and not an instance folder. But this fix should apply to instance folder opening too. 