### PR TITLE
feat(app-backend): key circuit breaker by URI path pattern

### DIFF
--- a/packages/app-lib/src/api/jre.rs
+++ b/packages/app-lib/src/api/jre.rs
@@ -78,6 +78,7 @@ pub async fn auto_install_java(java_version: u32) -> crate::Result<PathBuf> {
                 ),
                 None,
                 None,
+                None,
                 &state.fetch_semaphore,
                 &state.pool,
             ).await?;
@@ -92,6 +93,7 @@ pub async fn auto_install_java(java_version: u32) -> crate::Result<PathBuf> {
             None,
             None,
             Some((&loading_bar, 80.0)),
+            None,
             &state.fetch_semaphore,
             &state.pool,
         )

--- a/packages/app-lib/src/api/pack/import/curseforge.rs
+++ b/packages/app-lib/src/api/pack/import/curseforge.rs
@@ -82,6 +82,7 @@ pub async fn import_curseforge(
             &thumbnail_url,
             None,
             None,
+            None,
             &state.fetch_semaphore,
             &state.pool,
         )

--- a/packages/app-lib/src/api/pack/install_from.rs
+++ b/packages/app-lib/src/api/pack/install_from.rs
@@ -326,6 +326,7 @@ pub async fn generate_pack_from_version_id(
         None,
         Some(&download_meta),
         Some((&loading_bar, 70.0)),
+        None,
         &state.fetch_semaphore,
         &state.pool,
     )
