### PR TITLE
fix: servers tab is breaking legacy navbar

### DIFF
--- a/apps/frontend/src/layouts/default.vue
+++ b/apps/frontend/src/layouts/default.vue
@@ -69,7 +69,8 @@
 				</NuxtLink>
 			</div>
 			<div
-				:class="`col-span-2 row-start-2 flex flex-wrap justify-center ${flags.projectTypesPrimaryNav ? 'gap-1' : 'gap-4'} lg:col-span-1 lg:row-start-auto`"
+				class="col-span-2 row-start-2 flex flex-wrap justify-center lg:col-span-1 lg:row-start-auto"
+				:class="{ 'gap-4': !flags.projectTypesPrimaryNav }"
 			>
 				<template v-if="flags.projectTypesPrimaryNav">
 					<ButtonStyled


### PR DESCRIPTION
## Fixes #5495 

Before:

<img width="1600" height="135" alt="image" src="https://github.com/user-attachments/assets/b4bf4f6a-f853-487b-8559-1aa95975909b" />

After:

<img width="1600" height="90" alt="image" src="https://github.com/user-attachments/assets/a8942eb3-538e-46f6-b0ca-4200459c241d" />

---

This PR fixes navbar getting broken by removing gap between tabs, however this problem will reappear on other languages or if Modrinth decides to add a new tab (e.g. Worlds).
I haven't found a way to fix it without major changes to the tree, as @T3sT3ro suggested - it's probably best to dedicate separate navbar. However I dunno what you guys think of that, considering you can only enable legacy navbar though the feature flags and not many people use it.