### PR TITLE
fix: prevent browse page reset on back navigation in app

### DIFF
--- a/packages/ui/src/layouts/shared/browse-tab/composables/use-browse-search.ts
+++ b/packages/ui/src/layouts/shared/browse-tab/composables/use-browse-search.ts
@@ -171,6 +171,7 @@ export function useBrowseSearch(options: UseBrowseSearchOptions): BrowseSearchSt
 
 	let searchVersion = 0
 	let searchDebounceTimer: ReturnType<typeof setTimeout> | null = null
+	let hasInitialized = false
 
 	const providedFiltersOrEmpty = computed(() => options.providedFilters?.value ?? [])
 
@@ -187,6 +188,7 @@ export function useBrowseSearch(options: UseBrowseSearchOptions): BrowseSearchSt
 			providedFiltersOrEmpty,
 		],
 		() => {
+			if (!hasInitialized) return
 			currentPage.value = 1
 		},
 		{ deep: true },
@@ -247,6 +249,8 @@ export function useBrowseSearch(options: UseBrowseSearchOptions): BrowseSearchSt
 			if (version === searchVersion) {
 				loading.value = false
 			}
+		} finally {
+			hasInitialized = true
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Fixes a bug in the app where browsing content within an instance (e.g. a modpack), navigating to a project page, and then using the back button always returned to page 1 instead of the page the user was on.
- Root cause: `useBrowseSearch` resets `currentPage` to 1 whenever filters/sort/query change. This reset watcher also fired during the initial setup of the Browse page, when a default `server_game_version` filter is pushed for the instance's game version, overwriting the page number restored from the `b` query param before it could take effect.
- Fix: the reset watcher is now guarded by a `hasInitialized` flag that only becomes `true` after the first `refreshSearch()` completes, so setup-time filter pushes no longer reset the page while user-driven filter changes still reset it as expected.

## Test plan
- [ ] In the app, open an instance and browse mods/resource packs
- [ ] Navigate to page 4 of results
- [ ] Click into a project, then click the back button
- [ ] Verify the browse page returns to page 4 (not page 1)
- [ ] Verify changing filters, sort, or search query while browsing still resets to page 1