### PR TITLE
fix: maven version ranges not matching correctly

### DIFF
--- a/apps/frontend/src/helpers/infer/version-ranges.ts
+++ b/apps/frontend/src/helpers/infer/version-ranges.ts
@@ -50,15 +50,15 @@ export function getGameVersionsMatchingMavenRange(
 		ranges.push(range)
 	}
 
-	const LESS_THAN_EQUAL = /^\(,(.*)]$/
-	const LESS_THAN = /^\(,(.*)\)$/
-	const EQUAL = /^\[(.*)]$/
-	const GREATER_THAN_EQUAL = /^\[(.*),\)$/
-	const GREATER_THAN = /^\((.*),\)$/
-	const BETWEEN = /^\((.*),(.*)\)$/
-	const BETWEEN_EQUAL = /^\[(.*),(.*)]$/
-	const BETWEEN_LESS_THAN_EQUAL = /^\((.*),(.*)]$/
-	const BETWEEN_GREATER_THAN_EQUAL = /^\[(.*),(.*)\)$/
+	const LESS_THAN_EQUAL = /^\(,([^,]*)]$/
+	const LESS_THAN = /^\(,([^,]*)\)$/
+	const EQUAL = /^\[([^,]*)]$/
+	const GREATER_THAN_EQUAL = /^\[([^,]*),\)$/
+	const GREATER_THAN = /^\(([^,]*),\)$/
+	const BETWEEN = /^\(([^,]*),([^,]*)\)$/
+	const BETWEEN_EQUAL = /^\[([^,]*),([^,]*)]$/
+	const BETWEEN_LESS_THAN_EQUAL = /^\(([^,]*),([^,]*)]$/
+	const BETWEEN_GREATER_THAN_EQUAL = /^\[([^,]*),([^,]*)\)$/
 
 	const semverRanges = []
 


### PR DESCRIPTION
fixes maven ranges not matching correctly due to equals matching when it should be matching on between equals