### PR TITLE
fix: filtering for user page now properly shows other categories projects fall under 

### DIFF
--- a/apps/frontend/src/pages/user/[user].vue
+++ b/apps/frontend/src/pages/user/[user].vue
@@ -338,11 +338,10 @@
 					>
 						<ProjectCard
 							v-for="project in (route.params.projectType !== undefined
-								? projects.filter(
-										(x) =>
-											x.project_type ===
-											route.params.projectType.substr(0, route.params.projectType.length - 1),
-									)
+								? projects.filter((x) => {
+									const type = route.params.projectType.substr(0, route.params.projectType.length - 1)
+									return projectMatchesType(x, type)
+								})
 								: projects
 							)
 								.slice()
@@ -841,20 +840,61 @@ useSeoMeta({
 	ogImage: () => user.value?.avatar_url ?? 'https://cdn.modrinth.com/placeholder.png',
 })
 
+function getProjectTypesForProject(project) {
+	const types = new Set()
+
+ 	if (!project) return []
+
+ 	if (project.project_type === 'minecraft_java_server') {
+ 		types.add('server')
+ 	}
+
+ 	if (project.project_type && project.project_type !== 'project') {
+ 		types.add(project.project_type)
+ 	}
+
+ 	const tagsState = tags.value
+ 	const categories = [
+ 		...(project.categories ?? []),
+ 		...(project.loaders ?? []),
+ 		...(project.additional_categories ?? []),
+ 	]
+
+ 	if (tagsState && tagsState.loaderData) {
+ 		const ld = tagsState.loaderData
+
+ 		if (categories.some((c) => ld.dataPackLoaders?.includes(c))) types.add('datapack')
+ 		if (categories.some((c) => ld.allPluginLoaders?.includes(c))) types.add('plugin')
+ 		if (categories.some((c) => ld.modLoaders?.includes(c))) types.add('mod')
+ 	} else {
+ 		if (project.project_type === 'mod') types.add('mod')
+ 	}
+
+ 	return Array.from(types)
+}
+
+function projectMatchesType(project, type) {
+ 	if (!project) return false
+ 	if (!type) return true
+ 	return getProjectTypesForProject(project).includes(type)
+}
+
 const projectTypes = computed(() => {
-	const obj = {}
+ 	const obj = {}
 
-	if (collections.value?.length > 0) {
-		obj.collection = true
-	}
+ 	if (collections.value?.length > 0) {
+ 		obj.collection = true
+ 	}
 
-	for (const project of projects.value ?? []) {
-		obj[project.project_type] = true
-	}
+ 	for (const project of projects.value ?? []) {
+ 		for (const t of getProjectTypesForProject(project)) {
+ 			obj[t] = true
+ 		}
+ 	}
 
-	delete obj.project
+ 	delete obj.project
 
-	return Object.keys(obj)
+ 	return Object.keys(obj)
 })
 const sumDownloads = computed(() => {
 	let sum = 0


### PR DESCRIPTION
closes #6397 

Currently, on the user profile page (like https://modrinth.com/user/derexXD/plugins) Modrinth projects can only be assigned to a single top-level category or type (e.g., Mod, Data Pack, Plugin). While Modrinth allows creators to stack different types of versions under a single project page, which is something other platforms don't let me do, the platform's search/browse filters use a strict hierarchy to decide which single category the project belongs to.

<img width="508" height="82" alt="Image" src="https://github.com/user-attachments/assets/d7bab947-00e9-45c3-821d-1ab1976e247d" />

If a project contains all of these: Data Pack version, a Mod version (Fabric/Forge), and a Plugin version (Paper/Purpur), it will only appear under one of those filters when browsing. It is completely hidden from the other relevant filter tabs.

<div align="center">
  <img width="45%" alt="Image 1" src="https://github.com/user-attachments/assets/e2698e99-2857-41b4-b9a5-6a3237f4add7" />
  <img width="45%" alt="Image 2" src="https://github.com/user-attachments/assets/93f4654e-0251-4ad3-bb8b-c402a7224787" />
</div>

For example, my Elytra Vaults and Happy Ghast projects both have datapack AND plugin ports, but will only show for the datapack category when clicked