### PR TITLE
Fix misc ui overflow issues

### DIFF
--- a/apps/frontend/src/components/ui/NavStack.vue
+++ b/apps/frontend/src/components/ui/NavStack.vue
@@ -19,7 +19,7 @@
 					<NuxtLink
 						v-else-if="item.link ?? item.to"
 						:to="(item.link ?? item.to) as string"
-						class="nav-item inline-flex w-full cursor-pointer items-center gap-2 text-nowrap rounded-xl border-none bg-transparent px-4 py-2.5 text-left text-base font-semibold leading-tight text-button-text transition-all hover:bg-button-bg hover:text-contrast active:scale-[0.97]"
+						class="nav-item inline-flex w-full cursor-pointer items-center gap-2 rounded-xl border-none bg-transparent px-4 py-2.5 text-left text-base font-semibold leading-tight text-button-text transition-all hover:bg-button-bg hover:text-contrast active:scale-[0.97]"
 						:class="{ 'is-active': isActive(item as NavStackLinkItem) }"
 					>
 						<component

--- a/packages/ui/src/components/settings/ThemeSelector.vue
+++ b/packages/ui/src/components/settings/ThemeSelector.vue
@@ -98,7 +98,7 @@ function getPreviewClass(option: T): string {
 <style scoped lang="scss">
 .theme-options {
 	display: grid;
-	grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+	grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
 	gap: var(--gap-lg);
 
 	.preview {


### PR DESCRIPTION
Fixes some ui overflow issues ive noticed with labels in other languages.

This removes `text-nowrap` from NavStack items, which doesnt look super great but will get rid of the ui overflow.

Also, theme selector items now wrap around earlier to also remove overflow, which sadly makes the retro option alone on its row.
I dont know of a cleaner way of doing this, you could maybe make the cards a bit smaller?

<img width="1627" height="837" alt="Screenshot 2026-02-11 231925" src="https://github.com/user-attachments/assets/1767a96e-881c-4aa3-8bab-1169d6f15bb1" />

<img width="1722" height="852" alt="image" src="https://github.com/user-attachments/assets/b26db01d-2ee2-4dda-aa9e-d492d8eb624e" />
