### PR TITLE
fix(thread): pass i18n values via correct prop name (#6141)

### DIFF
--- a/apps/frontend/src/components/ui/thread/ConversationThread.vue
+++ b/apps/frontend/src/components/ui/thread/ConversationThread.vue
@@ -14,7 +14,7 @@
 				<p class="m-0">
 					<IntlFormatted
 						:message-id="messages.resubmitModalDescription"
-						:message-values="{ projectTitle: project.title }"
+						:values="{ projectTitle: project.title }"
 					>
 						<template #project-title="{ children }">
 							<span class="font-semibold text-contrast">


### PR DESCRIPTION
## Summary

Fixes #6141. The project resubmission modal was rendering literal `<project-title>{projectTitle}</project-title>` text instead of the project name.

## Root cause

`packages/ui/src/components/base/IntlFormatted.vue` declares its value-binding prop as `values` (camelCase). The caller `apps/frontend/src/components/ui/thread/ConversationThread.vue` was passing values under a non-existent prop name:

```vue
<IntlFormatted
  :message-id="messages.resubmitModalDescription"
  :message-values="{ projectTitle: project.title }"   <!-- no such prop -->
>
```

Because `:message-values` does not bind to any declared prop, `props.values` was `undefined` inside `IntlFormatted`. The `<project-title>` slot handler was still registered, but the inner `{projectTitle}` placeholder had no value, so `intl-messageformat` threw `The intl string context variable "projectTitle" was not provided`. The `catch` branch returned the raw message and Vue rendered the literal tags shown in the issue screenshot.

## Fix

Single-line change: rename `:message-values` to `:values` in `ConversationThread.vue`. All other `<IntlFormatted>` callers in the monorepo (e.g. `apps/frontend/src/pages/auth/authorize.vue`, `apps/app-frontend/src/components/ui/modal/ModpackAlreadyInstalledModal.vue`) already use the canonical `:values=` binding; this file was the only outlier.

The translations themselves are correct in all 13 locales that define this key; no translation changes are needed.

## Test plan

- [ ] Open a project's resubmission modal in the frontend and confirm the description reads "You're submitting `<project title>` to be reviewed again by the moderators." with the real project title (and the title styled via the slot template).
- [ ] Confirm no console error from `intl-messageformat` about a missing context variable.

Closes #6141.