### PR TITLE
fix modpacks no loader

### DIFF
--- a/apps/frontend/src/pages/[type]/[id]/version/[version].vue
+++ b/apps/frontend/src/pages/[type]/[id]/version/[version].vue
@@ -714,8 +714,8 @@ const modpackLoaders = computed<string[]>(() => {
 const noModpackLoader = computed(
 	() =>
 		project.value.project_type === 'modpack' &&
-		modpackLoaders.value.length === 1 &&
-		modpackLoaders.value[0] === 'minecraft',
+		((modpackLoaders.value.length === 1 && modpackLoaders.value[0] === 'minecraft') ||
+			modpackLoaders.value.length === 0),
 )
 
 const description = computed(

--- a/packages/ui/src/components/project/ProjectPageVersions.vue
+++ b/packages/ui/src/components/project/ProjectPageVersions.vue
@@ -343,7 +343,10 @@ function getModpackLoaders(version: VersionWithDisplayUrlEnding): string[] {
 
 function hasNoModLoader(loaders: string[]): boolean {
 	return (
-		props.project.project_type === 'modpack' && loaders.length === 1 && loaders[0] === 'minecraft'
+		(props.project.project_type === 'modpack' &&
+			loaders.length === 1 &&
+			loaders[0] === 'minecraft') ||
+		loaders.length === 0
 	)
 }
 

--- a/packages/ui/src/components/project/ProjectSidebarCompatibility.vue
+++ b/packages/ui/src/components/project/ProjectSidebarCompatibility.vue
@@ -141,9 +141,10 @@ const props = defineProps<{
 
 const noModpackLoader = computed(
 	() =>
-		props.projectV3?.project_types.includes('modpack') &&
-		props.projectV3?.mrpack_loaders.length === 1 &&
-		props.projectV3?.mrpack_loaders[0] === 'minecraft',
+		(props.projectV3?.project_types.includes('modpack') &&
+			props.projectV3?.mrpack_loaders.length === 1 &&
+			props.projectV3?.mrpack_loaders[0] === 'minecraft') ||
+		props.projectV3?.mrpack_loaders.length === 0,
 )
 
 const showEnvironments = computed(


### PR DESCRIPTION
- Fix modpack projects not properly displaying "No modpack loader" Example project: https://modrinth.com/modpack/sigma-pi-cobbleverse/version/1.1