### PR TITLE
fix: use nullish coalescing instead of OR on fraction digits

### DIFF
--- a/packages/ui/src/composables/format-money.ts
+++ b/packages/ui/src/composables/format-money.ts
@@ -68,7 +68,7 @@ function getMaxDigits(currency: string): number {
 				style: 'currency',
 				currency,
 			})
-			maxDigits = formatter.resolvedOptions().maximumFractionDigits || 2
+			maxDigits = formatter.resolvedOptions().maximumFractionDigits ?? 2
 		} catch {
 			maxDigits = 2
 		}


### PR DESCRIPTION
for zero-decimal currencies like JPY or VND, this is returning 2 instead of 0