### PR TITLE
fix: always hide custom window decorations on linux

### DIFF
--- a/apps/app-frontend/src/App.vue
+++ b/apps/app-frontend/src/App.vue
@@ -214,7 +214,6 @@ window.addEventListener('online', () => {
 })
 
 const showOnboarding = ref(false)
-const nativeDecorations = ref(false)
 
 const os = ref('')
 const isDevEnvironment = ref(false)
@@ -330,8 +329,9 @@ async function setupApp() {
 	const version = await getVersion()
 	showOnboarding.value = !onboarded
 
-	nativeDecorations.value = native_decorations
-	if (os.value !== 'MacOS') await getCurrentWindow().setDecorations(native_decorations)
+	if (os.value !== 'MacOS' && os.value !== 'Linux') {
+		await getCurrentWindow().setDecorations(native_decorations)
+	}
 
 	themeStore.setThemeState(theme)
 	themeStore.collapsedNavigation = collapsed_navigation

--- a/apps/app-frontend/src/components/ui/WindowControls.vue
+++ b/apps/app-frontend/src/components/ui/WindowControls.vue
@@ -51,7 +51,7 @@ const alwaysShowAppControls = computed(() => themeStore.getFeatureFlag('always_s
 const showControls = computed(
 	() =>
 		alwaysShowAppControls.value ||
-		(!nativeDecorations.value && (os.value === 'Windows' || os.value === 'Linux')),
+		(!nativeDecorations.value && os.value !== 'MacOS' && os.value !== 'Linux'),
 )
 
 onMounted(async () => {
@@ -60,7 +60,7 @@ onMounted(async () => {
 	const settings = await getSettings()
 	nativeDecorations.value = settings.native_decorations
 
-	if (os.value !== 'MacOS') {
+	if (os.value !== 'MacOS' && os.value !== 'Linux') {
 		await getCurrentWindow().setDecorations(nativeDecorations.value)
 	}
 

--- a/apps/app-frontend/src/components/ui/settings/AppearanceSettings.vue
+++ b/apps/app-frontend/src/components/ui/settings/AppearanceSettings.vue
@@ -163,7 +163,7 @@ watch(
 		<Toggle id="hide-nametag-skins-page" v-model="settings.hide_nametag_skins_page" />
 	</div>
 
-	<div v-if="os !== 'MacOS'" class="mt-6 flex items-center justify-between gap-4">
+	<div v-if="os !== 'MacOS' && os !== 'Linux'" class="mt-6 flex items-center justify-between gap-4">
 		<div>
 			<h2 class="m-0 text-lg font-semibold text-contrast">
 				{{ formatMessage(messages.nativeDecorationsTitle) }}


### PR DESCRIPTION
on linux, it doesn't really make sense to use non-native decorations since each desktop environment has its own thing and unique way to do it. better to just stay out of it even if it means a little extra wasted space.

Closes https://github.com/flathub/com.modrinth.ModrinthApp/issues/4