### PR TITLE
fix: normalize copied full paths across platforms

### DIFF
--- a/packages/ui/src/layouts/shared/files-tab/components/FileContextMenu.vue
+++ b/packages/ui/src/layouts/shared/files-tab/components/FileContextMenu.vue
@@ -131,7 +131,11 @@ function getFullPath() {
 	if (!currentItem.value) return ''
 	const basePath = ctx.basePath?.value
 	const itemPath = currentItem.value.path
-	return basePath ? `${basePath}/${itemPath}`.replace(/\/+/g, '/') : itemPath
+	if (!basePath) return itemPath
+	const fullPath = `${basePath}/${itemPath}`
+	return navigator.userAgent.includes('Windows')
+		? fullPath.replace(/[\\/]+/g, '\\')
+		: fullPath.replace(/[\\/]+/g, '/')
 }
 
 function handleCopyPath() {

--- a/packages/ui/src/layouts/shared/files-tab/components/FileTableRow.vue
+++ b/packages/ui/src/layouts/shared/files-tab/components/FileTableRow.vue
@@ -197,7 +197,11 @@ const isZip = computed(() => fileExtension.value === 'zip')
 
 function getFullPath() {
 	const basePath = ctx.basePath?.value
-	return basePath ? `${basePath}/${props.path}`.replace(/\/+/g, '/') : props.path
+	if (!basePath) return props.path
+	const fullPath = `${basePath}/${props.path}`
+	return navigator.userAgent.includes('Windows')
+		? fullPath.replace(/[\\/]+/g, '\\')
+		: fullPath.replace(/[\\/]+/g, '/')
 }
 
 const menuOptions = computed(() => {


### PR DESCRIPTION
Fixes #6100

This updates the path generation used by the "Copy full path" and "Open in folder" actions to normalize path separators based on the user's platform.

Previously, Windows users could receive mixed path separators such as:

C:\Users\Void\AppData\Roaming\ModrinthApp\profiles\Instance/downloads

This change preserves forward slashes on macOS/Linux while normalizing Windows paths to use backslashes consistently.