### PR TITLE
fix: app caching invalid values before checking if they are valid

### DIFF
--- a/packages/app-lib/src/state/cache.rs
+++ b/packages/app-lib/src/state/cache.rs
@@ -904,7 +904,8 @@ impl CachedEntry {
                     remaining_keys.retain(|x| {
                         x != &&*row.id
                             && !row.alias.as_ref().is_some_and(|y| {
-                                if type_.case_sensitive_alias().unwrap_or(true) {
+                                if type_.case_sensitive_alias().unwrap_or(true)
+                                {
                                     x == y
                                 } else {
                                     y.to_lowercase() == x.to_lowercase()

--- a/packages/app-lib/src/state/cache.rs
+++ b/packages/app-lib/src/state/cache.rs
@@ -890,17 +890,6 @@ impl CachedEntry {
                     }
                 }
 
-                remaining_keys.retain(|x| {
-                    x != &&*row.id
-                        && !row.alias.as_ref().is_some_and(|y| {
-                            if type_.case_sensitive_alias().unwrap_or(true) {
-                                x == y
-                            } else {
-                                y.to_lowercase() == x.to_lowercase()
-                            }
-                        })
-                });
-
                 if let Some(data) = parsed_data {
                     if data.get_type() != type_ {
                         return Err(crate::ErrorKind::OtherError(format!(
@@ -911,6 +900,17 @@ impl CachedEntry {
                         ))
                         .as_error());
                     }
+
+                    remaining_keys.retain(|x| {
+                        x != &&*row.id
+                            && !row.alias.as_ref().is_some_and(|y| {
+                                if type_.case_sensitive_alias().unwrap_or(true) {
+                                    x == y
+                                } else {
+                                    y.to_lowercase() == x.to_lowercase()
+                                }
+                            })
+                    });
 
                     return_vals.push(Self {
                         id: row.id,


### PR DESCRIPTION
This should fix this longstanding issue requiring users to purge their cache by collecting the uncached data after filtering out the invalid ones. Tested to work by simulating nulls in the db, on prod it shows the unable to read tags error, on this branch it just fetches new tags without error.

Closes #2919