### PR TITLE
fix: invalid payout source code link

### DIFF
--- a/apps/frontend/src/pages/legal/cmp-info.vue
+++ b/apps/frontend/src/pages/legal/cmp-info.vue
@@ -128,7 +128,7 @@
 		<p>
 			We aim to be as transparent as possible with creator revenue. All of our code is open source,
 			including our
-			<a href="https://github.com/modrinth/code/blob/main/apps/labrinth/src/queue/payouts.rs#L598">
+			<a href="https://github.com/modrinth/code/blob/main/apps/labrinth/src/queue/payouts">
 				revenue distribution system</a
 			>. We also have an
 			<a href="https://api.modrinth.com/v3/payout/platform_revenue">API route</a>


### PR DESCRIPTION
Fixes #4877 

I updated the link on the [Rewards Program Information Page](https://modrinth.com/legal/cmp-info#pending:~:text=revenue%20distribution%20system) as specified in the issue, since it seems like the best fit to replace the current 404 error.
Current Hyperlink Text Address: https://github.com/modrinth/code/blob/main/apps/labrinth/src/queue/payouts.rs#L598 
New Address: https://github.com/modrinth/code/tree/main/apps/labrinth/src/queue/payouts

I did not update the "Last modified: Feb 20, 2025" section of the page, since I presume that the date is reserved for updates to the legal terms.