### PR TITLE
Fix library routerview race condition

### DIFF
--- a/apps/app-frontend/src/pages/library/Index.vue
+++ b/apps/app-frontend/src/pages/library/Index.vue
@@ -48,7 +48,7 @@ onUnmounted(() => {
 			]"
 		/>
 		<template v-if="instances.length > 0">
-			<RouterView :instances="instances" />
+			<RouterView v-if="route.path.startsWith('/library')" :instances="instances" />
 		</template>
 		<div v-else class="no-instance">
 			<div class="icon">


### PR DESCRIPTION
When navigating to an instance page locally, vue's suspense kept the library page mounted while the instance page loads    asynchronously. During this transition, the RouterView reacts to the route change and renders the instance's mods component with the wrong props, messing up vue's state.

This didn't reproduce in production builds because the tauri backend responds fast enough that the suspense transition was effectively instant.

Fix: Added a route guard on the RouterView so it only renders when on a /library route.