### PR TITLE
fix: hide content selection floating bar modal issues

### DIFF
--- a/packages/ui/src/layouts/shared/content-tab/components/ContentSelectionBar.vue
+++ b/packages/ui/src/layouts/shared/content-tab/components/ContentSelectionBar.vue
@@ -141,7 +141,7 @@ const bulkProgressMessage = computed(() => {
 </script>
 
 <template>
-	<FloatingActionBar :shown="shown" :aria-label="ariaLabel">
+	<FloatingActionBar :shown="shown" :aria-label="ariaLabel" hide-when-modal-open>
 		<div class="flex items-center gap-0.5">
 			<div
 				v-if="selectedItems.length > 0"


### PR DESCRIPTION
- Fixes shifting when modal opens
- Hides when modals open so not to appear behind modal blur bg