### PR TITLE
fix: users projects shifting around while in queue

### DIFF
--- a/apps/frontend/src/pages/organization/[organization].vue
+++ b/apps/frontend/src/pages/organization/[organization].vue
@@ -211,7 +211,7 @@
 							: (projects ?? [])
 						)
 							.slice()
-							.sort((a, b) => b.downloads - a.downloads)"
+							.sort(projectUserSorting)"
 						:key="project.id"
 					>
 						<ProjectCard
@@ -327,6 +327,7 @@ import {
 	provideOrganizationContext,
 } from '~/providers/organization-context.ts'
 import { isPermission } from '~/utils/permissions.ts'
+import { projectUserSorting } from '~/utils/projects.ts'
 
 type ProjectV3 = Labrinth.Projects.v3.Project & {
 	client_side: 'required' | 'optional' | 'unsupported'

--- a/apps/frontend/src/pages/user/[user].vue
+++ b/apps/frontend/src/pages/user/[user].vue
@@ -346,7 +346,7 @@
 								: projects
 							)
 								.slice()
-								.sort((a, b) => b.downloads - a.downloads)"
+								.sort(projectUserSorting)"
 							:key="project.id"
 							:link="`/${project.project_type ?? 'project'}/${project.slug ? project.slug : project.id}`"
 							:title="project.title"
@@ -562,6 +562,7 @@ import AdPlaceholder from '~/components/ui/AdPlaceholder.vue'
 import CollectionCreateModal from '~/components/ui/create/CollectionCreateModal.vue'
 import ModalCreation from '~/components/ui/create/ProjectCreateModal.vue'
 import { getSignInRouteObj } from '~/composables/auth.js'
+import { projectUserSorting } from '~/utils/projects.ts'
 import { reportUser } from '~/utils/report-helpers.ts'
 import { hasActiveMidas, hasPride26Badge } from '~/utils/user-membership.ts'
 

--- a/apps/frontend/src/utils/projects.ts
+++ b/apps/frontend/src/utils/projects.ts
@@ -1,0 +1,50 @@
+import type { Labrinth } from '@modrinth/api-client'
+
+type ProjectSorting = 'publish_time' | 'queue_time' | 'downloads'
+type ProjectStatusPriority = { order: number; sort: ProjectSorting }
+// An order can only be the same as another if the sorting type is the same.
+const projectStatusPriority: {
+	[status in Labrinth.Projects.v2.ProjectStatus]: ProjectStatusPriority
+} = {
+	approved: { order: 1, sort: 'downloads' },
+	scheduled: { order: 1, sort: 'downloads' },
+	archived: { order: 2, sort: 'downloads' },
+	unlisted: { order: 3, sort: 'downloads' },
+	private: { order: 4, sort: 'downloads' },
+	processing: { order: 5, sort: 'queue_time' },
+	withheld: { order: 6, sort: 'publish_time' },
+	rejected: { order: 7, sort: 'publish_time' },
+	draft: { order: 8, sort: 'publish_time' },
+	unknown: { order: 9, sort: 'publish_time' },
+}
+
+function getProjectSortValue(
+	project: Labrinth.Projects.v3.Project | Labrinth.Projects.v2.Project,
+	sorting: ProjectSorting,
+): number {
+	switch (sorting) {
+		case 'publish_time':
+			return new Date(project.published).getTime()
+		case 'queue_time':
+			return new Date(project.queued || project.published).getTime()
+		case 'downloads':
+			return project.downloads
+		default:
+			return 0
+	}
+}
+
+export const projectUserSorting = (
+	first: Labrinth.Projects.v3.Project | Labrinth.Projects.v2.Project,
+	second: Labrinth.Projects.v3.Project | Labrinth.Projects.v2.Project,
+): number => {
+	const priority1 = projectStatusPriority[first.status] || projectStatusPriority['unknown']
+	const priority2 = projectStatusPriority[second.status] || projectStatusPriority['unknown']
+
+	if (priority1.order !== priority2.order) {
+		return priority1.order - priority2.order
+	} else if (priority1.sort !== priority2.sort) {
+		return 0
+	}
+	return getProjectSortValue(second, priority2.sort) - getProjectSortValue(first, priority1.sort)
+}


### PR DESCRIPTION
Changes the users/orgs project sorting to have a priority/order dependent on its status and then secondary sort depending on the status as well to stop projects from moving around the place when at low download counts, rather localize them to their own buckets.
- Approved statuses sort by downloads, but are first sorted by their status: approved, scheduled -> archived -> unlisted -> private
- In queue status sorted by queue time
- Rejected/unapproved sorted by publish time, but are first sorted by their status: withheld -> rejected -> draft -> unknown