### PR TITLE
fix: allow PAT scope labels to wrap on long strings

### DIFF
--- a/apps/frontend/src/pages/settings/pats.vue
+++ b/apps/frontend/src/pages/settings/pats.vue
@@ -468,7 +468,6 @@ async function removePat(id) {
 </script>
 <style lang="scss" scoped>
 .scope-items :deep(.checkbox-outer) {
-	white-space: nowrap !important;
 	justify-content: flex-start !important;
 }
 


### PR DESCRIPTION
Fixes #5866 

Removed `white-space: nowrap !important;` to allow longer strings (such as those in Spanish translations) to flow onto the next line, rather than being overlapping with the next checkbox.