### PR TITLE
Add git.gay as a common source domain

### DIFF
--- a/packages/moderation/src/data/nags/links.ts
+++ b/packages/moderation/src/data/nags/links.ts
@@ -3,7 +3,7 @@ import { defineMessage, useVIntl } from '@modrinth/ui'
 import type { Nag, NagContext } from '../../types/nags'
 
 export const commonLinkDomains = {
-	source: ['github.com', 'gitlab.com', 'bitbucket.org', 'codeberg.org', 'git.sr.ht', 'tangled.org'],
+	source: ['github.com', 'gitlab.com', 'bitbucket.org', 'codeberg.org', 'git.sr.ht', 'tangled.org', 'git.gay'],
 	issues: [
 		'github.com',
 		'gitlab.com',
@@ -11,6 +11,7 @@ export const commonLinkDomains = {
 		'codeberg.org',
 		'docs.google.com',
 		'tangled.org',
+		'git.gay',
 	],
 	discord: ['discord.gg', 'discord.com', 'dsc.gg'],
 	licenseBlocklist: [

--- a/packages/moderation/src/data/nags/links.ts
+++ b/packages/moderation/src/data/nags/links.ts
@@ -3,7 +3,15 @@ import { defineMessage, useVIntl } from '@modrinth/ui'
 import type { Nag, NagContext } from '../../types/nags'
 
 export const commonLinkDomains = {
-	source: ['github.com', 'gitlab.com', 'bitbucket.org', 'codeberg.org', 'git.sr.ht', 'tangled.org', 'git.gay'],
+	source: [
+		'github.com',
+		'gitlab.com',
+		'bitbucket.org',
+		'codeberg.org',
+		'git.sr.ht',
+		'tangled.org',
+		'git.gay',
+	],
 	issues: [
 		'github.com',
 		'gitlab.com',


### PR DESCRIPTION
When I added my mod, it complained that git.gay is not a common source domain. So I wanted to fix this.