### PR TITLE
fix(app): prevent browse controls from wrapping

### DIFF
--- a/packages/ui/src/components/base/Combobox.vue
+++ b/packages/ui/src/components/base/Combobox.vue
@@ -62,18 +62,20 @@
 			@click="handleTriggerClick($event)"
 			@keydown="handleTriggerKeydown"
 		>
-			<div class="flex items-center gap-2">
-				<slot name="prefix"></slot>
+			<div class="flex min-w-0 items-center gap-2">
+				<span class="shrink-0 whitespace-nowrap">
+					<slot name="prefix"></slot>
+				</span>
 				<component
 					:is="selectedOption?.icon"
 					v-if="showIconInSelected && selectedOption?.icon"
-					class="h-5 w-5"
+					class="h-5 w-5 shrink-0"
 				/>
-				<span class="text-primary font-semibold leading-tight">
+				<span class="min-w-0 truncate whitespace-nowrap text-primary font-semibold leading-tight">
 					<slot name="selected">{{ triggerText }}</slot>
 				</span>
 			</div>
-			<div class="flex items-center gap-1">
+			<div class="flex shrink-0 items-center gap-1">
 				<slot name="suffix"></slot>
 				<ChevronLeftIcon
 					v-if="showChevron"

--- a/packages/ui/src/components/base/Combobox.vue
+++ b/packages/ui/src/components/base/Combobox.vue
@@ -62,20 +62,18 @@
 			@click="handleTriggerClick($event)"
 			@keydown="handleTriggerKeydown"
 		>
-			<div class="flex min-w-0 items-center gap-2">
-				<span class="shrink-0 whitespace-nowrap">
-					<slot name="prefix"></slot>
-				</span>
+			<div class="flex items-center gap-2">
+				<slot name="prefix"></slot>
 				<component
 					:is="selectedOption?.icon"
 					v-if="showIconInSelected && selectedOption?.icon"
-					class="h-5 w-5 shrink-0"
+					class="h-5 w-5"
 				/>
-				<span class="min-w-0 truncate whitespace-nowrap text-primary font-semibold leading-tight">
+				<span class="text-primary font-semibold leading-tight">
 					<slot name="selected">{{ triggerText }}</slot>
 				</span>
 			</div>
-			<div class="flex shrink-0 items-center gap-1">
+			<div class="flex items-center gap-1">
 				<slot name="suffix"></slot>
 				<ChevronLeftIcon
 					v-if="showChevron"

--- a/packages/ui/src/layouts/shared/browse-tab/layout.vue
+++ b/packages/ui/src/layouts/shared/browse-tab/layout.vue
@@ -99,7 +99,7 @@ const messages = defineMessages({
 		<Combobox
 			:model-value="ctx.effectiveCurrentSortType.value"
 			:options="sortOptions"
-			:class="ctx.variant === 'web' ? '!w-auto flex-grow md:flex-grow-0' : 'max-w-[16rem]'"
+			:class="ctx.variant === 'web' ? '!w-auto flex-grow md:flex-grow-0' : '!w-auto max-w-full'"
 			@update:model-value="(val: SortType) => (ctx.effectiveCurrentSortType.value = val)"
 		>
 			<template #prefix>
@@ -112,7 +112,7 @@ const messages = defineMessages({
 		<Combobox
 			:model-value="ctx.maxResults.value"
 			:options="maxResultsOptions"
-			:class="ctx.variant === 'web' ? '!w-auto flex-grow md:flex-grow-0' : 'max-w-[9rem]'"
+			:class="ctx.variant === 'web' ? '!w-auto flex-grow md:flex-grow-0' : '!w-auto max-w-full'"
 			:placeholder="formatMessage(commonMessages.viewLabel)"
 			@update:model-value="(val: number) => (ctx.maxResults.value = val)"
 		>

--- a/packages/ui/src/layouts/shared/browse-tab/layout.vue
+++ b/packages/ui/src/layouts/shared/browse-tab/layout.vue
@@ -101,7 +101,7 @@ const messages = defineMessages({
 			:options="sortOptions"
 			:class="
 				ctx.variant === 'web'
-					? '!w-auto flex-grow md:flex-grow-0'
+					? '!w-[16rem] min-w-max max-w-full flex-grow md:flex-grow-0'
 					: '!w-[16rem] min-w-max max-w-full'
 			"
 			@update:model-value="(val: SortType) => (ctx.effectiveCurrentSortType.value = val)"
@@ -118,7 +118,7 @@ const messages = defineMessages({
 			:options="maxResultsOptions"
 			:class="
 				ctx.variant === 'web'
-					? '!w-auto flex-grow md:flex-grow-0'
+					? '!w-[9rem] min-w-max max-w-full flex-grow md:flex-grow-0'
 					: '!w-[9rem] min-w-max max-w-full'
 			"
 			:placeholder="formatMessage(commonMessages.viewLabel)"

--- a/packages/ui/src/layouts/shared/browse-tab/layout.vue
+++ b/packages/ui/src/layouts/shared/browse-tab/layout.vue
@@ -99,7 +99,11 @@ const messages = defineMessages({
 		<Combobox
 			:model-value="ctx.effectiveCurrentSortType.value"
 			:options="sortOptions"
-			:class="ctx.variant === 'web' ? '!w-auto flex-grow md:flex-grow-0' : '!w-auto max-w-full'"
+			:class="
+				ctx.variant === 'web'
+					? '!w-auto flex-grow md:flex-grow-0'
+					: '!w-[16rem] min-w-max max-w-full'
+			"
 			@update:model-value="(val: SortType) => (ctx.effectiveCurrentSortType.value = val)"
 		>
 			<template #prefix>
@@ -112,7 +116,11 @@ const messages = defineMessages({
 		<Combobox
 			:model-value="ctx.maxResults.value"
 			:options="maxResultsOptions"
-			:class="ctx.variant === 'web' ? '!w-auto flex-grow md:flex-grow-0' : '!w-auto max-w-full'"
+			:class="
+				ctx.variant === 'web'
+					? '!w-auto flex-grow md:flex-grow-0'
+					: '!w-[9rem] min-w-max max-w-full'
+			"
 			:placeholder="formatMessage(commonMessages.viewLabel)"
 			@update:model-value="(val: number) => (ctx.maxResults.value = val)"
 		>


### PR DESCRIPTION
Fixes this wrapping issue:

<img width="713" height="344" alt="image" src="https://github.com/user-attachments/assets/427b390b-0062-4ce7-b3cc-6a60a83f9554" />
