### PR TITLE
chore: bump cidre

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1572,18 +1572,19 @@ dependencies = [
 
 [[package]]
 name = "cidre"
-version = "0.11.3"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc0eb4d7faf9f94493eaf7e7c0534dee2dfa9642353382039572abb4e0e56e9"
+checksum = "0c903ff1729987d29e07295d2c5841993db25ff86cca43bee04505878d3ec1a7"
 dependencies = [
+ "cc",
  "cidre-macros",
 ]
 
 [[package]]
 name = "cidre-macros"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82bc2f84c0baaa09299da3a03864491549685912c1e338a54211e00589dc1e4c"
+checksum = "6facfeffa8b9792dc014bb4e65e364d13518b74e06783d56249810a3e48cfad7"
 
 [[package]]
 name = "cityhash-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ bytes = "1.10.1"
 censor = "0.3.0"
 chardetng = "0.1.17"
 chrono = "0.4.42"
-cidre = { version = "0.11.3", default-features = false, features = [
+cidre = { version = "0.15.0", default-features = false, features = [
   "macos_15_0"
 ] }
 clap = "4.5.48"


### PR DESCRIPTION
I ran into some issues when trying to package the Modrinth App in `nixpkgs` for macOS (darwin). Updating `cidre` seems to have resolved that issue and would make it so we don't have to manually patch the dependency. I tested the changes thoroughly on my darwin WM and couldn't find any regression added by it. 