### PR TITLE
fix: use correct organization route parameter

### DIFF
--- a/apps/frontend/src/pages/organization/[organization]/settings/index.vue
+++ b/apps/frontend/src/pages/organization/[organization]/settings/index.vue
@@ -85,7 +85,7 @@ const showPreviewImage = (files) => {
 	}
 }
 
-const orgId = useRouteId('orgId')
+const orgId = useRouteId('organization')
 
 const save = async () => {
 	// Save field changes via useSavable


### PR DESCRIPTION
Fixes #6271 

The organization settings page was using `useRouteId('orgId')` instead of `useRouteId('organization')` causing variable orgId to be undefined.