### PR TITLE
fix: upload a version nag 

### DIFF
--- a/packages/moderation/src/data/nags/core.ts
+++ b/packages/moderation/src/data/nags/core.ts
@@ -38,7 +38,7 @@ export const coreNags: Nag[] = [
 		}),
 		status: 'required',
 		shouldShow: (context: NagContext) =>
-			context.versions.length < 1 && !context.projectV3?.minecraft_server,
+			context.projectV3?.versions?.length < 1 && !context.projectV3?.minecraft_server,
 		link: {
 			path: 'settings/versions',
 			title: defineMessage({


### PR DESCRIPTION
Use projectV3.versions instead of NagContext.versions to prevent the warning showing up when versions have not been loaded yet.