### PR TITLE
fix: email banner type warning

### DIFF
--- a/apps/frontend/src/layouts/default.vue
+++ b/apps/frontend/src/layouts/default.vue
@@ -39,7 +39,7 @@
 		<TaxComplianceBanner v-if="showTaxComplianceBanner" />
 		<VerifyEmailBanner
 			v-if="auth.user && !auth.user.email_verified && route.path !== '/auth/verify-email'"
-			:has-email="auth?.user?.email != null"
+			:has-email="!!auth?.user?.email"
 		/>
 		<SubscriptionPaymentFailedBanner
 			v-if="


### PR DESCRIPTION
Fixes this warning:

```
@modrinth/frontend:dev:  WARN  [Vue warn]: Invalid prop: type check failed for prop "hasEmail". Expected Boolean, got String with value "xander@isxander.dev". at <VerifyEmailBanner>  
```