### PR TITLE
chore: add modfolio to allowed hostnames

### DIFF
--- a/packages/utils/parse.ts
+++ b/packages/utils/parse.ts
@@ -112,6 +112,7 @@ export const configuredXss = new FilterXSS({
 					'wsrv.nl',
 					'cf.way2muchnoise.eu',
 					'bstats.org',
+					'modfolio.creeperkatze.dev',
 				]
 
 				const allowedHostnameSuffixes = ['.github.io']


### PR DESCRIPTION
Adds [Modfolio](https://github.com/creeperkatze/modfolio) to the allowed hostnames so it wont be cached by wsrv.nl.

This is required since its a dynamic badge generator.