### PR TITLE
Hide shader configuration files from content list

### DIFF
--- a/packages/app-lib/src/state/profiles.rs
+++ b/packages/app-lib/src/state/profiles.rs
@@ -640,6 +640,8 @@ impl Profile {
                             && let Some(file_name) = subdirectory
                                 .file_name()
                                 .and_then(|x| x.to_str())
+                            && !(project_type == ProjectType::ShaderPack
+                                && file_name.ends_with(".txt"))
                         {
                             let file_size = subdirectory
                                 .metadata()
@@ -934,6 +936,8 @@ impl Profile {
                     if subdirectory.is_file()
                         && let Some(file_name) =
                             subdirectory.file_name().and_then(|x| x.to_str())
+                        && !(project_type == ProjectType::ShaderPack
+                            && file_name.ends_with(".txt"))
                     {
                         let file_size = subdirectory
                             .metadata()


### PR DESCRIPTION
When shaderpack is customized in game, a new file with shader name + `.txt`  is created in shaderpacks folder.
These files are shown in Modrinth App in content list of an instance. This PR filters them out from showing in that list making it cleaner.

Closes #4898.

### Before:
<img width="1920" height="1020" alt="before" src="https://github.com/user-attachments/assets/6e4ba9fd-de1d-4621-9660-b1acee702adc" />

### Afler:
<img width="1920" height="1020" alt="after" src="https://github.com/user-attachments/assets/b8349fa8-0be3-437f-b46d-3563129a5345" />