### PR TITLE
Fix loader icon not respecting parent container size

### DIFF
--- a/apps/frontend/src/components/ui/servers/icons/LoaderIcon.vue
+++ b/apps/frontend/src/components/ui/servers/icons/LoaderIcon.vue
@@ -1,5 +1,5 @@
 <template>
-	<div v-if="loaderData?.icon" v-html="loaderData.icon" />
+	<div v-if="loaderData?.icon" v-html="loaderData.icon" class="loader-icon-wrapper" />
 	<LoaderIcon v-else />
 </template>
 
@@ -20,3 +20,10 @@ const loaderData = computed(() =>
 	tags.value.loaders.find((l) => l.name.toLowerCase() === props.loader.toLowerCase()),
 )
 </script>
+
+<style scoped>
+.loader-icon-wrapper :deep(svg) {
+	width: 100%;
+	height: 100%;
+}
+</style>


### PR DESCRIPTION
<img width="1261" height="289" alt="image" src="https://github.com/user-attachments/assets/f71210bd-9141-40e5-a90b-80f4b5f3ddb4" />
