### PR TITLE
Modfied a translation

### DIFF
--- a/packages/ui/src/locales/it-IT/index.json
+++ b/packages/ui/src/locales/it-IT/index.json
@@ -42,7 +42,7 @@
     "defaultMessage": "Beta"
   },
   "badge.beta-release": {
-    "defaultMessage": "Rilascio in beta"
+    "defaultMessage": "Rilascio beta"
   },
   "badge.new": {
     "defaultMessage": "Novità"


### PR DESCRIPTION
I modified an incorrect translation:
OLD:
  "badge.beta-release": {
    "defaultMessage": "Rilascio in beta"
 Fixed:
   "badge.beta-release": {
    "defaultMessage": "Rilascio beta"
