### PR TITLE
fix(skins): loading state flash on delete

### DIFF
--- a/apps/app-frontend/src/helpers/rendering/batch-skin-renderer.ts
+++ b/apps/app-frontend/src/helpers/rendering/batch-skin-renderer.ts
@@ -404,7 +404,7 @@ async function generateSkinPreviewsForGeneration(
 			const headKey = headKeys[i]
 
 			const rawCached = cachedSkinPreviews[skinKey]
-			if (rawCached) {
+			if (rawCached && !skinBlobUrlMap.has(skinKey)) {
 				const cached: RenderResult = {
 					forwards: URL.createObjectURL(rawCached.forwards),
 					backwards: URL.createObjectURL(rawCached.backwards),
@@ -413,7 +413,7 @@ async function generateSkinPreviewsForGeneration(
 			}
 
 			const cachedHead = cachedHeadPreviews[headKey]
-			if (cachedHead) {
+			if (cachedHead && !headBlobUrlMap.has(headKey)) {
 				headBlobUrlMap.set(headKey, URL.createObjectURL(cachedHead))
 			}
 		}


### PR DESCRIPTION
- Loading state flashes every time a saved skin is deleted because the blobs are regenerated even when not needed