### PR TITLE
fix: send boolean filter values without quotes

### DIFF
--- a/packages/ui/src/utils/search.ts
+++ b/packages/ui/src/utils/search.ts
@@ -474,7 +474,7 @@ export function useSearch(
 					}
 					orGroups[field].push(val)
 				} else {
-					parts.push(`${field} = "${val}"`)
+					parts.push(`${field} = ${val === 'true' || val === 'false' ? val : `"${val}"`}`)
 				}
 			}
 		}


### PR DESCRIPTION
fixes an issue where the open source filter returned no results because open_source=true was serialized as a quoted string ("true") in new_filters instead of a boolean.