### PR TITLE
fix: can't auto install JRE on macOS

### DIFF
--- a/packages/app-lib/src/api/jre.rs
+++ b/packages/app-lib/src/api/jre.rs
@@ -135,7 +135,6 @@ pub async fn auto_install_java(java_version: u32) -> crate::Result<PathBuf> {
         #[cfg(target_os = "macos")]
         {
             base_path = base_path
-                .join(format!("zulu-{java_version}.jre"))
                 .join("Contents")
                 .join("Home")
                 .join("bin")


### PR DESCRIPTION
Fixes the JRE auto install process on macOS (#5891)

The way Zulu JREs are packaged on macOS was changed a week ago, and the Modrinth App hasn't been updated to reflect these changes, meaning anyone who tries to auto install Java will be met with an I/O error.

Related patch notes:
https://docs.azul.com/core/release/october-2025/release-notes?r=zulu#detection-macos
https://docs.azul.com/core/release/january-2026/release-notes?r=zulu#better-support-for-jvm-detection-on-macos
https://docs.azul.com/core/release/april-2026/release-notes?r=zulu#better-support-for-jvm-detection-on-macos