### PR TITLE
Add Tangled to common source links

### DIFF
--- a/packages/moderation/src/data/nags/links.ts
+++ b/packages/moderation/src/data/nags/links.ts
@@ -4,7 +4,14 @@ import type { Nag, NagContext } from '../../types/nags'
 
 export const commonLinkDomains = {
 	source: ['github.com', 'gitlab.com', 'bitbucket.org', 'codeberg.org', 'git.sr.ht', 'tangled.org'],
-	issues: ['github.com', 'gitlab.com', 'bitbucket.org', 'codeberg.org', 'docs.google.com', 'tangled.org'],
+	issues: [
+		'github.com',
+		'gitlab.com',
+		'bitbucket.org',
+		'codeberg.org',
+		'docs.google.com',
+		'tangled.org',
+	],
 	discord: ['discord.gg', 'discord.com', 'dsc.gg'],
 	licenseBlocklist: [
 		'youtube.com',


### PR DESCRIPTION
[Tangled](https://tangled.org/) is a decentralized git platform used by mods like [Infinite Dimensions](https://modrinth.com/mod/infinite-dimensions/). While new, I see no reason to be nagged that it is not a common platform, as it is designed to host source code and issues.