### PR TITLE
fix(teams): accept username in edit member endpoint

### DIFF
--- a/apps/labrinth/src/routes/v2/teams.rs
+++ b/apps/labrinth/src/routes/v2/teams.rs
@@ -296,7 +296,7 @@ pub struct EditTeamMember {
 #[patch("/{id}/members/{user_id}")]
 pub async fn edit_team_member(
     req: HttpRequest,
-    info: web::Path<(TeamId, UserId)>,
+    info: web::Path<(TeamId, String)>,
     pool: web::Data<PgPool>,
     edit_member: web::Json<EditTeamMember>,
     redis: web::Data<RedisPool>,

--- a/apps/labrinth/src/routes/v3/teams.rs
+++ b/apps/labrinth/src/routes/v3/teams.rs
@@ -4,7 +4,9 @@ use crate::database::DBProject;
 use crate::database::PgPool;
 use crate::database::models::notification_item::NotificationBuilder;
 use crate::database::models::team_item::TeamAssociationId;
-use crate::database::models::{DBOrganization, DBTeam, DBTeamMember, DBUser};
+use crate::database::models::{
+    DBOrganization, DBTeam, DBTeamMember, DBUser, DBUserId,
+};
 use crate::database::redis::RedisPool;
 use crate::models::ids::TeamId;
 use crate::models::notifications::NotificationBody;
@@ -689,7 +691,7 @@ pub struct EditTeamMember {
 
 pub async fn edit_team_member(
     req: HttpRequest,
-    info: web::Path<(TeamId, UserId)>,
+    info: web::Path<(TeamId, String)>,
     pool: web::Data<PgPool>,
     edit_member: web::Json<EditTeamMember>,
     redis: web::Data<RedisPool>,
@@ -697,7 +699,15 @@ pub async fn edit_team_member(
 ) -> Result<HttpResponse, ApiError> {
     let ids = info.into_inner();
     let id = ids.0.into();
-    let user_id = ids.1.into();
+
+    let user_id = DBUser::get(&ids.1, &**pool, &redis)
+        .await?
+        .ok_or_else(|| {
+            ApiError::InvalidInput(
+                "The user specified does not exist".to_string(),
+            )
+        })?
+        .id;
 
     let current_user = get_user_from_headers(
         &req,

--- a/apps/labrinth/src/routes/v3/teams.rs
+++ b/apps/labrinth/src/routes/v3/teams.rs
@@ -714,24 +714,19 @@ pub async fn edit_team_member(
     .await?
     .1;
 
-    let team_association =
-        DBTeam::get_association(id, &**pool).await?.ok_or_else(|| {
-            ApiError::InvalidInput(
-                "The team specified does not exist".to_string(),
-            )
-        })?;
+    let team_association = DBTeam::get_association(id, &**pool)
+        .await?
+        .wrap_request_err("The team specified does not exist")?;
     let member =
         DBTeamMember::get_from_user_id(id, current_user.id.into(), &**pool)
             .await?;
     let edit_member_db =
         DBTeamMember::get_from_user_id_pending(id, user_id, &**pool)
             .await?
-            .ok_or_else(|| {
-                ApiError::Request(eyre!(
-                    "This member does not exist in this team - \
-                    the member must first be created via `POST`"
-                ))
-            })?;
+            .wrap_request_err(
+                "This member does not exist in this team - \
+                    the member must first be created via `POST`",
+            )?;
 
     let mut transaction = pool.begin().await?;
 

--- a/apps/labrinth/src/routes/v3/teams.rs
+++ b/apps/labrinth/src/routes/v3/teams.rs
@@ -4,9 +4,7 @@ use crate::database::DBProject;
 use crate::database::PgPool;
 use crate::database::models::notification_item::NotificationBuilder;
 use crate::database::models::team_item::TeamAssociationId;
-use crate::database::models::{
-    DBOrganization, DBTeam, DBTeamMember, DBUser, DBUserId,
-};
+use crate::database::models::{DBOrganization, DBTeam, DBTeamMember, DBUser};
 use crate::database::redis::RedisPool;
 use crate::models::ids::TeamId;
 use crate::models::notifications::NotificationBody;

--- a/apps/labrinth/src/routes/v3/teams.rs
+++ b/apps/labrinth/src/routes/v3/teams.rs
@@ -699,8 +699,9 @@ pub async fn edit_team_member(
     let id = ids.0.into();
 
     let user_id = DBUser::get(&ids.1, &**pool, &redis)
-        .await?
-        .wrap_internal_err("Failed to fetch the specified user")?
+        .await
+        .wrap_internal_err("failed to fetch the specified user")?
+        .wrap_request_err("the specified user does not exist")?
         .id;
 
     let current_user = get_user_from_headers(
@@ -714,17 +715,18 @@ pub async fn edit_team_member(
     .1;
 
     let team_association = DBTeam::get_association(id, &**pool)
-        .await?
-        .wrap_internal_err("Failed to fetch the specified team")?;
+        .await
+        .wrap_internal_err("failed to fetch the specified team")?
+        .wrap_request_err("the specified team does not exist")?;
     let member =
         DBTeamMember::get_from_user_id(id, current_user.id.into(), &**pool)
             .await?;
     let edit_member_db =
         DBTeamMember::get_from_user_id_pending(id, user_id, &**pool)
-            .await?
-            .wrap_internal_err(
-                "Failed to fetch team member: \
-				this member does not exist in this team - \
+            .await
+            .wrap_internal_err("failed to fetch team member")?
+            .wrap_request_err(
+                "this member does not exist in this team - \
 				the member must first be created via `POST`",
             )?;
 

--- a/apps/labrinth/src/routes/v3/teams.rs
+++ b/apps/labrinth/src/routes/v3/teams.rs
@@ -700,7 +700,7 @@ pub async fn edit_team_member(
 
     let user_id = DBUser::get(&ids.1, &**pool, &redis)
         .await?
-        .wrap_request_err("The user specified does not exist")?
+        .wrap_internal_err("Failed to fetch the specified user")?
         .id;
 
     let current_user = get_user_from_headers(
@@ -715,16 +715,17 @@ pub async fn edit_team_member(
 
     let team_association = DBTeam::get_association(id, &**pool)
         .await?
-        .wrap_request_err("The team specified does not exist")?;
+        .wrap_internal_err("Failed to fetch the specified team")?;
     let member =
         DBTeamMember::get_from_user_id(id, current_user.id.into(), &**pool)
             .await?;
     let edit_member_db =
         DBTeamMember::get_from_user_id_pending(id, user_id, &**pool)
             .await?
-            .wrap_request_err(
-                "This member does not exist in this team - \
-                    the member must first be created via `POST`",
+            .wrap_internal_err(
+                "Failed to fetch team member: \
+				this member does not exist in this team - \
+				the member must first be created via `POST`",
             )?;
 
     let mut transaction = pool.begin().await?;

--- a/apps/labrinth/src/routes/v3/teams.rs
+++ b/apps/labrinth/src/routes/v3/teams.rs
@@ -15,7 +15,6 @@ use crate::routes::ApiError;
 use crate::util::error::Context;
 use actix_web::{HttpRequest, HttpResponse, get, web};
 use ariadne::ids::UserId;
-use eyre::eyre;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 

--- a/apps/labrinth/src/routes/v3/teams.rs
+++ b/apps/labrinth/src/routes/v3/teams.rs
@@ -12,6 +12,7 @@ use crate::models::pats::Scopes;
 use crate::models::teams::{OrganizationPermissions, ProjectPermissions};
 use crate::queue::session::AuthQueue;
 use crate::routes::ApiError;
+use crate::util::error::Context;
 use actix_web::{HttpRequest, HttpResponse, get, web};
 use ariadne::ids::UserId;
 use eyre::eyre;
@@ -700,11 +701,7 @@ pub async fn edit_team_member(
 
     let user_id = DBUser::get(&ids.1, &**pool, &redis)
         .await?
-        .ok_or_else(|| {
-            ApiError::InvalidInput(
-                "The user specified does not exist".to_string(),
-            )
-        })?
+        .wrap_request_err("The user specified does not exist")?
         .id;
 
     let current_user = get_user_from_headers(


### PR DESCRIPTION
Previously, all inputs to the id/username argument were treated as ids regardless of whether they were or not. Now the input is resolved to a user to obtain a user id before proceeding.

Closes #2568 