### PR TITLE
add excessive languages warning nag

### DIFF
--- a/packages/moderation/src/data/nags/server-projects.ts
+++ b/packages/moderation/src/data/nags/server-projects.ts
@@ -1,6 +1,9 @@
-import { defineMessage } from '@modrinth/ui'
+import { defineMessage, useVIntl } from '@modrinth/ui'
 
 import type { Nag, NagContext } from '../../types/nags'
+
+const MAX_LANGUAGE_COUNT = 10
+const ALL_LANGUAGE_COUNT = 72
 
 export const serverProjectsNags: Nag[] = [
 	{
@@ -16,6 +19,84 @@ export const serverProjectsNags: Nag[] = [
 		status: 'required',
 		shouldShow: (context: NagContext) =>
 			!!context.projectV3?.minecraft_server && !context.projectV3?.minecraft_server.region,
+		link: {
+			path: 'settings/server',
+			title: defineMessage({
+				id: 'nags.server.title',
+				defaultMessage: 'Visit server settings',
+			}),
+			shouldShow: (context: NagContext) => context.currentRoute !== 'type-project-settings-server',
+		},
+	},
+	{
+		id: 'too-many-languages',
+		title: defineMessage({
+			id: 'nags.too-many-languages.title',
+			defaultMessage: 'Select accurate languages',
+		}),
+		description: (context: NagContext) => {
+			const { formatMessage } = useVIntl()
+			const languageCount = context.projectV3?.minecraft_server?.languages?.length || 0
+			const maxLanguageCount = MAX_LANGUAGE_COUNT
+
+			return formatMessage(
+				defineMessage({
+					id: 'nags.too-many-languages.description',
+					defaultMessage:
+						"You've selected {languageCount, plural, one {# language} other {# languages}}. Please list only the languages your server actively supports.",
+				}),
+				{
+					languageCount,
+					maxLanguageCount,
+				},
+			)
+		},
+		status: 'warning',
+		shouldShow: (context: NagContext) => {
+			const languageCount = context.projectV3?.minecraft_server?.languages?.length || 0
+			return (
+				languageCount > MAX_LANGUAGE_COUNT &&
+				//languageCount <= ALL_LANGUAGE_COUNT &&
+				context.projectV3?.minecraft_server != null
+			)
+		},
+		link: {
+			path: 'settings/server',
+			title: defineMessage({
+				id: 'nags.server.title',
+				defaultMessage: 'Visit server settings',
+			}),
+			shouldShow: (context: NagContext) => context.currentRoute !== 'type-project-settings-server',
+		},
+	},
+	{
+		id: 'all-languages',
+		title: defineMessage({
+			id: 'nags.all-languages.title',
+			defaultMessage: 'Select accurate languages',
+		}),
+		description: (context: NagContext) => {
+			const { formatMessage } = useVIntl()
+			const languageCount = context.projectV3?.minecraft_server?.languages?.length || 0
+			const allLanguageCount = ALL_LANGUAGE_COUNT
+
+			return formatMessage(
+				defineMessage({
+					id: 'nags.all-languages.description',
+					defaultMessage:
+						"You've selected all available language options. Please list only the languages your server actively supports.",
+				}),
+				{
+					languageCount,
+					allLanguageCount,
+				},
+			)
+		},
+		status: 'required',
+		shouldShow: (context: NagContext) => {
+			// const languageCount = context.projectV3?.minecraft_server?.languages?.length || 0
+			return false //languageCount >= ALL_LANGUAGE_COUNT && context.projectV3?.minecraft_server != null
+		},
 		link: {
 			path: 'settings/server',
 			title: defineMessage({

--- a/packages/moderation/src/locales/en-US/index.json
+++ b/packages/moderation/src/locales/en-US/index.json
@@ -35,6 +35,12 @@
   "nags.add-links.title": {
     "defaultMessage": "Add external links"
   },
+  "nags.all-languages.description": {
+    "defaultMessage": "You've selected all available language options. Please list only the languages your server actively supports."
+  },
+  "nags.all-languages.title": {
+    "defaultMessage": "Select accurate languages"
+  },
   "nags.all-tags-selected.description": {
     "defaultMessage": "You've selected all {totalAvailableTags, plural, one {# available tag} other {# available tags}}. This defeats the purpose of tags, which are meant to help users find relevant projects. Please select only the tags that are relevant to your project."
   },
@@ -226,6 +232,12 @@
   },
   "nags.title-contains-technical-info.title": {
     "defaultMessage": "Clean up the name"
+  },
+  "nags.too-many-languages.description": {
+    "defaultMessage": "You've selected {languageCount, plural, one {# language} other {# languages}}. Please list only the languages your server actively supports."
+  },
+  "nags.too-many-languages.title": {
+    "defaultMessage": "Select accurate languages"
   },
   "nags.too-many-tags-server.description": {
     "defaultMessage": "You've selected {tagCount, plural, one {# tag} other {# tags}}. Please reduce to {maxTagCount} or fewer to make sure your server appears in relevant search results."


### PR DESCRIPTION
Functionality for an "all languages" required nag is present but will be unused for now.