### PR TITLE
fix #5243: detect file data on multi-part uploads

### DIFF
--- a/apps/frontend/src/providers/version/manage-version-modal.ts
+++ b/apps/frontend/src/providers/version/manage-version-modal.ts
@@ -271,7 +271,10 @@ export function createManageVersionContext(
 			if (primaryFileIndex !== null) {
 				const primaryFileData = filesToAdd.value[0]?.file
 				if (primaryFileData) {
-					if (await rejectOnRedundantWrappedZip(primaryFileData)) return
+					if (await rejectOnRedundantWrappedZip(primaryFileData)) {
+						handlingNewFiles.value = false
+						return
+					}
 					await addDetectedData(primaryFileData)
 				}
 				if (filesToAdd.value.length === 1 && primaryFileData) {


### PR DESCRIPTION
Fixes #5243

## Changes

- Previously `addDetectedData` was only called when `filesToAdd.value.length === 1`.
  - Instead, we now check if there is a new *primary file* and check against that.

Confirmed fixed.