### PR TITLE
[WIP] Improved UX for switching modpack versions

### DIFF
--- a/apps/app-frontend/src/components/ui/ModpackVersionModal.vue
+++ b/apps/app-frontend/src/components/ui/ModpackVersionModal.vue
@@ -142,7 +142,7 @@ const onHide = () => {
 }
 
 .with-columns {
-	grid-template-columns: min-content 1fr 1fr;
+	grid-template-columns: min-content 1fr 1fr min-content;
 }
 
 .scrollable {


### PR DESCRIPTION
# Not tested yet

Probable problems:
.download-cell on the header cell influencing button with text
ExternalIcon is not be the best fit for navigating to modpack's version page (icon for "link" or "changelog"?)