### PR TITLE
fix: typo "recieving" in logs placeholder

### DIFF
--- a/packages/ui/src/components/base/BaseTerminal.vue
+++ b/packages/ui/src/components/base/BaseTerminal.vue
@@ -86,7 +86,7 @@ const EMPTY_STATE_BUBBLES: Record<string, string[]> = {
 	instance: [
 		'   _____________________________________________________________',
 		' /  Start your instance in the top right to start               \\',
-		'|   recieving live logs!                                        |',
+		'|   receiving live logs!                                        |',
 		' \\_____________________________________________________________/',
 	],
 }


### PR DESCRIPTION
This PR fixes a typo in the ASCII graphic shown when client logs are yet to arrive.

### Changes
* Replaced "recieving" with "receiving".

### Screenshot (before)
<img width="3682" height="1657" alt="image" src="https://github.com/user-attachments/assets/5f7fa20f-1d67-4edc-a651-fb50c6d673ed" />

