### PR TITLE
fix: neoforge mc version inferring incorrectly

### DIFF
--- a/apps/frontend/src/helpers/infer/loader-parsers.ts
+++ b/apps/frontend/src/helpers/infer/loader-parsers.ts
@@ -28,14 +28,18 @@ export function createLoaderParsers(
 			if (metadata.dependencies) {
 				const neoForgeDependency = Object.values(metadata.dependencies)
 					.flat()
-					.find((dependency: any) => dependency.modId === 'neoforge')
+					.filter((dependency: any) => dependency.modId === 'neoforge')
+					.map((dependency: any) => dependency.versionRange)
+					.find((range) => range)
 				const minecraftDependency = Object.values(metadata.dependencies)
 					.flat()
-					.find((dependency: any) => dependency.modId === 'minecraft')
+					.filter((dependency: any) => dependency.modId === 'minecraft')
+					.map((dependency: any) => dependency.versionRange)
+					.find((range) => range)
 
 				if (minecraftDependency) {
 					newGameVersions = getGameVersionsMatchingMavenRange(
-						(minecraftDependency as any).versionRange,
+						minecraftDependency,
 						simplifiedGameVersions,
 					)
 				} else if (neoForgeDependency) {
@@ -46,7 +50,7 @@ export function createLoaderParsers(
 						/^(?<mc_year>\d+)(?:\.(?<mc_drop>\d+))?(?:\.(?<mc_patch>\d+)?)?(?:\.(\d+))?$/
 
 					newGameVersions = getGameVersionsMatchingMavenRange(
-						(neoForgeDependency as any).versionRange.replace('-beta', ''),
+						neoForgeDependency.replace('-beta', ''),
 						simplifiedGameVersions,
 						(version) => {
 							const matchPre26 = version.match(neoPre26Regex)

--- a/apps/frontend/src/helpers/infer/loader-parsers.ts
+++ b/apps/frontend/src/helpers/infer/loader-parsers.ts
@@ -29,25 +29,39 @@ export function createLoaderParsers(
 				const neoForgeDependency = Object.values(metadata.dependencies)
 					.flat()
 					.find((dependency: any) => dependency.modId === 'neoforge')
+				const minecraftDependency = Object.values(metadata.dependencies)
+					.flat()
+					.find((dependency: any) => dependency.modId === 'minecraft')
 
-				if (neoForgeDependency) {
-					try {
-						// https://docs.neoforged.net/docs/gettingstarted/versioning/#neoforge
-						const mcVersionRange = (neoForgeDependency as any).versionRange
-							.replace('-beta', '')
-							.replace(
-								/(\d+)(?:\.(\d+))?(?:\.(\d+)?)?/g,
-								(_match: string, major: string, minor: string) => {
-									return `1.${major}${minor ? '.' + minor : ''}`
-								},
-							)
-						newGameVersions = getGameVersionsMatchingMavenRange(
-							mcVersionRange,
-							simplifiedGameVersions,
-						)
-					} catch {
-						// Ignore parsing errors, just leave game_versions empty
-					}
+				if (minecraftDependency) {
+					newGameVersions = getGameVersionsMatchingMavenRange(
+						(minecraftDependency as any).versionRange,
+						simplifiedGameVersions,
+					)
+				} else if (neoForgeDependency) {
+					// https://docs.neoforged.net/docs/gettingstarted/versioning/#neoforge
+					// NeoForge's versioning changed after Mojang changed from 1.<major>.<minor> to <year>.<drop>.<patch>, so both cases need to be handled
+					const neoPre26Regex = /^(?<mc_major>\d+)(?:\.(?<mc_minor>\d+))?(?:\.(?<neo>\d+)?)?$/
+					const neoPost26Regex =
+						/^(?<mc_year>\d+)(?:\.(?<mc_drop>\d+))?(?:\.(?<mc_patch>\d+)?)?(?:\.(\d+))?$/
+
+					newGameVersions = getGameVersionsMatchingMavenRange(
+						(neoForgeDependency as any).versionRange.replace('-beta', ''),
+						simplifiedGameVersions,
+						(version) => {
+							const matchPre26 = version.match(neoPre26Regex)
+							if (matchPre26 && matchPre26.groups) {
+								const { mc_major, mc_minor } = matchPre26.groups
+								return mc_minor ? `1.${mc_major}.${mc_minor}` : `1.${mc_major}`
+							}
+							const matchPost26 = version.match(neoPost26Regex)
+							if (matchPost26 && matchPost26.groups) {
+								const { mc_year, mc_drop, mc_patch } = matchPost26.groups
+								return `${mc_year}${mc_drop ? `.${mc_drop}` : ''}${mc_patch ? `.${mc_patch}` : ''}`
+							}
+							return version
+						},
+					)
 				}
 			}
 

--- a/apps/frontend/src/helpers/infer/version-ranges.ts
+++ b/apps/frontend/src/helpers/infer/version-ranges.ts
@@ -25,6 +25,7 @@ export function getGameVersionsMatchingSemverRange(
 export function getGameVersionsMatchingMavenRange(
 	range: string | undefined,
 	gameVersions: string[],
+	processor: (version: string) => string | null = (v) => v,
 ): string[] {
 	if (!range) {
 		return []
@@ -63,24 +64,42 @@ export function getGameVersionsMatchingMavenRange(
 
 	for (const range of ranges) {
 		let result
-		if ((result = range.match(LESS_THAN_EQUAL))) {
-			semverRanges.push(`<=${result[1]}`)
-		} else if ((result = range.match(LESS_THAN))) {
-			semverRanges.push(`<${result[1]}`)
-		} else if ((result = range.match(EQUAL))) {
-			semverRanges.push(`${result[1]}`)
-		} else if ((result = range.match(GREATER_THAN_EQUAL))) {
-			semverRanges.push(`>=${result[1]}`)
-		} else if ((result = range.match(GREATER_THAN))) {
-			semverRanges.push(`>${result[1]}`)
-		} else if ((result = range.match(BETWEEN))) {
-			semverRanges.push(`>${result[1]} <${result[2]}`)
-		} else if ((result = range.match(BETWEEN_EQUAL))) {
-			semverRanges.push(`>=${result[1]} <=${result[2]}`)
-		} else if ((result = range.match(BETWEEN_LESS_THAN_EQUAL))) {
-			semverRanges.push(`>${result[1]} <=${result[2]}`)
-		} else if ((result = range.match(BETWEEN_GREATER_THAN_EQUAL))) {
-			semverRanges.push(`>=${result[1]} <${result[2]}`)
+		let version1
+		let version2
+		if ((result = range.match(LESS_THAN_EQUAL)) && (version1 = processor(result[1]))) {
+			semverRanges.push(`<=${version1}`)
+		} else if ((result = range.match(LESS_THAN)) && (version1 = processor(result[1]))) {
+			semverRanges.push(`<${version1}`)
+		} else if ((result = range.match(EQUAL)) && (version1 = processor(result[1]))) {
+			semverRanges.push(`${version1}`)
+		} else if ((result = range.match(GREATER_THAN_EQUAL)) && (version1 = processor(result[1]))) {
+			semverRanges.push(`>=${version1}`)
+		} else if ((result = range.match(GREATER_THAN)) && (version1 = processor(result[1]))) {
+			semverRanges.push(`>${version1}`)
+		} else if (
+			(result = range.match(BETWEEN)) &&
+			(version1 = processor(result[1])) &&
+			(version2 = processor(result[2]))
+		) {
+			semverRanges.push(`>${version1} <${version2}`)
+		} else if (
+			(result = range.match(BETWEEN_EQUAL)) &&
+			(version1 = processor(result[1])) &&
+			(version2 = processor(result[2]))
+		) {
+			semverRanges.push(`>=${version1} <=${version2}`)
+		} else if (
+			(result = range.match(BETWEEN_LESS_THAN_EQUAL)) &&
+			(version1 = processor(result[1])) &&
+			(version2 = processor(result[2]))
+		) {
+			semverRanges.push(`>${version1} <=${version2}`)
+		} else if (
+			(result = range.match(BETWEEN_GREATER_THAN_EQUAL)) &&
+			(version1 = processor(result[1])) &&
+			(version2 = processor(result[2]))
+		) {
+			semverRanges.push(`>=${version1} <${version2}`)
 		}
 	}
 	return getGameVersionsMatchingSemverRange(semverRanges, gameVersions)


### PR DESCRIPTION
changes to neoforge inferring:
- uses minecraft dependency if available as the neoforge version is usually incorrect due to too broad of a range
- fixes neoforge version parsing for 26+
- properly checks if `versionRange` exists