### PR TITLE
hosting: feature flag forcing Archon requests to be traced

### DIFF
--- a/apps/frontend/src/composables/featureFlags.ts
+++ b/apps/frontend/src/composables/featureFlags.ts
@@ -38,6 +38,7 @@ export const DEFAULT_FEATURE_FLAGS = validateValues({
 	showProjectPageQuickServerButton: false,
 	newProjectGeneralSettings: false,
 	newProjectEnvironmentSettings: true,
+	archonSentryCapture: false,
 	hideRussiaCensorshipBanner: false,
 	disablePrettyProjectUrlRedirects: false,
 	hidePreviewBanner: false,

--- a/apps/frontend/src/helpers/api.ts
+++ b/apps/frontend/src/helpers/api.ts
@@ -13,6 +13,8 @@ import {
 } from '@modrinth/api-client'
 import type { Ref } from 'vue'
 
+import { useFeatureFlags } from '~/composables/featureFlags.ts'
+
 async function getRateLimitKeyFromSecretsStore(): Promise<string | undefined> {
 	try {
 		const mod = 'cloudflare:workers'
@@ -28,6 +30,7 @@ export function createModrinthClient(
 	auth: Ref<{ token: string | undefined }>,
 	config: { apiBaseUrl: string; archonBaseUrl: string; rateLimitKey?: string },
 ): NuxtModrinthClient {
+	const flags = useFeatureFlags()
 	const optionalFeatures = [
 		import.meta.dev ? (new VerboseLoggingFeature() as AbstractFeature) : undefined,
 	].filter(Boolean) as AbstractFeature[]
@@ -35,6 +38,7 @@ export function createModrinthClient(
 	const clientConfig: NuxtClientConfig = {
 		labrinthBaseUrl: config.apiBaseUrl,
 		archonBaseUrl: config.archonBaseUrl,
+		archonSentryCapture: () => flags.value.archonSentryCapture,
 		rateLimitKey: config.rateLimitKey || getRateLimitKeyFromSecretsStore,
 		features: [
 			// for modrinth hosting

--- a/packages/api-client/src/core/abstract-client.ts
+++ b/packages/api-client/src/core/abstract-client.ts
@@ -126,6 +126,7 @@ export abstract class AbstractModrinthClient extends AbstractUploadClient {
 				...options.headers,
 			},
 		}
+		this.attachArchonSentryCaptureHeader(mergedOptions)
 
 		const headers = mergedOptions.headers
 		if (headers && 'Content-Type' in headers && headers['Content-Type'] === '') {
@@ -307,6 +308,21 @@ export abstract class AbstractModrinthClient extends AbstractUploadClient {
 		}
 
 		return headers
+	}
+
+	protected attachArchonSentryCaptureHeader(options: RequestOptions): void {
+		if (options.api !== 'archon' || !options.headers || !this.shouldCaptureArchonRequests()) {
+			return
+		}
+
+		options.headers['modrinth-sentry-capture'] = '1'
+	}
+
+	private shouldCaptureArchonRequests(): boolean {
+		const archonSentryCapture = this.config.archonSentryCapture
+		return typeof archonSentryCapture === 'function'
+			? archonSentryCapture()
+			: archonSentryCapture === true
 	}
 
 	/**

--- a/packages/api-client/src/platform/xhr-upload-client.ts
+++ b/packages/api-client/src/platform/xhr-upload-client.ts
@@ -46,6 +46,7 @@ export abstract class XHRUploadClient extends AbstractModrinthClient {
 				...options.headers,
 			},
 		}
+		this.attachArchonSentryCaptureHeader(mergedOptions)
 
 		const context = this.buildUploadContext(url, path, mergedOptions)
 

--- a/packages/api-client/src/types/client.ts
+++ b/packages/api-client/src/types/client.ts
@@ -56,6 +56,14 @@ export interface ClientConfig {
 	headers?: Record<string, string>
 
 	/**
+	 * Whether to attach `modrinth-sentry-capture: 1` to Archon requests.
+	 * Can be a callback so apps can drive this from runtime feature flags.
+	 *
+	 * @default false
+	 */
+	archonSentryCapture?: boolean | (() => boolean)
+
+	/**
 	 * Features to enable for this client
 	 * Features are applied in the order they appear in this array
 	 */


### PR DESCRIPTION
Archon supports setting `Modrinth-Sentry-Capture: 1` to have the request bypass the configured sampling rate & force the transactions to be pushed to Sentry.