### PR TITLE
Update "Launch SFTP" button to a plain hyperlink

### DIFF
--- a/apps/frontend/src/pages/hosting/manage/[id]/options/info.vue
+++ b/apps/frontend/src/pages/hosting/manage/[id]/options/info.vue
@@ -131,7 +131,7 @@ const props = defineProps<{
 const data = computed(() => props.server.general)
 const showPassword = ref(false)
 
-const sftpUrl = `sftp://${data.value?.sftp_username}@${data.value?.sftp_host}`
+const sftpUrl = computed(() => `sftp://${data.value?.sftp_username}@${data.value?.sftp_host}`)
 
 const togglePassword = () => {
 	showPassword.value = !showPassword.value


### PR DESCRIPTION
This PR updates the "Launch SFTP" button on a hosted server's Info page to use a hyperlink rather than a button.

Using a hyperlink here provides the UX advantage of allowing the user to right-click and copy the link for use in whatever client they want, which may not be the default on their system.

Unless there was a very specific reason for using a ``<button />`` with a click action, this is generally the preferred behavior for this type of button.

Thank you!

## Demo


https://github.com/user-attachments/assets/8e3c380c-6da1-447d-9080-78c630792708

