### PR TITLE
feat: update default memory from 2GB to 4GB

### DIFF
--- a/packages/app-lib/src/api/jre.rs
+++ b/packages/app-lib/src/api/jre.rs
@@ -181,12 +181,29 @@ pub async fn test_jre(
     Ok(version == major_version)
 }
 
-// Gets maximum memory in KiB.
-pub async fn get_max_memory() -> crate::Result<u64> {
-    Ok(sysinfo::System::new_with_specifics(
+fn system_memory_bytes() -> u64 {
+    sysinfo::System::new_with_specifics(
         RefreshKind::nothing()
             .with_memory(MemoryRefreshKind::nothing().with_ram()),
     )
     .total_memory()
-        / 1024)
+}
+
+/// Recommended default max heap (MiB) for new instances based on system RAM.
+pub fn default_memory_max_mb() -> u32 {
+    const BYTES_PER_GIB: u64 = 1024 * 1024 * 1024;
+    let system_gib = system_memory_bytes() / BYTES_PER_GIB;
+
+    if system_gib < 8 {
+        1024 * 2
+    } else if system_gib >= 24 {
+        1024 * 6
+    } else {
+        1024 * 4
+    }
+}
+
+// Gets maximum memory in KiB.
+pub async fn get_max_memory() -> crate::Result<u64> {
+    Ok(system_memory_bytes() / 1024)
 }

--- a/packages/app-lib/src/state/settings.rs
+++ b/packages/app-lib/src/state/settings.rs
@@ -64,7 +64,7 @@ pub enum FeatureFlag {
 }
 
 impl Settings {
-    const CURRENT_VERSION: usize = 2;
+    const CURRENT_VERSION: usize = 3;
 
     pub async fn get(
         exec: impl sqlx::Executor<'_, Database = sqlx::Sqlite>,
@@ -294,6 +294,16 @@ impl Settings {
                 }
 
                 self.version = 2;
+            }
+            2 => {
+				// Update old default memory setting from 2GB to 4GB (depending on system memory)
+                const LEGACY_DEFAULT_MEMORY_MB: u32 = 2048;
+                if self.memory.maximum == LEGACY_DEFAULT_MEMORY_MB {
+                    self.memory.maximum =
+                        crate::api::jre::default_memory_max_mb();
+                }
+
+                self.version = 3;
             }
             version => {
                 return Err(crate::ErrorKind::OtherError(format!(

--- a/packages/app-lib/src/state/settings.rs
+++ b/packages/app-lib/src/state/settings.rs
@@ -296,7 +296,7 @@ impl Settings {
                 self.version = 2;
             }
             2 => {
-				// Update old default memory setting from 2GB to 4GB (depending on system memory)
+                // Update old default memory setting from 2GB to 4GB (depending on system memory)
                 const LEGACY_DEFAULT_MEMORY_MB: u32 = 2048;
                 if self.memory.maximum == LEGACY_DEFAULT_MEMORY_MB {
                     self.memory.maximum =


### PR DESCRIPTION
- on systems with < 8GB of memory, it will retain the 2GB default. On systems with > 24 GB, we'll bump it to 6. Reason being, you will often have to bump it anyway if you are installing a bunch of beefier mods, if they have the ram to spare why not make it less likely they have to adjust it.