### PR TITLE
fix(docs): correct OAuth authorization URL in guide

### DIFF
--- a/apps/docs/src/content/docs/guide/oauth.md
+++ b/apps/docs/src/content/docs/guide/oauth.md
@@ -28,7 +28,7 @@ After you've registered your application, it is important that you take note of 
 
 ## Getting authorization
 
-Once the user is ready to authorize your application, you need to construct a URL to redirect them to. The authorization URL for Modrinth is `https://api.modrinth.com/_internal/oauth/token`. Supply the following query parameters:
+Once the user is ready to authorize your application, you need to construct a URL to redirect them to. The authorization URL for Modrinth is `https://modrinth.com/auth/authorize`. Supply the following query parameters:
 
 | Query parameter | Description                                                                               |
 | --------------- | ----------------------------------------------------------------------------------------- |


### PR DESCRIPTION
The OAuth guide cited the token-exchange endpoint as the authorization URL, contradicting the reference table and the actual authorize route at apps/frontend/src/pages/auth/authorize.vue. Updated to https://modrinth.com/auth/authorize.