@@ -354,6 +355,7 @@ pub async fn generate_pack_from_version_id(
             let state = State::get().await?;
             let icon_bytes = fetch(
                 &icon_url,
+                None,
                 None,
                 None,
                 &state.fetch_semaphore,

--- a/packages/app-lib/src/api/pack/install_mrpack.rs
+++ b/packages/app-lib/src/api/pack/install_mrpack.rs
@@ -441,6 +441,7 @@ pub async fn install_zipped_mrpack_files(
                         .collect::<Vec<&str>>(),
                     project.hashes.get(&PackFileHash::Sha1).map(|x| &**x),
                     Some(&download_meta),
+                    None,
                     &state.fetch_semaphore,
                     &state.pool,
                 )

--- a/packages/app-lib/src/api/profile/create.rs
+++ b/packages/app-lib/src/api/profile/create.rs
@@ -113,6 +113,7 @@ pub async fn profile_create(
                     icon,
                     None,
                     None,
+                    None,
                     &state.fetch_semaphore,
                     &state.pool,
                 )

--- a/packages/app-lib/src/error.rs
+++ b/packages/app-lib/src/error.rs
@@ -68,8 +68,8 @@ pub enum ErrorKind {
     #[error("Error fetching URL: {0}")]
     FetchError(#[from] reqwest::Error),
 
-    #[error("Too many API errors; temporarily blocked")]
-    ApiIsDownError,
+    #[error("Too many API errors, try again in {0} minutes")]
+    ApiIsDownError(u32),
 
     #[error("{0}")]
     LabrinthError(LabrinthError),

--- a/packages/app-lib/src/launcher/download.rs
+++ b/packages/app-lib/src/launcher/download.rs
@@ -415,8 +415,15 @@ pub async fn download_libraries(
                     // failed download here is not a fatal condition.
                     //
                     // See DEV-479.
-                    match fetch(&url, None, None, None, &st.fetch_semaphore, &st.pool)
-                        .await
+                    match fetch(
+                        &url,
+                        None,
+                        None,
+                        None,
+                        &st.fetch_semaphore,
+                        &st.pool,
+                    )
+                    .await
                     {
                         Ok(bytes) => {
                             write(&path, &bytes, &st.io_semaphore).await?;

--- a/packages/app-lib/src/launcher/download.rs
+++ b/packages/app-lib/src/launcher/download.rs
@@ -88,6 +88,7 @@ pub async fn download_version_info(
             &version.url,
             None,
             None,
+            None,
             &st.api_semaphore,
             &st.pool,
         )
@@ -97,6 +98,7 @@ pub async fn download_version_info(
             let partial: d::modded::PartialVersionInfo = fetch_json(
                 Method::GET,
                 &loader.url,
+                None,
                 None,
                 None,
                 &st.api_semaphore,
@@ -149,6 +151,7 @@ pub async fn download_client(
             &client_download.url,
             Some(&client_download.sha1),
             None,
+            None,
             &st.fetch_semaphore,
             &st.pool,
         )
@@ -187,6 +190,7 @@ pub async fn download_assets_index(
         let index = fetch_json(
             Method::GET,
             &version.asset_index.url,
+            None,
             None,
             None,
             &st.fetch_semaphore,
@@ -239,7 +243,7 @@ pub async fn download_assets(
                     async {
                         if !resource_path.exists() || force {
                             let resource = fetch_cell
-                                .get_or_try_init(|| fetch(&url, Some(hash), None, &st.fetch_semaphore, &st.pool))
+                                .get_or_try_init(|| fetch(&url, Some(hash), None, None, &st.fetch_semaphore, &st.pool))
                                 .await?;
                             write(&resource_path, resource, &st.io_semaphore).await?;
                             tracing::trace!("Fetched asset with hash {hash}");
@@ -253,7 +257,7 @@ pub async fn download_assets(
 
                         if with_legacy && !resource_path.exists() || force {
                             let resource = fetch_cell
-                                .get_or_try_init(|| fetch(&url, Some(hash), None, &st.fetch_semaphore, &st.pool))
+                                .get_or_try_init(|| fetch(&url, Some(hash), None, None, &st.fetch_semaphore, &st.pool))
                                 .await?;
                             write(&resource_path, resource, &st.io_semaphore).await?;
                             tracing::trace!("Fetched legacy asset with hash {hash}");
@@ -328,6 +332,7 @@ pub async fn download_libraries(
                         &native.url,
                         Some(&native.sha1),
                         None,
+                        None,
                         &st.fetch_semaphore,
                         &st.pool,
                     )
@@ -373,6 +378,7 @@ pub async fn download_libraries(
                         &artifact.url,
                         Some(&artifact.sha1),
                         None,
+                        None,
                         &st.fetch_semaphore,
                         &st.pool,
                     )
@@ -409,7 +415,7 @@ pub async fn download_libraries(
                     // failed download here is not a fatal condition.
                     //
                     // See DEV-479.
-                    match fetch(&url, None, None, &st.fetch_semaphore, &st.pool)
+                    match fetch(&url, None, None, None, &st.fetch_semaphore, &st.pool)
                         .await
                     {
                         Ok(bytes) => {
@@ -469,6 +475,7 @@ pub async fn download_log_config(
         let bytes = fetch(
             &log_download.url,
             Some(&log_download.sha1),
+            None,
             None,
             &st.fetch_semaphore,
             &st.pool,

--- a/packages/app-lib/src/state/cache.rs
+++ b/packages/app-lib/src/state/cache.rs
@@ -1080,6 +1080,7 @@ impl CachedEntry {
             method: Method,
             api_url: &str,
             url: &str,
+            uri_path: Option<&'static str>,
             keys: &DashSet<impl Display + Eq + Hash + Serialize>,
             fetch_semaphore: &FetchSemaphore,
             pool: &SqlitePool,
@@ -1102,6 +1103,7 @@ impl CachedEntry {
                     url,
                     None,
                     None,
+                    uri_path,
                     fetch_semaphore,
                     pool,
                 )
@@ -1112,11 +1114,12 @@ impl CachedEntry {
         }
 
         macro_rules! fetch_original_values {
-            ($type:ident, $api_url:expr, $url_suffix:expr, $cache_variant:path) => {{
+            ($type:ident, $api_url:expr, $url_suffix:expr, $uri_path:expr, $cache_variant:path) => {{
                 let mut results = fetch_many_batched(
                     Method::GET,
                     $api_url,
                     &format!("{}?ids=", $url_suffix),
+                    $uri_path,
                     &keys,
                     &fetch_semaphore,
                     &pool,
@@ -1172,7 +1175,7 @@ impl CachedEntry {
         }
 
         macro_rules! fetch_original_value {
-            ($type:ident, $api_url:expr, $url_suffix:expr, $cache_variant:path) => {{
+            ($type:ident, $api_url:expr, $url_suffix:expr, $uri_path:expr, $cache_variant:path) => {{
                 vec![(
                     $cache_variant(
                         fetch_json(
@@ -1180,6 +1183,7 @@ impl CachedEntry {
                             &*format!("{}{}", $api_url, $url_suffix),
                             None,
                             None,
+                            $uri_path,
                             &fetch_semaphore,
                             pool,
                         )
@@ -1197,6 +1201,7 @@ impl CachedEntry {
                     Project,
                     env!("MODRINTH_API_URL"),
                     "projects",
+                    Some("/v2/projects"),
                     CacheValue::Project
                 )
             }
@@ -1205,6 +1210,7 @@ impl CachedEntry {
                     ProjectV3,
                     env!("MODRINTH_API_URL_V3"),
                     "projects",
+                    Some("/v3/projects"),
                     CacheValue::ProjectV3
                 )
             }
@@ -1213,6 +1219,7 @@ impl CachedEntry {
                     Version,
                     env!("MODRINTH_API_URL"),
                     "versions",
+                    Some("/v2/versions"),
                     CacheValue::Version
                 )
             }
@@ -1221,6 +1228,7 @@ impl CachedEntry {
                     User,
                     env!("MODRINTH_API_URL"),
                     "users",
+                    Some("/v2/users"),
                     CacheValue::User
                 )
             }
@@ -1229,6 +1237,7 @@ impl CachedEntry {
                     Method::GET,
                     env!("MODRINTH_API_URL_V3"),
                     "teams?ids=",
+                    Some("/v3/teams"),
                     &keys,
                     fetch_semaphore,
                     pool,
@@ -1268,6 +1277,7 @@ impl CachedEntry {
                     Method::GET,
                     env!("MODRINTH_API_URL_V3"),
                     "organizations?ids=",
+                    Some("/v3/organizations"),
                     &keys,
                     fetch_semaphore,
                     pool,
@@ -1327,6 +1337,7 @@ impl CachedEntry {
                         "algorithm": "sha1",
                         "hashes": &keys,
                     })),
+                    Some("/v2/version_files"),
                     fetch_semaphore,
                     pool,
                 )
@@ -1393,6 +1404,7 @@ impl CachedEntry {
                             url,
                             None,
                             None,
+                            None,
                             fetch_semaphore,
                             pool,
                         )
@@ -1421,6 +1433,7 @@ impl CachedEntry {
                         "minecraft/v{}/manifest.json",
                         daedalus::minecraft::CURRENT_FORMAT_VERSION
                     ),
+                    None,
                     CacheValue::MinecraftManifest
                 )
             }
@@ -1429,6 +1442,7 @@ impl CachedEntry {
                     Categories,
                     env!("MODRINTH_API_URL"),
                     "tag/category",
+                    Some("/v2/tag/category"),
                     CacheValue::Categories
                 )
             }
@@ -1437,6 +1451,7 @@ impl CachedEntry {
                     ReportTypes,
                     env!("MODRINTH_API_URL"),
                     "tag/report_type",
+                    Some("/v2/tag/report_type"),
                     CacheValue::ReportTypes
                 )
             }
@@ -1445,6 +1460,7 @@ impl CachedEntry {
                     Loaders,
                     env!("MODRINTH_API_URL"),
                     "tag/loader",
+                    Some("/v2/tag/loader"),
                     CacheValue::Loaders
                 )
             }
@@ -1453,6 +1469,7 @@ impl CachedEntry {
                     GameVersions,
                     env!("MODRINTH_API_URL"),
                     "tag/game_version",
+                    Some("/v2/tag/game_version"),
                     CacheValue::GameVersions
                 )
             }
@@ -1461,6 +1478,7 @@ impl CachedEntry {
                     DonationPlatforms,
                     env!("MODRINTH_API_URL"),
                     "tag/donation_platform",
+                    Some("/v2/tag/donation_platform"),
                     CacheValue::DonationPlatforms
                 )
             }
@@ -1617,6 +1635,7 @@ impl CachedEntry {
                                         "game_versions": [game_version],
                                         "version_types": version_types
                                     })),
+                                    Some("/v2/version_files/update_many"),
                                     fetch_semaphore,
                                     pool,
                                 )
@@ -1713,6 +1732,7 @@ impl CachedEntry {
                             url,
                             None,
                             None,
+                            Some("/v2/search"),
                             fetch_semaphore,
                             pool,
                         )
@@ -1754,6 +1774,7 @@ impl CachedEntry {
                         &url,
                         None,
                         None,
+                        Some("/v2/project/:id/version"),
                         fetch_semaphore,
                         pool,
                     )
@@ -1805,6 +1826,7 @@ impl CachedEntry {
                             url,
                             None,
                             None,
+                            Some("/v3/search"),
                             fetch_semaphore,
                             pool,
                         )

--- a/packages/app-lib/src/state/friends.rs
+++ b/packages/app-lib/src/state/friends.rs
@@ -331,6 +331,7 @@ impl FriendsSocket {
             concat!(env!("MODRINTH_API_URL_V3"), "friends"),
             None,
             None,
+            Some("/v3/friends"),
             semaphore,
             exec,
         )
@@ -359,6 +360,7 @@ impl FriendsSocket {
             None,
             None,
             None,
+            Some("/v3/friend/:user_id"),
             semaphore,
             exec,
         )
@@ -392,6 +394,7 @@ impl FriendsSocket {
             None,
             None,
             None,
+            Some("/v3/friend/:user_id"),
             semaphore,
             exec,
         )

--- a/packages/app-lib/src/state/instances/content.rs
+++ b/packages/app-lib/src/state/instances/content.rs
@@ -895,6 +895,7 @@ async fn get_modpack_identifiers(
         &[&primary_file.url],
         primary_file.hashes.get("sha1").map(|s| s.as_str()),
         Some(&download_meta),
+        None,
         fetch_semaphore,
         pool,
     )

--- a/packages/app-lib/src/state/mr_auth.rs
+++ b/packages/app-lib/src/state/mr_auth.rs
@@ -36,6 +36,7 @@ impl ModrinthCredentials {
                     Some(("Authorization", &*creds.session)),
                     None,
                     None,
+                    Some("/v2/session/refresh"),
                     semaphore,
                     exec,
                 )
@@ -228,6 +229,7 @@ async fn fetch_info(
         Some(("Authorization", token)),
         None,
         None,
+        Some("/v2/user"),
         semaphore,
         exec,
     )

--- a/packages/app-lib/src/state/profiles.rs
+++ b/packages/app-lib/src/state/profiles.rs
@@ -1382,6 +1382,7 @@ impl Profile {
             &file.url,
             file.hashes.get("sha1").map(|x| &**x),
             Some(&download_meta),
+            None,
             fetch_semaphore,
             pool,
         )

--- a/packages/app-lib/src/util/fetch.rs
+++ b/packages/app-lib/src/util/fetch.rs
@@ -10,7 +10,7 @@ use rand::Rng;
 use reqwest::Method;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
@@ -50,21 +50,49 @@ pub struct IoSemaphore(pub Semaphore);
 pub struct FetchSemaphore(pub Semaphore);
 
 struct FetchFence {
-    inner: Mutex<FenceInner>,
+    inner: Mutex<HashMap<&'static str, FenceInner>>,
 }
 
 impl FetchFence {
-    pub fn is_blocked(&self) -> bool {
-        self.inner.lock().is_blocked()
-    }
+	pub fn is_blocked(&self, key: &'static str) -> bool {
+		self.inner
+			.lock()
+			.entry(key)
+			.or_insert_with(FenceInner::new)
+			.is_blocked()
+	}
 
-    pub fn record_ok(&self) {
-        self.inner.lock().record_ok()
-    }
+	pub fn record_ok(&self, key: &'static str) {
+		self.inner
+			.lock()
+			.entry(key)
+			.or_insert_with(FenceInner::new)
+			.record_ok()
+	}
 
-    pub fn record_fail(&self) {
-        self.inner.lock().record_fail()
-    }
+	pub fn record_fail(&self, key: &'static str) {
+		self.inner
+			.lock()
+			.entry(key)
+			.or_insert_with(FenceInner::new)
+			.record_fail()
+	}
+
+	pub fn latest_block_minutes(&self) -> u32 {
+		let now = Utc::now();
+
+		self.inner
+			.lock()
+			.values()
+			.filter_map(|fence| fence.block_until)
+			.filter(|until| *until > now)
+			.max()
+			.map(|until| {
+				let seconds = until.signed_duration_since(now).num_seconds();
+				(seconds.max(0) as u32).div_ceil(60).max(1)
+			})
+			.unwrap_or(1)
+	}
 }
 
 struct FenceInner {
@@ -154,7 +182,7 @@ impl FenceInner {
 
 static GLOBAL_FETCH_FENCE: LazyLock<FetchFence> =
     LazyLock::new(|| FetchFence {
-        inner: Mutex::new(FenceInner::new()),
+        inner: Mutex::new(HashMap::new()),
     });
 
 fn reqwest_client_builder() -> reqwest::ClientBuilder {
@@ -184,6 +212,7 @@ pub async fn fetch(
     url: &str,
     sha1: Option<&str>,
     download_meta: Option<&DownloadMeta>,
+    uri_path: Option<&'static str>,
     semaphore: &FetchSemaphore,
     exec: impl sqlx::Executor<'_, Database = sqlx::Sqlite>,
 ) -> crate::Result<Bytes> {
@@ -195,6 +224,7 @@ pub async fn fetch(
         None,
         download_meta,
         None,
+        uri_path,
         semaphore,
         exec,
     )
@@ -206,6 +236,7 @@ pub async fn fetch_with_client(
     url: &str,
     sha1: Option<&str>,
     download_meta: Option<&DownloadMeta>,
+    uri_path: Option<&'static str>,
     semaphore: &FetchSemaphore,
     exec: impl sqlx::Executor<'_, Database = sqlx::Sqlite>,
     client: &reqwest::Client,
@@ -218,6 +249,7 @@ pub async fn fetch_with_client(
         None,
         download_meta,
         None,
+        uri_path,
         semaphore,
         exec,
         client,
@@ -231,6 +263,7 @@ pub async fn fetch_json<T>(
     url: &str,
     sha1: Option<&str>,
     json_body: Option<serde_json::Value>,
+    uri_path: Option<&'static str>,
     semaphore: &FetchSemaphore,
     exec: impl sqlx::Executor<'_, Database = sqlx::Sqlite>,
 ) -> crate::Result<T>
@@ -238,7 +271,8 @@ where
     T: DeserializeOwned,
 {
     let result = fetch_advanced(
-        method, url, sha1, json_body, None, None, None, semaphore, exec,
+        method, url, sha1, json_body, None, None, None, uri_path, semaphore,
+        exec,
     )
     .await?;
     let value = serde_json::from_slice(&result)?;
@@ -257,6 +291,7 @@ pub async fn fetch_advanced(
     header: Option<(&str, &str)>,
     download_meta: Option<&DownloadMeta>,
     loading_bar: Option<(&LoadingBarId, f64)>,
+    uri_path: Option<&'static str>,
     semaphore: &FetchSemaphore,
     exec: impl sqlx::Executor<'_, Database = sqlx::Sqlite>,
 ) -> crate::Result<Bytes> {
@@ -268,6 +303,7 @@ pub async fn fetch_advanced(
         header,
         download_meta,
         loading_bar,
+        uri_path,
         semaphore,
         exec,
         &INSECURE_REQWEST_CLIENT,
@@ -286,6 +322,7 @@ pub async fn fetch_advanced_with_client(
     header: Option<(&str, &str)>,
     download_meta: Option<&DownloadMeta>,
     loading_bar: Option<(&LoadingBarId, f64)>,
+    uri_path: Option<&'static str>,
     semaphore: &FetchSemaphore,
     exec: impl sqlx::Executor<'_, Database = sqlx::Sqlite>,
     client: &reqwest::Client,
@@ -294,6 +331,7 @@ pub async fn fetch_advanced_with_client(
 
     let is_api_url = url.starts_with(env!("MODRINTH_API_URL"))
         || url.starts_with(env!("MODRINTH_API_URL_V3"));
+    let fence_key = if is_api_url { uri_path } else { None };
 
     let creds = if header
         .as_ref()
@@ -309,8 +347,13 @@ pub async fn fetch_advanced_with_client(
         .map(|m| (DOWNLOAD_META_HEADER.to_string(), m.to_header_value()));
 
     for attempt in 1..=(FETCH_ATTEMPTS + 1) {
-        if is_api_url && GLOBAL_FETCH_FENCE.is_blocked() {
-            return Err(ErrorKind::ApiIsDownError.into());
+        if let Some(fence_key) = fence_key
+            && GLOBAL_FETCH_FENCE.is_blocked(fence_key)
+        {
+            return Err(ErrorKind::ApiIsDownError(
+                GLOBAL_FETCH_FENCE.latest_block_minutes(),
+            )
+            .into());
         }
 
         let mut req = client.request(method.clone(), url);
@@ -336,8 +379,8 @@ pub async fn fetch_advanced_with_client(
         match result {
             Ok(resp) => {
                 if resp.status().is_server_error() {
-                    if is_api_url {
-                        GLOBAL_FETCH_FENCE.record_fail();
+                    if let Some(fence_key) = fence_key {
+                        GLOBAL_FETCH_FENCE.record_fail(fence_key);
                     }
 
                     if attempt <= FETCH_ATTEMPTS {
@@ -400,8 +443,8 @@ pub async fn fetch_advanced_with_client(
 
                     tracing::trace!("Done downloading URL {url}");
 
-                    if is_api_url {
-                        GLOBAL_FETCH_FENCE.record_ok();
+                    if let Some(fence_key) = fence_key {
+                        GLOBAL_FETCH_FENCE.record_ok(fence_key);
                     }
 
                     return Ok(bytes);
@@ -427,6 +470,7 @@ pub async fn fetch_mirrors(
     mirrors: &[&str],
     sha1: Option<&str>,
     download_meta: Option<&DownloadMeta>,
+    uri_path: Option<&'static str>,
     semaphore: &FetchSemaphore,
     exec: impl sqlx::Executor<'_, Database = sqlx::Sqlite> + Copy,
 ) -> crate::Result<Bytes> {
@@ -441,6 +485,7 @@ pub async fn fetch_mirrors(
             mirror,
             sha1,
             download_meta,
+            uri_path,
             semaphore,
             exec,
             &REQWEST_CLIENT,
@@ -618,6 +663,42 @@ mod tests {
 
         fence.record_fail();
         assert!(fence.is_blocked());
+    }
+
+    #[test]
+    fn test_fetch_fence_keys_are_independent() {
+        let fence = FetchFence {
+            inner: Mutex::new(HashMap::new()),
+        };
+
+        for _ in 0..FenceInner::FAILURE_THRESHOLD {
+            fence.record_fail("/v3/version_file/:sha1/update");
+        }
+
+        assert!(fence.is_blocked("/v3/version_file/:sha1/update"));
+        assert!(!fence.is_blocked("/v3/project/:id"));
+    }
+
+    #[test]
+    fn test_fetch_fence_latest_block_minutes() {
+        let fence = FetchFence {
+            inner: Mutex::new(HashMap::new()),
+        };
+
+        {
+            let mut inner = fence.inner.lock();
+            inner.insert("/expired", FenceInner::new());
+            inner.get_mut("/expired").unwrap().block_until =
+                Some(Utc::now() - TimeDelta::minutes(1));
+            inner.insert("/short", FenceInner::new());
+            inner.get_mut("/short").unwrap().block_until =
+                Some(Utc::now() + TimeDelta::seconds(61));
+            inner.insert("/long", FenceInner::new());
+            inner.get_mut("/long").unwrap().block_until =
+                Some(Utc::now() + TimeDelta::seconds(121));
+        }
+
+        assert_eq!(fence.latest_block_minutes(), 3);
     }
 
     #[test]

--- a/packages/app-lib/src/util/fetch.rs
+++ b/packages/app-lib/src/util/fetch.rs
@@ -695,7 +695,7 @@ mod tests {
                 Some(Utc::now() + TimeDelta::seconds(61));
             inner.insert("/long", FenceInner::new());
             inner.get_mut("/long").unwrap().block_until =
-                Some(Utc::now() + TimeDelta::seconds(121));
+                Some(Utc::now() + TimeDelta::seconds(140));
         }
 
         assert_eq!(fence.latest_block_minutes(), 3);

--- a/packages/app-lib/src/util/fetch.rs
+++ b/packages/app-lib/src/util/fetch.rs
@@ -54,45 +54,45 @@ struct FetchFence {
 }
 
 impl FetchFence {
-	pub fn is_blocked(&self, key: &'static str) -> bool {
-		self.inner
-			.lock()
-			.entry(key)
-			.or_insert_with(FenceInner::new)
-			.is_blocked()
-	}
+    pub fn is_blocked(&self, key: &'static str) -> bool {
+        self.inner
+            .lock()
+            .entry(key)
+            .or_insert_with(FenceInner::new)
+            .is_blocked()
+    }
 
-	pub fn record_ok(&self, key: &'static str) {
-		self.inner
-			.lock()
-			.entry(key)
-			.or_insert_with(FenceInner::new)
-			.record_ok()
-	}
+    pub fn record_ok(&self, key: &'static str) {
+        self.inner
+            .lock()
+            .entry(key)
+            .or_insert_with(FenceInner::new)
+            .record_ok()
+    }
 
-	pub fn record_fail(&self, key: &'static str) {
-		self.inner
-			.lock()
-			.entry(key)
-			.or_insert_with(FenceInner::new)
-			.record_fail()
-	}
+    pub fn record_fail(&self, key: &'static str) {
+        self.inner
+            .lock()
+            .entry(key)
+            .or_insert_with(FenceInner::new)
+            .record_fail()
+    }
 
-	pub fn latest_block_minutes(&self) -> u32 {
-		let now = Utc::now();
+    pub fn latest_block_minutes(&self) -> u32 {
+        let now = Utc::now();
 
-		self.inner
-			.lock()
-			.values()
-			.filter_map(|fence| fence.block_until)
-			.filter(|until| *until > now)
-			.max()
-			.map(|until| {
-				let seconds = until.signed_duration_since(now).num_seconds();
-				(seconds.max(0) as u32).div_ceil(60).max(1)
-			})
-			.unwrap_or(1)
-	}
+        self.inner
+            .lock()
+            .values()
+            .filter_map(|fence| fence.block_until)
+            .filter(|until| *until > now)
+            .max()
+            .map(|until| {
+                let seconds = until.signed_duration_since(now).num_seconds();
+                (seconds.max(0) as u32).div_ceil(60).max(1)
+            })
+            .unwrap_or(1)
+    }
 }
 
 struct FenceInner {


### PR DESCRIPTION
- Changes `fetch_*` functions to accept an optional URI path pattern (`/v2/version_file/:hash/update`, `/v3/version/:id`, etc)
- Uses the URI path pattern as a key for failure count tracking in `FetchFence`
- Only block requests matching the path until block expiration
- Tweak error message to include how long requests are blocked for in minutes