### PR TITLE
fix: nested details tags in markdown bodies

### DIFF
--- a/packages/assets/styles/classes.scss
+++ b/packages/assets/styles/classes.scss
@@ -1006,6 +1006,11 @@ a:not(.no-click-animation),
 			> :last-child:not(summary) {
 				margin-bottom: 0 !important;
 			}
+
+			> details:not([open]) summary {
+				margin: -0.5em -0.5em 0;
+				border-radius: var(--radius-xs);
+			}
 		}
 	}
 


### PR DESCRIPTION
Nearly 5 years ago, I reviewed [a pull request](https://github.com/modrinth/knossos/pull/268) that gave us much of the project description styling we know and love today.

However, for that entire time, something has plagued me deeply. Unopened nested `<details>` tags have long had an extra gap in a place where they shouldn't. See, for instance, the "within details" and "more" tags in the pictures below.

This PR aims to finally fix this, once and for all.

<table>
<tr>
 <td>Before
 <td><img width="1005" height="385" alt="image" src="https://github.com/user-attachments/assets/299eabd8-c37b-4698-950b-5d3e6ac48005" />
<tr>
 <td>After
 <td><img width="1011" height="366" alt="image" src="https://github.com/user-attachments/assets/01289cd5-3763-4bc7-b4bf-830ba6b6cb20" />
</table>
