### PR TITLE
Also run Daedalus manifest uploads when there's a new game version

### DIFF
--- a/apps/daedalus_client/src/fabric.rs
+++ b/apps/daedalus_client/src/fabric.rs
@@ -65,49 +65,65 @@ async fn fetch(
     )
     .await?;
 
-    // We check Modrinth's fabric version manifest and compare if the fabric version exists in Modrinth's database
-    // We also check intermediary versions that are newly added to query
-    let (fetch_fabric_versions, fetch_intermediary_versions) =
-        if let Some(modrinth_manifest) = modrinth_manifest {
-            let (mut fetch_versions, mut fetch_intermediary_versions) =
-                (Vec::new(), Vec::new());
+    // We check Modrinth's manifest to find newly added loader versions,
+    // intermediary/mapping artifacts, and game versions.
+    let (
+        fetch_fabric_versions,
+        fetch_intermediary_versions,
+        has_new_game_versions,
+    ) = if let Some(modrinth_manifest) = modrinth_manifest {
+        let (mut fetch_versions, mut fetch_intermediary_versions) =
+            (Vec::new(), Vec::new());
 
-            for version in &fabric_manifest.loader {
-                if !modrinth_manifest
-                    .game_versions
-                    .iter()
-                    .any(|x| x.loaders.iter().any(|x| x.id == version.version))
-                    && !skip_versions.contains(&&*version.version)
-                {
-                    fetch_versions.push(version);
-                }
+        for version in &fabric_manifest.loader {
+            if !modrinth_manifest
+                .game_versions
+                .iter()
+                .any(|x| x.loaders.iter().any(|x| x.id == version.version))
+                && !skip_versions.contains(&&*version.version)
+            {
+                fetch_versions.push(version);
             }
+        }
 
-            for version in &fabric_manifest.intermediary {
-                if !modrinth_manifest
+        for version in &fabric_manifest.intermediary {
+            if !modrinth_manifest
+                .game_versions
+                .iter()
+                .any(|x| x.id == version.version)
+                && fabric_manifest
+                    .game
+                    .iter()
+                    .any(|x| x.version == version.version)
+            {
+                fetch_intermediary_versions.push(version);
+            }
+        }
+
+        let has_new_game_versions =
+            fabric_manifest.game.iter().any(|version| {
+                !modrinth_manifest
                     .game_versions
                     .iter()
                     .any(|x| x.id == version.version)
-                    && fabric_manifest
-                        .game
-                        .iter()
-                        .any(|x| x.version == version.version)
-                {
-                    fetch_intermediary_versions.push(version);
-                }
-            }
+            });
 
-            (fetch_versions, fetch_intermediary_versions)
-        } else {
-            (
-                fabric_manifest
-                    .loader
-                    .iter()
-                    .filter(|x| !skip_versions.contains(&&*x.version))
-                    .collect(),
-                fabric_manifest.intermediary.iter().collect(),
-            )
-        };
+        (
+            fetch_versions,
+            fetch_intermediary_versions,
+            has_new_game_versions,
+        )
+    } else {
+        (
+            fabric_manifest
+                .loader
+                .iter()
+                .filter(|x| !skip_versions.contains(&&*x.version))
+                .collect(),
+            fabric_manifest.intermediary.iter().collect(),
+            true,
+        )
+    };
 
     const DUMMY_GAME_VERSION: &str = "1.21";
 
@@ -216,6 +232,7 @@ async fn fetch(
 
     if !fetch_fabric_versions.is_empty()
         || !fetch_intermediary_versions.is_empty()
+        || has_new_game_versions
     {
         let fabric_manifest_path =
             format!("{mod_loader}/v{format_version}/manifest.json",);


### PR DESCRIPTION
Fixes Quilt 26.x versions not appearing.

From investigation, the Quilt manifest seems to have intermediaries and mappings for e.g. game version 1.21.9, but 26.x is missing these intermediaries. Due to this, we never run the code gated behind `fetch_fabric_versions` and `fetch_intermediary_versions` -- the only thing that changed is the game versions, not the intermediaries. To fix this, we also check if the game versions are any different, and if so do the meta run.