### PR TITLE
Fix: update modpack export filter

### DIFF
--- a/apps/app-frontend/src/components/ui/ExportModal.vue
+++ b/apps/app-frontend/src/components/ui/ExportModal.vue
@@ -91,28 +91,8 @@ const initFiles = async () => {
 					folder === 'profile.json' ||
 					folder.startsWith('modrinth_logs') ||
 					folder.startsWith('.fabric') ||
-					folder.startsWith('essential') ||
-					folder.startsWith('.mixin.out') ||
 					folder.startsWith('__MACOSX'),
 			}))
-			.filter(
-				(pathData) =>
-					!pathData.path.includes('.DS_Store') &&
-					pathData.path !== 'mods/.connector' &&
-					!pathData.path.startsWith('mods/.connector/') &&
-					pathData.path !== '.sable/natives' &&
-					!pathData.path.startsWith('.sable/natives') &&
-					pathData.path !== 'local/crash_assistant' &&
-					!pathData.path.startsWith('local/crash_assistant') &&
-					pathData.path !== 'mods/mcef-libraries' &&
-					!pathData.path.startsWith('mods/mcef-libraries/') &&
-					pathData.path !== 'config/super_resolution/libraries' &&
-					!pathData.path.startsWith('config/super_resolution/libraries') &&
-					pathData.path !== 'config/veinminer/update' &&
-					!pathData.path.startsWith('config/veinminer/update') &&
-					pathData.path !== 'config/epicfight/native' &&
-					!pathData.path.startsWith('config/epicfight/native'),
-			)
 			.forEach((pathData) => {
 				const parent = pathData.path.split(sep).slice(0, -1).join(sep)
 				if (parent !== '') {

--- a/apps/app-frontend/src/components/ui/ExportModal.vue
+++ b/apps/app-frontend/src/components/ui/ExportModal.vue
@@ -16,6 +16,7 @@ import { ref } from 'vue'
 import { PackageIcon, VersionIcon } from '@/assets/icons'
 import ModalWrapper from '@/components/ui/modal/ModalWrapper.vue'
 import { export_profile_mrpack, get_pack_export_candidates } from '@/helpers/profile.js'
+import path from 'path'
 
 const { handleError } = injectNotificationManager()
 const { formatMessage } = useVIntl()
@@ -89,13 +90,28 @@ const initFiles = async () => {
 				disabled:
 					folder === 'profile.json' ||
 					folder.startsWith('modrinth_logs') ||
-					folder.startsWith('.fabric'),
+					folder.startsWith('.fabric') ||
+					folder.startsWith('essential') ||
+					folder.startsWith('.mixin.out') ||
+					folder.startsWith('__MACOSX'),
 			}))
 			.filter(
 				(pathData) =>
 					!pathData.path.includes('.DS_Store') &&
 					pathData.path !== 'mods/.connector' &&
-					!pathData.path.startsWith('mods/.connector/'),
+					!pathData.path.startsWith('mods/.connector/') &&
+					pathData.path !== '.sable/natives' &&
+					!pathData.path.startsWith('.sable/natives') &&
+					pathData.path !== 'local/crash_assistant' &&
+					!pathData.path.startsWith('local/crash_assistant') &&
+					pathData.path !== 'mods/mcef-libraries' &&
+					!pathData.path.startsWith('mods/mcef-libraries/') &&
+					pathData.path !== 'config/super_resolution/libraries' &&
+					!pathData.path.startsWith('config/super_resolution/libraries') &&
+					pathData.path !== 'config/veinminer/update' &&
+					!pathData.path.startsWith('config/veinminer/update') &&
+					pathData.path !== 'config/epicfight/native' &&
+					!pathData.path.startsWith('config/epicfight/native'),
 			)
 			.forEach((pathData) => {
 				const parent = pathData.path.split(sep).slice(0, -1).join(sep)

--- a/apps/app-frontend/src/components/ui/ExportModal.vue
+++ b/apps/app-frontend/src/components/ui/ExportModal.vue
@@ -16,7 +16,6 @@ import { ref } from 'vue'
 import { PackageIcon, VersionIcon } from '@/assets/icons'
 import ModalWrapper from '@/components/ui/modal/ModalWrapper.vue'
 import { export_profile_mrpack, get_pack_export_candidates } from '@/helpers/profile.js'
-import path from 'path'
 
 const { handleError } = injectNotificationManager()
 const { formatMessage } = useVIntl()

--- a/packages/app-lib/src/api/profile/mod.rs
+++ b/packages/app-lib/src/api/profile/mod.rs
@@ -666,7 +666,7 @@ pub async fn export_mrpack(
         }
 
         // File is not in the config file, add it to the .mrpack zip
-        if path.is_file() {
+        if path.is_file() && is_path_exportable(&relative_path) {
             let mut file = File::open(&path)
                 .await
                 .map_err(|e| IOError::with_path(e, &path))?;
@@ -693,6 +693,30 @@ pub async fn export_mrpack(
     writer.close().await?;
 
     Ok(())
+}
+
+fn is_path_exportable(relative_path: &SafeRelativeUtf8UnixPathBuf) -> bool {
+    if relative_path.ends_with(".DS_Store") {
+        return false;
+    }
+
+    if relative_path.starts_with("mods/.connector/")
+        || relative_path.starts_with(".sable/natives/")
+        || relative_path.starts_with("local/crash_assistant/")
+        || relative_path.starts_with("mods/mcef-libraries/")
+        || relative_path.starts_with("mods/mcef-cache/")
+        || relative_path.starts_with("config/super_resolution/libraries/")
+        || relative_path.starts_with("config/Veinminer/update/")
+        || relative_path.starts_with("config/epicfight/native/")
+        || relative_path.starts_with("essential/")
+        || relative_path.starts_with(".mixin.out/")
+        || relative_path.starts_with(".fabric/")
+        || relative_path.starts_with("__MACOSX/")
+    {
+        return false;
+    }
+
+    true
 }
 
 // Given a folder path, populate a Vec of all the subfolders and files, at most 2 layers deep
@@ -726,14 +750,20 @@ pub async fn get_pack_export_candidates(
                 .await
                 .map_err(|e| IOError::with_path(e, &profile_base_dir))?
             {
-                path_list.push(pack_get_relative_path(
-                    &profile_base_dir,
-                    &entry.path(),
-                )?);
+                let relative =
+                    pack_get_relative_path(&profile_base_dir, &entry.path())?;
+                if !is_path_exportable(&relative) {
+                    continue;
+                }
+                path_list.push(relative);
             }
         } else {
             // One layer of files/folders if its a file
-            path_list.push(pack_get_relative_path(&profile_base_dir, &path)?);
+            let relative = pack_get_relative_path(&profile_base_dir, &path)?;
+            if !is_path_exportable(&relative) {
+                continue;
+            }
+            path_list.push(relative);
         }
     }
     Ok(path_list)


### PR DESCRIPTION
Prevent certain unnecessary files from being included in modpack exports to prevent inflated file sizes and unnecessary moderation work.