### PR TITLE
fix(maven): return escaped summary for project description

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4941,6 +4941,7 @@ dependencies = [
  "paste",
  "path-util",
  "prometheus",
+ "quick-xml 0.38.3",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "redis",

--- a/apps/labrinth/Cargo.toml
+++ b/apps/labrinth/Cargo.toml
@@ -80,6 +80,7 @@ murmur2 = { workspace = true }
 paste = { workspace = true }
 path-util = { workspace = true }
 prometheus = { workspace = true }
+quick-xml = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
 redis = { workspace = true, features = ["ahash", "r2d2", "tokio-comp"] }

--- a/apps/labrinth/src/routes/maven.rs
+++ b/apps/labrinth/src/routes/maven.rs
@@ -329,7 +329,7 @@ pub async fn version_file(
             artifact_id: project_id,
             version: vnum,
             name: project.inner.name,
-            description: project.inner.description,
+            description: format!(r#""{}""#, project.inner.summary),
         };
         return Ok(HttpResponse::Ok()
             .content_type("text/xml")

--- a/apps/labrinth/src/routes/maven.rs
+++ b/apps/labrinth/src/routes/maven.rs
@@ -13,6 +13,7 @@ use crate::queue::session::AuthQueue;
 use crate::routes::ApiError;
 use crate::{auth::get_user_from_headers, database};
 use actix_web::{HttpRequest, HttpResponse, get, route, web};
+use quick_xml::escape::escape;
 use std::collections::HashSet;
 use yaserde::YaSerialize;
 
@@ -329,7 +330,7 @@ pub async fn version_file(
             artifact_id: project_id,
             version: vnum,
             name: project.inner.name,
-            description: format!(r#""{}""#, project.inner.summary),
+            description: escape(project.inner.summary).into_owned(),
         };
         return Ok(HttpResponse::Ok()
             .content_type("text/xml")


### PR DESCRIPTION
Project summary aligns more with the description field: "A short, human-readable description of the project" ([source](https://maven.apache.org/pom.html#More_Project_Information)). Also wraps the summary in quotations to avoid possible XML parsing.

Closes #3152 