### PR TITLE
feat: Add Collections on the App

### DIFF
--- a/apps/app-frontend/src/components/ui/CollectionInstallModal.vue
+++ b/apps/app-frontend/src/components/ui/CollectionInstallModal.vue
@@ -1,0 +1,678 @@
+<template>
+	<NewModal ref="modal" no-padding scrollable max-width="600px" width="600px" :on-hide="reset">
+		<template #title>
+			<span class="text-2xl font-semibold text-contrast">
+				{{
+					collectionName
+						? formatMessage(messages.headerNamed, { name: collectionName })
+						: formatMessage(messages.header)
+				}}
+			</span>
+		</template>
+
+		<template v-if="!lockedInstance">
+			<div class="flex flex-col gap-2.5 p-6">
+				<span class="font-semibold text-contrast">
+					{{ formatMessage(messages.instanceType) }}
+				</span>
+				<Chips
+					v-model="tab"
+					:items="['existing', 'new']"
+					:format-label="formatTabLabel"
+					:never-empty="true"
+					:capitalize="false"
+				/>
+			</div>
+
+			<div class="h-px bg-divider" />
+
+			<div v-if="tab === 'existing'" class="flex flex-col gap-2.5 p-6">
+				<span class="font-semibold text-contrast">
+					{{ formatMessage(messages.selectInstance) }}
+				</span>
+				<div v-if="loadingInstances" class="flex items-center justify-center py-6">
+					<LoadingIndicator />
+				</div>
+				<div
+					v-else-if="instances.length === 0"
+					class="flex items-center justify-center py-6 text-secondary"
+				>
+					{{ formatMessage(messages.noInstances) }}
+				</div>
+				<Combobox
+					v-else
+					v-model="selectedInstanceId"
+					:options="instanceOptions"
+					searchable
+					:placeholder="formatMessage(messages.selectInstancePlaceholder)"
+				/>
+			</div>
+
+			<div v-else class="flex flex-col gap-4 p-6">
+				<div class="flex flex-col gap-2.5">
+					<span class="font-semibold text-contrast">
+						{{ formatMessage(messages.nameLabel) }}
+					</span>
+					<StyledInput
+						v-model="newInstanceName"
+						:placeholder="formatMessage(messages.namePlaceholder)"
+					/>
+				</div>
+				<div class="flex flex-col gap-2.5">
+					<span class="font-semibold text-contrast">
+						{{ formatMessage(messages.loaderLabel) }}
+					</span>
+					<Chips
+						v-model="newInstanceLoader"
+						:items="NEW_INSTANCE_LOADERS"
+						:format-label="formatLoaderLabel"
+						:never-empty="true"
+					/>
+				</div>
+				<div class="flex flex-col gap-2.5">
+					<span class="font-semibold text-contrast">
+						{{ formatMessage(commonMessages.gameVersionLabel) }}
+					</span>
+					<Combobox
+						v-model="newInstanceGameVersion"
+						:options="gameVersionOptions"
+						searchable
+						sync-with-selection
+						:placeholder="formatMessage(messages.gameVersionPlaceholder)"
+					>
+						<template #dropdown-footer>
+							<button
+								class="flex w-full cursor-pointer items-center justify-center gap-1.5 border-0 border-t border-solid border-surface-5 bg-transparent py-3 text-center text-sm font-semibold text-secondary transition-colors hover:text-contrast"
+								@mousedown.prevent
+								@click="showSnapshots = !showSnapshots"
+							>
+								<EyeOffIcon v-if="showSnapshots" class="size-4" />
+								<EyeIcon v-else class="size-4" />
+								{{
+									showSnapshots
+										? formatMessage(commonMessages.hideSnapshotsButton)
+										: formatMessage(commonMessages.showAllVersionsButton)
+								}}
+							</button>
+						</template>
+					</Combobox>
+				</div>
+			</div>
+
+			<div class="h-px bg-divider" />
+		</template>
+
+		<div class="flex flex-col gap-2.5 p-6">
+			<div class="flex items-center justify-between">
+				<span class="font-semibold text-contrast">
+					{{
+						formatMessage(messages.projectsLabel, {
+							selected: checkedIds.size,
+							total: projects.length,
+						})
+					}}
+				</span>
+				<ButtonStyled v-if="selectableProjects.length > 0" type="transparent">
+					<button @click="toggleAll">
+						{{
+							checkedIds.size > 0
+								? formatMessage(messages.deselectAll)
+								: formatMessage(messages.selectAll)
+						}}
+					</button>
+				</ButtonStyled>
+			</div>
+
+			<div class="flex max-h-[320px] flex-col gap-0.5 overflow-y-auto rounded-xl bg-surface-2 p-2">
+				<div v-if="checkingTarget" class="flex items-center justify-center py-6">
+					<LoadingIndicator />
+				</div>
+				<template v-else>
+					<label
+						v-for="project in projects"
+						:key="project.id"
+						class="flex items-center gap-2.5 rounded-lg px-2 py-1.5"
+						:class="
+							projectStatus(project) === 'ok' ? 'cursor-pointer hover:bg-surface-3' : 'opacity-60'
+						"
+					>
+						<Checkbox
+							:model-value="checkedIds.has(project.id)"
+							:disabled="projectStatus(project) !== 'ok' || installing"
+							@update:model-value="(value) => setChecked(project.id, value)"
+						/>
+						<Avatar :src="project.icon_url" size="2rem" rounded="md" />
+						<span class="min-w-0 flex-1 truncate font-semibold text-contrast">
+							{{ project.title }}
+						</span>
+						<span
+							v-if="projectStatus(project) === 'installed'"
+							class="flex shrink-0 items-center gap-1 text-sm text-secondary"
+						>
+							<CheckIcon class="size-4" aria-hidden="true" />
+							{{ formatMessage(messages.alreadyInstalled) }}
+						</span>
+						<span
+							v-else-if="projectStatus(project) === 'incompatible'"
+							v-tooltip="formatMessage(messages.incompatibleTooltip)"
+							class="flex shrink-0 items-center gap-1 text-sm text-orange"
+						>
+							<TriangleAlertIcon class="size-4" aria-hidden="true" />
+							{{ formatMessage(messages.incompatible) }}
+						</span>
+						<span
+							v-else-if="projectStatus(project) === 'unsupported'"
+							class="flex shrink-0 items-center gap-1 text-sm text-secondary"
+						>
+							<XIcon class="size-4" aria-hidden="true" />
+							{{ formatMessage(messages.unsupported) }}
+						</span>
+					</label>
+				</template>
+			</div>
+
+			<div v-if="installing" class="flex items-center gap-2 text-secondary">
+				<SpinnerIcon class="size-4 animate-spin" aria-hidden="true" />
+				{{
+					formatMessage(messages.installingProgress, {
+						current: progressCurrent,
+						total: progressTotal,
+					})
+				}}
+			</div>
+		</div>
+
+		<template #actions>
+			<div class="flex items-center justify-end gap-2">
+				<ButtonStyled type="outlined">
+					<button :disabled="installing" @click="modal?.hide()">
+						<XIcon aria-hidden="true" />
+						{{ formatMessage(commonMessages.cancelButton) }}
+					</button>
+				</ButtonStyled>
+				<ButtonStyled color="brand">
+					<button :disabled="!canInstall" @click="handleInstall">
+						<SpinnerIcon v-if="installing" class="animate-spin" aria-hidden="true" />
+						<DownloadIcon v-else aria-hidden="true" />
+						{{
+							installing
+								? formatMessage(commonMessages.installingLabel)
+								: formatMessage(messages.installButton, { count: checkedIds.size })
+						}}
+					</button>
+				</ButtonStyled>
+			</div>
+		</template>
+	</NewModal>
+</template>
+
+<script setup lang="ts">
+import type { Labrinth } from '@modrinth/api-client'
+import {
+	CheckIcon,
+	DownloadIcon,
+	EyeIcon,
+	EyeOffIcon,
+	SpinnerIcon,
+	TriangleAlertIcon,
+	XIcon,
+} from '@modrinth/assets'
+import {
+	Avatar,
+	ButtonStyled,
+	Checkbox,
+	Chips,
+	Combobox,
+	type ComboboxOption,
+	commonMessages,
+	defineMessages,
+	formatLoaderLabel,
+	injectNotificationManager,
+	LoadingIndicator,
+	NewModal,
+	StyledInput,
+	useVIntl,
+} from '@modrinth/ui'
+import { computed, ref, watch } from 'vue'
+
+import {
+	install_create_instance,
+	installJobInstanceId,
+	wait_for_install_job,
+} from '@/helpers/install'
+import {
+	get_installed_project_ids,
+	install_project_with_dependencies,
+	list,
+} from '@/helpers/instance'
+import { get_game_versions } from '@/helpers/tags.js'
+import type { GameInstance, InstanceLoader } from '@/helpers/types'
+
+const { formatMessage } = useVIntl()
+const { handleError, addNotification } = injectNotificationManager()
+
+const messages = defineMessages({
+	header: {
+		id: 'app.collection-install.header',
+		defaultMessage: 'Install collection',
+	},
+	headerNamed: {
+		id: 'app.collection-install.header-named',
+		defaultMessage: 'Install {name}',
+	},
+	instanceType: {
+		id: 'app.collection-install.instance-type',
+		defaultMessage: 'Instance type',
+	},
+	existingTab: {
+		id: 'app.collection-install.existing-tab',
+		defaultMessage: 'Existing instance',
+	},
+	newTab: {
+		id: 'app.collection-install.new-tab',
+		defaultMessage: 'New instance',
+	},
+	selectInstance: {
+		id: 'app.collection-install.select-instance',
+		defaultMessage: 'Instance',
+	},
+	selectInstancePlaceholder: {
+		id: 'app.collection-install.select-instance-placeholder',
+		defaultMessage: 'Select an instance',
+	},
+	noInstances: {
+		id: 'app.collection-install.no-instances',
+		defaultMessage: 'No instances found. Create a new instance instead.',
+	},
+	nameLabel: {
+		id: 'app.collection-install.name-label',
+		defaultMessage: 'Name',
+	},
+	namePlaceholder: {
+		id: 'app.collection-install.name-placeholder',
+		defaultMessage: 'Enter instance name',
+	},
+	loaderLabel: {
+		id: 'app.collection-install.loader-label',
+		defaultMessage: 'Loader',
+	},
+	gameVersionPlaceholder: {
+		id: 'app.collection-install.game-version-placeholder',
+		defaultMessage: 'Select game version',
+	},
+	projectsLabel: {
+		id: 'app.collection-install.projects-label',
+		defaultMessage: '{selected} of {total} projects selected',
+	},
+	selectAll: {
+		id: 'app.collection-install.select-all',
+		defaultMessage: 'Select all',
+	},
+	deselectAll: {
+		id: 'app.collection-install.deselect-all',
+		defaultMessage: 'Deselect all',
+	},
+	alreadyInstalled: {
+		id: 'app.collection-install.already-installed',
+		defaultMessage: 'Installed',
+	},
+	incompatible: {
+		id: 'app.collection-install.incompatible',
+		defaultMessage: 'Incompatible',
+	},
+	incompatibleTooltip: {
+		id: 'app.collection-install.incompatible-tooltip',
+		defaultMessage:
+			'This project has no version compatible with the selected loader and game version.',
+	},
+	unsupported: {
+		id: 'app.collection-install.unsupported',
+		defaultMessage: 'Not supported',
+	},
+	installButton: {
+		id: 'app.collection-install.install-button',
+		defaultMessage: 'Install {count, plural, one {# project} other {# projects}}',
+	},
+	installingProgress: {
+		id: 'app.collection-install.installing-progress',
+		defaultMessage: 'Installing {current, number} of {total, number}...',
+	},
+	installSuccess: {
+		id: 'app.collection-install.success',
+		defaultMessage: 'Collection installed',
+	},
+	installSuccessText: {
+		id: 'app.collection-install.success-text',
+		defaultMessage:
+			'{count, plural, one {# project} other {# projects}} added to {instance}. Missing dependencies were installed automatically.',
+	},
+	installPartialText: {
+		id: 'app.collection-install.partial-text',
+		defaultMessage:
+			'{count, plural, one {# project} other {# projects}} added to {instance}, {failed} failed.',
+	},
+	installFailed: {
+		id: 'app.collection-install.failed',
+		defaultMessage: 'Failed to install collection',
+	},
+})
+
+type ProjectStatus = 'ok' | 'installed' | 'incompatible' | 'unsupported'
+
+const RESOLVABLE_PROJECT_TYPES = new Set(['mod', 'plugin', 'datapack', 'resourcepack', 'shader'])
+const NEW_INSTANCE_LOADERS = ['vanilla', 'fabric', 'quilt', 'neoforge', 'forge']
+
+const emit = defineEmits<{
+	installed: [instanceId: string]
+}>()
+
+const modal = ref<InstanceType<typeof NewModal>>()
+
+const projects = ref<Labrinth.Projects.v2.Project[]>([])
+const collectionName = ref<string | null>(null)
+const lockedInstance = ref<GameInstance | null>(null)
+
+const tab = ref<'existing' | 'new'>('existing')
+const tabLabels: Record<'existing' | 'new', () => string> = {
+	existing: () => formatMessage(messages.existingTab),
+	new: () => formatMessage(messages.newTab),
+}
+const formatTabLabel = (item: 'existing' | 'new') => tabLabels[item]()
+
+const instances = ref<GameInstance[]>([])
+const loadingInstances = ref(false)
+const selectedInstanceId = ref<string | null>(null)
+
+const newInstanceName = ref('')
+const newInstanceLoader = ref<string>('fabric')
+const newInstanceGameVersion = ref<string | null>(null)
+const allGameVersions = ref<{ version: string; version_type: string }[]>([])
+const showSnapshots = ref(false)
+
+const installedProjectIds = ref<Set<string>>(new Set())
+const checkingTarget = ref(false)
+const checkedIds = ref<Set<string>>(new Set())
+
+const installing = ref(false)
+const progressCurrent = ref(0)
+const progressTotal = ref(0)
+
+const instanceOptions = computed<ComboboxOption<string>[]>(() =>
+	instances.value.map((instance) => ({
+		value: instance.id,
+		label: `${instance.name} (${formatLoaderLabel(instance.loader)} ${instance.game_version})`,
+	})),
+)
+
+const gameVersionOptions = computed<ComboboxOption<string>[]>(() => {
+	const versions = showSnapshots.value
+		? allGameVersions.value
+		: allGameVersions.value.filter((v) => v.version_type === 'release')
+	return versions.map((v) => ({ value: v.version, label: v.version }))
+})
+
+const targetLoader = computed(() => {
+	if (lockedInstance.value) return lockedInstance.value.loader
+	if (tab.value === 'new') return newInstanceLoader.value
+	return (
+		instances.value.find((instance) => instance.id === selectedInstanceId.value)?.loader ?? null
+	)
+})
+
+const targetGameVersion = computed(() => {
+	if (lockedInstance.value) return lockedInstance.value.game_version
+	if (tab.value === 'new') return newInstanceGameVersion.value
+	return (
+		instances.value.find((instance) => instance.id === selectedInstanceId.value)?.game_version ??
+		null
+	)
+})
+
+const hasTarget = computed(() => !!targetLoader.value && !!targetGameVersion.value)
+
+function isProjectCompatible(project: Labrinth.Projects.v2.Project) {
+	if (!targetLoader.value || !targetGameVersion.value) return false
+
+	const gameVersions = project.game_versions ?? []
+	if (!gameVersions.includes(targetGameVersion.value)) return false
+
+	if (project.project_type === 'mod' || project.project_type === 'plugin') {
+		const loaders = project.loaders ?? []
+		return loaders.includes(targetLoader.value) || loaders.includes('datapack')
+	}
+
+	return true
+}
+
+function projectStatus(project: Labrinth.Projects.v2.Project): ProjectStatus {
+	if (!RESOLVABLE_PROJECT_TYPES.has(project.project_type)) return 'unsupported'
+	if (installedProjectIds.value.has(project.id)) return 'installed'
+	if (!hasTarget.value || !isProjectCompatible(project)) return 'incompatible'
+	return 'ok'
+}
+
+const selectableProjects = computed(() =>
+	projects.value.filter((project) => projectStatus(project) === 'ok'),
+)
+
+const canInstall = computed(() => {
+	if (installing.value || checkedIds.value.size === 0) return false
+	if (lockedInstance.value) return true
+	if (tab.value === 'existing') return !!selectedInstanceId.value
+	return !!newInstanceName.value && !!newInstanceLoader.value && !!newInstanceGameVersion.value
+})
+
+function setChecked(projectId: string, value: boolean) {
+	const next = new Set(checkedIds.value)
+	if (value) next.add(projectId)
+	else next.delete(projectId)
+	checkedIds.value = next
+}
+
+function toggleAll() {
+	if (checkedIds.value.size > 0) {
+		checkedIds.value = new Set()
+	} else {
+		checkedIds.value = new Set(selectableProjects.value.map((project) => project.id))
+	}
+}
+
+function selectAllEligible() {
+	checkedIds.value = new Set(selectableProjects.value.map((project) => project.id))
+}
+
+async function refreshInstalledProjectIds(instanceId: string | null) {
+	checkingTarget.value = true
+	try {
+		installedProjectIds.value = instanceId
+			? new Set(await get_installed_project_ids(instanceId))
+			: new Set()
+	} catch (err) {
+		installedProjectIds.value = new Set()
+		handleError(err as Error)
+	} finally {
+		checkingTarget.value = false
+	}
+}
+
+watch([selectedInstanceId, tab], async ([instanceId, newTab]) => {
+	if (lockedInstance.value || installing.value) return
+	await refreshInstalledProjectIds(newTab === 'existing' ? instanceId : null)
+	selectAllEligible()
+})
+
+watch([newInstanceLoader, newInstanceGameVersion], () => {
+	if (lockedInstance.value || installing.value || tab.value !== 'new') return
+	selectAllEligible()
+})
+
+async function show(
+	projectList: Labrinth.Projects.v2.Project[],
+	options?: { instance?: GameInstance | null; collectionName?: string | null },
+) {
+	projects.value = projectList
+	collectionName.value = options?.collectionName ?? null
+	lockedInstance.value = options?.instance ?? null
+	tab.value = 'existing'
+	selectedInstanceId.value = null
+	newInstanceName.value = collectionName.value ?? ''
+	newInstanceLoader.value = 'fabric'
+	newInstanceGameVersion.value = null
+	showSnapshots.value = false
+	installedProjectIds.value = new Set()
+	checkedIds.value = new Set()
+	installing.value = false
+	progressCurrent.value = 0
+	progressTotal.value = 0
+
+	modal.value?.show()
+
+	if (lockedInstance.value) {
+		await refreshInstalledProjectIds(lockedInstance.value.id)
+		selectAllEligible()
+	} else {
+		loadingInstances.value = true
+		try {
+			instances.value = await list()
+			const firstCompatible = instances.value.find((instance) =>
+				projectList.some(
+					(project) =>
+						(project.game_versions ?? []).includes(instance.game_version) &&
+						(project.project_type !== 'mod' || (project.loaders ?? []).includes(instance.loader)),
+				),
+			)
+			selectedInstanceId.value = firstCompatible?.id ?? instances.value[0]?.id ?? null
+			if (instances.value.length === 0) {
+				tab.value = 'new'
+			}
+		} catch (err) {
+			handleError(err as Error)
+		} finally {
+			loadingInstances.value = false
+		}
+	}
+
+	if (allGameVersions.value.length === 0) {
+		get_game_versions()
+			.then((versions: { version: string; version_type: string }[]) => {
+				allGameVersions.value = versions
+				if (!newInstanceGameVersion.value) {
+					newInstanceGameVersion.value =
+						versions.find((v) => v.version_type === 'release')?.version ?? null
+				}
+			})
+			.catch(() => {})
+	} else if (!newInstanceGameVersion.value) {
+		newInstanceGameVersion.value =
+			allGameVersions.value.find((v) => v.version_type === 'release')?.version ?? null
+	}
+}
+
+function reset() {
+	if (!installing.value) {
+		projects.value = []
+		checkedIds.value = new Set()
+	}
+}
+
+function resolveContentType(projectType: string): Labrinth.Content.v3.ContentType {
+	return RESOLVABLE_PROJECT_TYPES.has(projectType)
+		? (projectType as Labrinth.Content.v3.ContentType)
+		: 'mod'
+}
+
+async function resolveTargetInstanceId(): Promise<string> {
+	if (lockedInstance.value) return lockedInstance.value.id
+	if (tab.value === 'existing') {
+		if (!selectedInstanceId.value) throw new Error('No instance selected')
+		return selectedInstanceId.value
+	}
+
+	const job = await install_create_instance({
+		name: newInstanceName.value,
+		gameVersion: newInstanceGameVersion.value!,
+		loader: newInstanceLoader.value as InstanceLoader,
+		loaderVersion: 'latest',
+		iconPath: null,
+	})
+	const finished = await wait_for_install_job(job.job_id)
+	const instanceId = installJobInstanceId(finished)
+	if (!instanceId) throw new Error('Failed to create instance')
+	return instanceId
+}
+
+async function handleInstall() {
+	if (!canInstall.value) return
+
+	const selectedProjects = projects.value.filter(
+		(project) => checkedIds.value.has(project.id) && projectStatus(project) === 'ok',
+	)
+	if (selectedProjects.length === 0) return
+
+	installing.value = true
+	progressCurrent.value = 0
+	progressTotal.value = selectedProjects.length
+
+	let instanceId: string
+	try {
+		instanceId = await resolveTargetInstanceId()
+	} catch (err) {
+		installing.value = false
+		handleError(err as Error)
+		return
+	}
+
+	const instanceName = lockedInstance.value
+		? lockedInstance.value.name
+		: tab.value === 'existing'
+			? (instances.value.find((instance) => instance.id === instanceId)?.name ?? instanceId)
+			: newInstanceName.value
+
+	let added = 0
+	const failed: string[] = []
+
+	for (const project of selectedProjects) {
+		progressCurrent.value += 1
+		try {
+			await install_project_with_dependencies(instanceId, {
+				project_id: project.id,
+				content_type: resolveContentType(project.project_type),
+			})
+			added += 1
+		} catch (err) {
+			console.error(`Failed to install ${project.title}:`, err)
+			failed.push(project.title)
+		}
+	}
+
+	installing.value = false
+
+	if (added > 0) {
+		addNotification({
+			type: failed.length > 0 ? 'warning' : 'success',
+			title: formatMessage(messages.installSuccess),
+			text:
+				failed.length > 0
+					? formatMessage(messages.installPartialText, {
+							count: added,
+							instance: instanceName,
+							failed: failed.length,
+						})
+					: formatMessage(messages.installSuccessText, {
+							count: added,
+							instance: instanceName,
+						}),
+		})
+		emit('installed', instanceId)
+		modal.value?.hide()
+	} else {
+		addNotification({
+			type: 'error',
+			title: formatMessage(messages.installFailed),
+			text: failed.join(', '),
+		})
+	}
+}
+
+defineExpose({ show })
+</script>

--- a/apps/app-frontend/src/components/ui/CollectionPickerModal.vue
+++ b/apps/app-frontend/src/components/ui/CollectionPickerModal.vue
@@ -1,0 +1,215 @@
+<template>
+	<NewModal ref="modal" no-padding scrollable max-width="560px" width="560px">
+		<template #title>
+			<span class="text-2xl font-semibold text-contrast">
+				{{ formatMessage(messages.header) }}
+			</span>
+		</template>
+
+		<div class="flex flex-col gap-3 p-6">
+			<div class="flex flex-wrap items-center gap-2">
+				<StyledInput
+					v-model="otherCollectionInput"
+					:icon="LinkIcon"
+					type="text"
+					autocomplete="off"
+					:spellcheck="false"
+					:placeholder="formatMessage(messages.otherCollectionPlaceholder)"
+					wrapper-class="w-full flex-grow sm:w-auto"
+					@keydown.enter="openOtherCollection"
+				/>
+				<ButtonStyled>
+					<button
+						:disabled="!otherCollectionInput.trim() || loadingOtherCollection"
+						@click="openOtherCollection"
+					>
+						<SpinnerIcon v-if="loadingOtherCollection" class="animate-spin" aria-hidden="true" />
+						<ExternalIcon v-else aria-hidden="true" />
+						{{ formatMessage(messages.openButton) }}
+					</button>
+				</ButtonStyled>
+			</div>
+
+			<div class="h-px bg-divider" />
+
+			<div v-if="!userId" class="flex flex-col items-center gap-3 py-6 text-secondary">
+				{{ formatMessage(messages.signInPrompt) }}
+				<ButtonStyled color="brand">
+					<button @click="auth.requestSignIn(route.fullPath)">
+						<LogInIcon aria-hidden="true" />
+						{{ formatMessage(messages.signInButton) }}
+					</button>
+				</ButtonStyled>
+			</div>
+			<div v-else-if="isPending" class="flex items-center justify-center py-6">
+				<LoadingIndicator />
+			</div>
+			<div
+				v-else-if="!collections || collections.length === 0"
+				class="flex items-center justify-center py-6 text-secondary"
+			>
+				{{ formatMessage(messages.noCollections) }}
+			</div>
+			<div v-else class="flex max-h-[400px] flex-col gap-0.5 overflow-y-auto">
+				<button
+					v-for="collection in collections"
+					:key="collection.id"
+					class="flex cursor-pointer items-center gap-2.5 rounded-xl border-0 bg-transparent px-2 py-2 text-left hover:bg-surface-3"
+					:disabled="loadingCollectionId !== null"
+					@click="pickCollection(collection)"
+				>
+					<Avatar :src="collection.icon_url" size="2.5rem" />
+					<div class="flex min-w-0 flex-1 flex-col">
+						<span class="truncate font-semibold text-contrast">{{ collection.name }}</span>
+						<span class="text-sm text-secondary">
+							{{ formatMessage(messages.projectsCount, { count: collection.projects.length }) }}
+						</span>
+					</div>
+					<SpinnerIcon
+						v-if="loadingCollectionId === collection.id"
+						class="size-5 animate-spin text-secondary"
+						aria-hidden="true"
+					/>
+					<ChevronRightIcon v-else class="size-5 text-secondary" aria-hidden="true" />
+				</button>
+			</div>
+		</div>
+	</NewModal>
+</template>
+
+<script setup lang="ts">
+import type { Labrinth } from '@modrinth/api-client'
+import { ChevronRightIcon, ExternalIcon, LinkIcon, LogInIcon, SpinnerIcon } from '@modrinth/assets'
+import {
+	Avatar,
+	ButtonStyled,
+	defineMessages,
+	injectAuth,
+	injectModrinthClient,
+	injectNotificationManager,
+	LoadingIndicator,
+	NewModal,
+	StyledInput,
+	useVIntl,
+} from '@modrinth/ui'
+import { useQuery } from '@tanstack/vue-query'
+import { computed, ref } from 'vue'
+import { useRoute } from 'vue-router'
+
+import { get_project_many } from '@/helpers/cache.js'
+import { parseCollectionId } from '@/helpers/collections'
+
+const { formatMessage } = useVIntl()
+const { handleError, addNotification } = injectNotificationManager()
+const auth = injectAuth()
+const client = injectModrinthClient()
+const route = useRoute()
+
+const messages = defineMessages({
+	header: {
+		id: 'app.collection-picker.header',
+		defaultMessage: 'Add from collection',
+	},
+	signInPrompt: {
+		id: 'app.collection-picker.sign-in-prompt',
+		defaultMessage: 'Sign in to view your collections',
+	},
+	signInButton: {
+		id: 'app.collection-picker.sign-in-button',
+		defaultMessage: 'Sign in',
+	},
+	noCollections: {
+		id: 'app.collection-picker.empty',
+		defaultMessage: "You don't have any collections yet",
+	},
+	projectsCount: {
+		id: 'app.collection-picker.projects-count',
+		defaultMessage: '{count, plural, =0 {No projects} one {# project} other {# projects}}',
+	},
+	otherCollectionPlaceholder: {
+		id: 'app.collection-picker.other-collection-placeholder',
+		defaultMessage: 'Paste a collection link or ID...',
+	},
+	openButton: {
+		id: 'app.collection-picker.open-button',
+		defaultMessage: 'Open',
+	},
+	invalidCollectionLink: {
+		id: 'app.collection-picker.invalid-collection-link',
+		defaultMessage: 'Invalid collection link',
+	},
+	invalidCollectionLinkText: {
+		id: 'app.collection-picker.invalid-collection-link-text',
+		defaultMessage: 'Paste a modrinth.com collection URL or a collection ID.',
+	},
+})
+
+const emit = defineEmits<{
+	select: [collection: Labrinth.Collections.Collection, projects: Labrinth.Projects.v2.Project[]]
+}>()
+
+const modal = ref<InstanceType<typeof NewModal>>()
+const isOpen = ref(false)
+const loadingCollectionId = ref<string | null>(null)
+const otherCollectionInput = ref('')
+const loadingOtherCollection = ref(false)
+
+const userId = computed(() => auth.user.value?.id)
+
+const { data: collections, isPending } = useQuery({
+	queryKey: computed(() => ['user', userId.value, 'collections']),
+	queryFn: () => client.labrinth.users_v2.getCollections(userId.value!),
+	enabled: computed(() => !!userId.value && isOpen.value),
+})
+
+async function pickCollection(collection: Labrinth.Collections.Collection) {
+	loadingCollectionId.value = collection.id
+	try {
+		const fetched: Labrinth.Projects.v2.Project[] =
+			collection.projects.length > 0 ? await get_project_many(collection.projects) : []
+		const projects = (fetched ?? []).filter((project) => !!project)
+		for (const project of projects) {
+			project.categories = (project.categories ?? []).concat(project.loaders ?? [])
+		}
+		emit('select', collection, projects)
+		modal.value?.hide()
+	} catch (err) {
+		handleError(err as Error)
+	} finally {
+		loadingCollectionId.value = null
+	}
+}
+
+async function openOtherCollection() {
+	const id = parseCollectionId(otherCollectionInput.value)
+	if (!id) {
+		addNotification({
+			type: 'error',
+			title: formatMessage(messages.invalidCollectionLink),
+			text: formatMessage(messages.invalidCollectionLinkText),
+		})
+		return
+	}
+
+	loadingOtherCollection.value = true
+	try {
+		const collection = await client.labrinth.collections.get(id)
+		await pickCollection(collection)
+		otherCollectionInput.value = ''
+	} catch (err) {
+		handleError(err as Error)
+	} finally {
+		loadingOtherCollection.value = false
+	}
+}
+
+function show() {
+	isOpen.value = true
+	loadingCollectionId.value = null
+	otherCollectionInput.value = ''
+	loadingOtherCollection.value = false
+	modal.value?.show()
+}
+
+defineExpose({ show })
+</script>

--- a/apps/app-frontend/src/components/ui/CollectionPickerModal.vue
+++ b/apps/app-frontend/src/components/ui/CollectionPickerModal.vue
@@ -9,20 +9,18 @@
 		<div class="flex flex-col gap-3 p-6">
 			<div class="flex flex-wrap items-center gap-2">
 				<StyledInput
-					v-model="otherCollectionInput"
-					:icon="LinkIcon"
+					v-model="query"
+					:icon="SearchIcon"
 					type="text"
 					autocomplete="off"
 					:spellcheck="false"
-					:placeholder="formatMessage(messages.otherCollectionPlaceholder)"
+					clearable
+					:placeholder="formatMessage(messages.searchPlaceholder)"
 					wrapper-class="w-full flex-grow sm:w-auto"
-					@keydown.enter="openOtherCollection"
+					@keydown.enter="showOpen && openOtherCollection()"
 				/>
-				<ButtonStyled>
-					<button
-						:disabled="!otherCollectionInput.trim() || loadingOtherCollection"
-						@click="openOtherCollection"
-					>
+				<ButtonStyled v-if="showOpen">
+					<button :disabled="loadingOtherCollection" @click="openOtherCollection">
 						<SpinnerIcon v-if="loadingOtherCollection" class="animate-spin" aria-hidden="true" />
 						<ExternalIcon v-else aria-hidden="true" />
 						{{ formatMessage(messages.openButton) }}
@@ -45,14 +43,34 @@
 				<LoadingIndicator />
 			</div>
 			<div
-				v-else-if="!collections || collections.length === 0"
+				v-else-if="!showFollowing && filteredCollections.length === 0"
 				class="flex items-center justify-center py-6 text-secondary"
 			>
-				{{ formatMessage(messages.noCollections) }}
+				{{ formatMessage(query.trim() ? messages.noMatches : messages.noCollections) }}
 			</div>
 			<div v-else class="flex max-h-[400px] flex-col gap-0.5 overflow-y-auto">
 				<button
-					v-for="collection in collections"
+					v-if="showFollowing"
+					class="flex cursor-pointer items-center gap-2.5 rounded-xl border-0 bg-transparent px-2 py-2 text-left hover:bg-surface-3"
+					:disabled="loadingCollectionId !== null"
+					@click="pickFollowing"
+				>
+					<Avatar src="https://cdn.modrinth.com/follow-collection.png" size="2.5rem" />
+					<div class="flex min-w-0 flex-1 flex-col">
+						<span class="truncate font-semibold text-contrast">{{ followingLabel }}</span>
+						<span class="text-sm text-secondary">
+							{{ formatMessage(messages.followingHint) }}
+						</span>
+					</div>
+					<SpinnerIcon
+						v-if="loadingCollectionId === 'following'"
+						class="size-5 animate-spin text-secondary"
+						aria-hidden="true"
+					/>
+					<HeartIcon v-else class="size-5 text-secondary" aria-hidden="true" />
+				</button>
+				<button
+					v-for="collection in filteredCollections"
 					:key="collection.id"
 					class="flex cursor-pointer items-center gap-2.5 rounded-xl border-0 bg-transparent px-2 py-2 text-left hover:bg-surface-3"
 					:disabled="loadingCollectionId !== null"
@@ -79,10 +97,18 @@
 
 <script setup lang="ts">
 import type { Labrinth } from '@modrinth/api-client'
-import { ChevronRightIcon, ExternalIcon, LinkIcon, LogInIcon, SpinnerIcon } from '@modrinth/assets'
+import {
+	ChevronRightIcon,
+	ExternalIcon,
+	HeartIcon,
+	LogInIcon,
+	SearchIcon,
+	SpinnerIcon,
+} from '@modrinth/assets'
 import {
 	Avatar,
 	ButtonStyled,
+	commonMessages,
 	defineMessages,
 	injectAuth,
 	injectModrinthClient,
@@ -97,7 +123,7 @@ import { computed, ref } from 'vue'
 import { useRoute } from 'vue-router'
 
 import { get_project_many } from '@/helpers/cache.js'
-import { parseCollectionId } from '@/helpers/collections'
+import { isCollectionLink, parseCollectionId } from '@/helpers/collections'
 
 const { formatMessage } = useVIntl()
 const { handleError, addNotification } = injectNotificationManager()
@@ -126,9 +152,17 @@ const messages = defineMessages({
 		id: 'app.collection-picker.projects-count',
 		defaultMessage: '{count, plural, =0 {No projects} one {# project} other {# projects}}',
 	},
-	otherCollectionPlaceholder: {
-		id: 'app.collection-picker.other-collection-placeholder',
-		defaultMessage: 'Paste a collection link or ID...',
+	searchPlaceholder: {
+		id: 'app.collection-picker.search-placeholder',
+		defaultMessage: 'Search your collections, or paste a link...',
+	},
+	noMatches: {
+		id: 'app.collection-picker.no-matches',
+		defaultMessage: 'No collections match your search',
+	},
+	followingHint: {
+		id: 'app.collection-picker.following-hint',
+		defaultMessage: 'Projects you follow',
 	},
 	openButton: {
 		id: 'app.collection-picker.open-button',
@@ -151,8 +185,9 @@ const emit = defineEmits<{
 const modal = ref<InstanceType<typeof NewModal>>()
 const isOpen = ref(false)
 const loadingCollectionId = ref<string | null>(null)
-const otherCollectionInput = ref('')
+const query = ref('')
 const loadingOtherCollection = ref(false)
+const showOpen = computed(() => isCollectionLink(query.value))
 
 const userId = computed(() => auth.user.value?.id)
 
@@ -160,6 +195,18 @@ const { data: collections, isPending } = useQuery({
 	queryKey: computed(() => ['user', userId.value, 'collections']),
 	queryFn: () => client.labrinth.users_v2.getCollections(userId.value!),
 	enabled: computed(() => !!userId.value && isOpen.value),
+})
+
+const filteredCollections = computed(() => {
+	const q = query.value.trim().toLowerCase()
+	if (!q) return collections.value ?? []
+	return (collections.value ?? []).filter((c) => c.name.toLowerCase().includes(q))
+})
+
+const followingLabel = computed(() => formatMessage(commonMessages.followedProjectsLabel))
+const showFollowing = computed(() => {
+	const q = query.value.trim().toLowerCase()
+	return !!userId.value && (!q || followingLabel.value.toLowerCase().includes(q))
 })
 
 async function pickCollection(collection: Labrinth.Collections.Collection) {
@@ -180,8 +227,29 @@ async function pickCollection(collection: Labrinth.Collections.Collection) {
 	}
 }
 
+async function pickFollowing() {
+	loadingCollectionId.value = 'following'
+	try {
+		const fetched = await client.labrinth.users_v2.getFollowedProjects(userId.value!)
+		const projects = (fetched ?? []).filter((project) => !!project)
+		for (const project of projects) {
+			project.categories = (project.categories ?? []).concat(project.loaders ?? [])
+		}
+		emit(
+			'select',
+			{ id: 'following', name: followingLabel.value } as Labrinth.Collections.Collection,
+			projects,
+		)
+		modal.value?.hide()
+	} catch (err) {
+		handleError(err as Error)
+	} finally {
+		loadingCollectionId.value = null
+	}
+}
+
 async function openOtherCollection() {
-	const id = parseCollectionId(otherCollectionInput.value)
+	const id = parseCollectionId(query.value)
 	if (!id) {
 		addNotification({
 			type: 'error',
@@ -195,7 +263,7 @@ async function openOtherCollection() {
 	try {
 		const collection = await client.labrinth.collections.get(id)
 		await pickCollection(collection)
-		otherCollectionInput.value = ''
+		query.value = ''
 	} catch (err) {
 		handleError(err as Error)
 	} finally {
@@ -206,7 +274,7 @@ async function openOtherCollection() {
 function show() {
 	isOpen.value = true
 	loadingCollectionId.value = null
-	otherCollectionInput.value = ''
+	query.value = ''
 	loadingOtherCollection.value = false
 	modal.value?.show()
 }

--- a/apps/app-frontend/src/helpers/collections.ts
+++ b/apps/app-frontend/src/helpers/collections.ts
@@ -1,0 +1,15 @@
+/**
+ * Extracts a collection ID from user input, accepting either a raw collection ID
+ * or a Modrinth collection URL (e.g. https://modrinth.com/collection/AbCdEf12).
+ */
+export function parseCollectionId(input: string): string | null {
+	const trimmed = input.trim()
+	if (!trimmed) return null
+
+	const urlMatch = trimmed.match(/collection\/([a-zA-Z0-9]+)/)
+	if (urlMatch) return urlMatch[1]
+
+	if (/^[a-zA-Z0-9]+$/.test(trimmed)) return trimmed
+
+	return null
+}

--- a/apps/app-frontend/src/helpers/collections.ts
+++ b/apps/app-frontend/src/helpers/collections.ts
@@ -13,3 +13,10 @@ export function parseCollectionId(input: string): string | null {
 
 	return null
 }
+
+/**
+ * Determines when url is pasted
+ */
+export function isCollectionLink(input: string): boolean {
+	return /collection\/[a-zA-Z0-9]+/.test(input.trim())
+}

--- a/apps/app-frontend/src/locales/en-US/index.json
+++ b/apps/app-frontend/src/locales/en-US/index.json
@@ -191,6 +191,162 @@
   "app.browse.server.installing": {
     "message": "Installing"
   },
+  "app.collection-install.already-installed": {
+    "message": "Installed"
+  },
+  "app.collection-install.deselect-all": {
+    "message": "Deselect all"
+  },
+  "app.collection-install.existing-tab": {
+    "message": "Existing instance"
+  },
+  "app.collection-install.failed": {
+    "message": "Failed to install collection"
+  },
+  "app.collection-install.game-version-placeholder": {
+    "message": "Select game version"
+  },
+  "app.collection-install.header": {
+    "message": "Install collection"
+  },
+  "app.collection-install.header-named": {
+    "message": "Install {name}"
+  },
+  "app.collection-install.incompatible": {
+    "message": "Incompatible"
+  },
+  "app.collection-install.incompatible-tooltip": {
+    "message": "This project has no version compatible with the selected loader and game version."
+  },
+  "app.collection-install.install-button": {
+    "message": "Install {count, plural, one {# project} other {# projects}}"
+  },
+  "app.collection-install.installing-progress": {
+    "message": "Installing {current, number} of {total, number}..."
+  },
+  "app.collection-install.instance-type": {
+    "message": "Instance type"
+  },
+  "app.collection-install.loader-label": {
+    "message": "Loader"
+  },
+  "app.collection-install.name-label": {
+    "message": "Name"
+  },
+  "app.collection-install.name-placeholder": {
+    "message": "Enter instance name"
+  },
+  "app.collection-install.new-tab": {
+    "message": "New instance"
+  },
+  "app.collection-install.no-instances": {
+    "message": "No instances found. Create a new instance instead."
+  },
+  "app.collection-install.partial-text": {
+    "message": "{count, plural, one {# project} other {# projects}} added to {instance}, {failed} failed."
+  },
+  "app.collection-install.projects-label": {
+    "message": "{selected} of {total} projects selected"
+  },
+  "app.collection-install.select-all": {
+    "message": "Select all"
+  },
+  "app.collection-install.select-instance": {
+    "message": "Instance"
+  },
+  "app.collection-install.select-instance-placeholder": {
+    "message": "Select an instance"
+  },
+  "app.collection-install.success": {
+    "message": "Collection installed"
+  },
+  "app.collection-install.success-text": {
+    "message": "{count, plural, one {# project} other {# projects}} added to {instance}. Missing dependencies were installed automatically."
+  },
+  "app.collection-install.unsupported": {
+    "message": "Not supported"
+  },
+  "app.collection-picker.empty": {
+    "message": "You don't have any collections yet"
+  },
+  "app.collection-picker.header": {
+    "message": "Add from collection"
+  },
+  "app.collection-picker.invalid-collection-link": {
+    "message": "Invalid collection link"
+  },
+  "app.collection-picker.invalid-collection-link-text": {
+    "message": "Paste a modrinth.com collection URL or a collection ID."
+  },
+  "app.collection-picker.open-button": {
+    "message": "Open"
+  },
+  "app.collection-picker.other-collection-placeholder": {
+    "message": "Paste a collection link or ID..."
+  },
+  "app.collection-picker.projects-count": {
+    "message": "{count, plural, =0 {No projects} one {# project} other {# projects}}"
+  },
+  "app.collection-picker.sign-in-button": {
+    "message": "Sign in"
+  },
+  "app.collection-picker.sign-in-prompt": {
+    "message": "Sign in to view your collections"
+  },
+  "app.collection.button.clear-filters": {
+    "message": "Clear filters"
+  },
+  "app.collection.button.install-all": {
+    "message": "Install all ({count})"
+  },
+  "app.collection.button.install-filtered": {
+    "message": "Install filtered ({count})"
+  },
+  "app.collection.label.curated-by": {
+    "message": "Curated by"
+  },
+  "app.collection.label.no-projects": {
+    "message": "No projects in collection yet"
+  },
+  "app.collection.label.no-results": {
+    "message": "No projects match your search"
+  },
+  "app.collection.label.not-found": {
+    "message": "Collection not found"
+  },
+  "app.collection.label.projects-count": {
+    "message": "{count, plural, =0 {No projects} one {# project} other {# projects}}"
+  },
+  "app.collection.search.placeholder": {
+    "message": "Search collection..."
+  },
+  "app.collections.empty": {
+    "message": "You don't have any collections yet"
+  },
+  "app.collections.empty-hint": {
+    "message": "Create collections on modrinth.com and view them here"
+  },
+  "app.collections.invalid-collection-link": {
+    "message": "Invalid collection link"
+  },
+  "app.collections.invalid-collection-link-text": {
+    "message": "Paste a modrinth.com collection URL or a collection ID."
+  },
+  "app.collections.open-collection-button": {
+    "message": "Open"
+  },
+  "app.collections.open-collection-placeholder": {
+    "message": "Paste a collection link or ID to open any collection..."
+  },
+  "app.collections.projects-count": {
+    "message": "{count, plural, =0 {No projects} one {# project} other {# projects}}"
+  },
+  "app.collections.sign-in-button": {
+    "message": "Sign in"
+  },
+  "app.collections.sign-in-prompt": {
+    "message": "Sign in to view your collections"
+  },
   "app.content-install.no-compatible-versions": {
     "message": "No available versions match {compatibilityLabel}. Select a version to install anyway. Dependencies will not be installed automatically."
   },
@@ -1033,6 +1189,15 @@
   },
   "search.filter.locked.server-loader.title": {
     "message": "Loader is provided by the server"
+  },
+  "search.filter_type.game_version": {
+    "message": "Game version"
+  },
+  "search.filter_type.game_version.all_versions": {
+    "message": "Show all versions"
+  },
+  "search.filter_type.mod_loader": {
+    "message": "Loader"
   },
   "unknown-pack-warning-modal.body": {
     "message": "A file is only reviewed if it’s uploaded to Modrinth, regardless of its file format (including .mrpack)."

--- a/apps/app-frontend/src/pages/Collection.vue
+++ b/apps/app-frontend/src/pages/Collection.vue
@@ -208,6 +208,7 @@ import {
 	formatCategoryHeader,
 	formatLoader,
 	HorizontalRule,
+	injectAuth,
 	injectModrinthClient,
 	injectNotificationManager,
 	ProjectCard,
@@ -231,6 +232,7 @@ import { useBreadcrumbs } from '@/store/breadcrumbs.js'
 const { formatMessage } = useVIntl()
 const { handleError } = injectNotificationManager()
 const client = injectModrinthClient()
+const auth = injectAuth()
 const route = useRoute()
 const breadcrumbs = useBreadcrumbs()
 const { install } = injectContentInstall()
@@ -272,6 +274,10 @@ const messages = defineMessages({
 		id: 'app.collection.label.not-found',
 		defaultMessage: 'Collection not found',
 	},
+	followingDescription: {
+		id: 'app.collection.following-description',
+		defaultMessage: "Auto-generated collection of all the projects you're following.",
+	},
 	gameVersionFilterLabel: {
 		id: 'search.filter_type.game_version',
 		defaultMessage: 'Game version',
@@ -287,16 +293,33 @@ const messages = defineMessages({
 })
 
 const collectionId = computed(() => route.params.id)
+const isFollowing = computed(() => collectionId.value === 'following')
+
+const followingCollection = computed(() =>
+	isFollowing.value
+		? {
+				id: 'following',
+				user: auth.user.value?.id,
+				name: formatMessage(commonMessages.followedProjectsLabel),
+				description: formatMessage(messages.followingDescription),
+				icon_url: 'https://cdn.modrinth.com/follow-collection.png',
+				status: 'private',
+				projects: [],
+			}
+		: null,
+)
 
 const {
-	data: collection,
+	data: fetchedCollection,
 	isPending: collectionIsPending,
 	error: collectionError,
 } = useQuery({
 	queryKey: computed(() => ['collection', collectionId.value]),
 	queryFn: () => client.labrinth.collections.get(collectionId.value),
-	enabled: computed(() => !!collectionId.value),
+	enabled: computed(() => !!collectionId.value && !isFollowing.value),
 })
+
+const collection = computed(() => followingCollection.value ?? fetchedCollection.value)
 
 watch(collectionError, (error) => {
 	if (error) handleError(error)
@@ -305,20 +328,28 @@ watch(collectionError, (error) => {
 const { data: creator } = useQuery({
 	queryKey: computed(() => ['user', collection.value?.user]),
 	queryFn: () => get_user(collection.value.user),
-	enabled: computed(() => !!collection.value?.user),
+	enabled: computed(() => !isFollowing.value && !!collection.value?.user),
 })
 
 const { data: projects, isFetching: projectsIsFetching } = useQuery({
-	queryKey: computed(() => ['collection-projects', collection.value?.projects]),
+	queryKey: computed(() =>
+		isFollowing.value
+			? ['followed-projects', auth.user.value?.id]
+			: ['collection-projects', collection.value?.projects],
+	),
 	queryFn: async () => {
-		const fetched = await get_project_many(collection.value.projects)
+		const fetched = isFollowing.value
+			? await client.labrinth.users_v2.getFollowedProjects(auth.user.value.id)
+			: await get_project_many(collection.value.projects)
 		const result = (fetched ?? []).filter((project) => !!project)
 		for (const project of result) {
 			project.categories = (project.categories ?? []).concat(project.loaders ?? [])
 		}
 		return result
 	},
-	enabled: computed(() => !!collection.value?.projects?.length),
+	enabled: computed(() =>
+		isFollowing.value ? !!auth.user.value?.id : !!collection.value?.projects?.length,
+	),
 	placeholderData: [],
 })
 
@@ -334,7 +365,9 @@ const { data: tags } = useQuery({
 	},
 })
 
-const isLoading = computed(() => collectionIsPending.value || projectsIsFetching.value)
+const isLoading = computed(
+	() => (!isFollowing.value && collectionIsPending.value) || projectsIsFetching.value,
+)
 
 watch(
 	collection,

--- a/apps/app-frontend/src/pages/Collection.vue
+++ b/apps/app-frontend/src/pages/Collection.vue
@@ -1,0 +1,534 @@
+<template>
+	<div v-if="isLoading" class="flex min-h-[50vh] items-center justify-center">
+		<SpinnerIcon class="h-12 w-12 animate-spin text-brand" />
+	</div>
+	<div v-else-if="collection" class="flex flex-col gap-4 p-6">
+		<CollectionInstallModal ref="installModal" />
+		<div class="grid grid-cols-[auto_1fr] gap-4 sm:grid-cols-[auto_1fr_auto]">
+			<Avatar :src="collection.icon_url" size="64px" />
+			<div class="flex flex-col gap-2">
+				<h1 class="m-0 text-2xl font-extrabold text-contrast">
+					{{ collection.name }}
+				</h1>
+				<div class="flex flex-wrap items-center gap-2 text-secondary">
+					<div v-if="collection.status !== 'listed'" class="flex items-center gap-1">
+						<LinkIcon v-if="collection.status === 'unlisted'" aria-hidden="true" />
+						<LockIcon v-else aria-hidden="true" />
+						{{
+							collection.status === 'unlisted'
+								? formatMessage(commonMessages.unlistedLabel)
+								: formatMessage(commonMessages.privateLabel)
+						}}
+						<span class="ml-1">•</span>
+					</div>
+					<span>
+						{{ formatMessage(messages.projectsCount, { count: projects?.length ?? 0 }) }}
+					</span>
+					<template v-if="creator">
+						<span>•</span>
+						<span class="flex items-center gap-1.5">
+							{{ formatMessage(messages.curatedByLabel) }}
+							<Avatar :src="creator.avatar_url" :alt="creator.username" size="20px" circle />
+							{{ creator.username }}
+						</span>
+					</template>
+				</div>
+				<p v-if="collection.description" class="m-0 break-words text-secondary">
+					{{ collection.description }}
+				</p>
+			</div>
+			<div class="col-span-2 flex items-start sm:col-span-1">
+				<ButtonStyled color="brand" size="large">
+					<button :disabled="displayProjects.length === 0" @click="openInstallModal">
+						<DownloadIcon aria-hidden="true" />
+						{{
+							hasActiveFilters
+								? formatMessage(messages.installFilteredButton, {
+										count: displayProjects.length,
+									})
+								: formatMessage(messages.installAllButton, { count: displayProjects.length })
+						}}
+					</button>
+				</ButtonStyled>
+			</div>
+		</div>
+		<HorizontalRule />
+
+		<template v-if="projects && projects.length > 0">
+			<div class="flex flex-col gap-3">
+				<div class="flex flex-wrap items-center gap-2">
+					<StyledInput
+						v-model="searchQuery"
+						:icon="SearchIcon"
+						type="text"
+						autocomplete="off"
+						:placeholder="formatMessage(messages.searchPlaceholder)"
+						clearable
+						wrapper-class="w-full flex-grow sm:w-auto"
+					/>
+					<Combobox
+						v-model="currentSort"
+						:options="sortOptions"
+						class="!w-[14rem] min-w-max max-w-full flex-grow sm:flex-grow-0"
+					>
+						<template #prefix>
+							<span class="font-semibold text-primary">
+								{{ formatMessage(commonMessages.sortByLabel) }}
+							</span>
+						</template>
+					</Combobox>
+					<ButtonStyled v-if="collectionFilterTypes.length > 0">
+						<button @click="filtersOpen = !filtersOpen">
+							<FilterIcon aria-hidden="true" />
+							{{ formatMessage(commonMessages.filtersLabel) }}
+							<span
+								v-if="selectedFilters.length > 0"
+								class="flex h-5 min-w-5 items-center justify-center rounded-full bg-brand px-1 text-xs font-bold text-brand-inverted"
+							>
+								{{ selectedFilters.length }}
+							</span>
+							<DropdownIcon
+								aria-hidden="true"
+								class="h-4 w-4 transition-transform"
+								:class="{ 'rotate-180': filtersOpen }"
+							/>
+						</button>
+					</ButtonStyled>
+				</div>
+				<div
+					v-if="filtersOpen && collectionFilterTypes.length > 0"
+					class="grid grid-cols-1 items-start gap-3 sm:grid-cols-2 lg:grid-cols-3"
+				>
+					<SearchSidebarFilter
+						v-for="filterType in collectionFilterTypes"
+						:key="filterType.id"
+						v-model:selected-filters="selectedFilters"
+						v-model:toggled-groups="toggledGroups"
+						:filter-type="filterType"
+						:provided-filters="[]"
+						:open-by-default="false"
+						class="card-shadow rounded-2xl border border-solid bg-surface-3 border-surface-4"
+						button-class="button-animation flex flex-col gap-1 px-4 py-3 w-full bg-transparent cursor-pointer border-none"
+						content-class="mb-4 mx-3"
+						inner-panel-class="p-1"
+					>
+						<template #header>
+							<h3 class="m-0 text-base font-semibold text-contrast">
+								{{ filterType.formatted_name }}
+							</h3>
+						</template>
+					</SearchSidebarFilter>
+				</div>
+				<SearchFilterControl
+					v-model:selected-filters="selectedFilters"
+					:filters="collectionFilterTypes"
+					:provided-filters="[]"
+					:overridden-provided-filter-types="[]"
+				/>
+			</div>
+			<ProjectCardList v-if="displayProjects.length > 0" layout="list">
+				<ProjectCard
+					v-for="project in displayProjects"
+					:key="project.id"
+					:link="`/project/${project.slug ?? project.id}`"
+					:title="project.title"
+					:icon-url="project.icon_url"
+					:banner="project.gallery?.find((element) => element.featured)?.url"
+					:summary="project.description"
+					:date-updated="project.updated"
+					:downloads="project.downloads ?? 0"
+					:followers="project.followers ?? 0"
+					:tags="project.categories"
+					:environment="{
+						clientSide: project.client_side,
+						serverSide: project.server_side,
+					}"
+					:color="project.color"
+					layout="list"
+				>
+					<template #actions>
+						<ButtonStyled color="brand">
+							<button
+								:disabled="installingProjectIds.has(project.id)"
+								@click.stop.prevent="installProject(project)"
+							>
+								<DownloadIcon aria-hidden="true" />
+								{{
+									installingProjectIds.has(project.id)
+										? formatMessage(commonMessages.installingLabel)
+										: formatMessage(commonMessages.installButton)
+								}}
+							</button>
+						</ButtonStyled>
+					</template>
+				</ProjectCard>
+			</ProjectCardList>
+			<EmptyState v-else type="no-search-result">
+				<template #heading>{{ formatMessage(messages.noResultsLabel) }}</template>
+				<template #actions>
+					<ButtonStyled v-if="searchQuery || selectedFilters.length > 0">
+						<button @click="clearSearchAndFilters">
+							<XIcon aria-hidden="true" />
+							{{ formatMessage(messages.clearFiltersButton) }}
+						</button>
+					</ButtonStyled>
+				</template>
+			</EmptyState>
+		</template>
+		<EmptyState v-else type="empty-inbox">
+			<template #heading>{{ formatMessage(messages.noProjectsLabel) }}</template>
+		</EmptyState>
+	</div>
+	<EmptyState v-else type="empty-inbox">
+		<template #heading>{{ formatMessage(messages.notFoundLabel) }}</template>
+	</EmptyState>
+</template>
+
+<script setup>
+import {
+	DownloadIcon,
+	DropdownIcon,
+	FilterIcon,
+	getCategoryIcon,
+	getLoaderIcon,
+	LinkIcon,
+	LockIcon,
+	SearchIcon,
+	SpinnerIcon,
+	XIcon,
+} from '@modrinth/assets'
+import {
+	Avatar,
+	ButtonStyled,
+	Combobox,
+	commonMessages,
+	defineMessages,
+	EmptyState,
+	formatCategory,
+	formatCategoryHeader,
+	formatLoader,
+	HorizontalRule,
+	injectModrinthClient,
+	injectNotificationManager,
+	ProjectCard,
+	ProjectCardList,
+	SearchFilterControl,
+	SearchSidebarFilter,
+	StyledInput,
+	useVIntl,
+} from '@modrinth/ui'
+import { useQuery } from '@tanstack/vue-query'
+import dayjs from 'dayjs'
+import { computed, ref, watch } from 'vue'
+import { useRoute } from 'vue-router'
+
+import CollectionInstallModal from '@/components/ui/CollectionInstallModal.vue'
+import { get_project_many, get_user } from '@/helpers/cache.js'
+import { get_categories, get_game_versions, get_loaders } from '@/helpers/tags.js'
+import { injectContentInstall } from '@/providers/content-install'
+import { useBreadcrumbs } from '@/store/breadcrumbs.js'
+
+const { formatMessage } = useVIntl()
+const { handleError } = injectNotificationManager()
+const client = injectModrinthClient()
+const route = useRoute()
+const breadcrumbs = useBreadcrumbs()
+const { install } = injectContentInstall()
+
+const messages = defineMessages({
+	curatedByLabel: {
+		id: 'app.collection.label.curated-by',
+		defaultMessage: 'Curated by',
+	},
+	projectsCount: {
+		id: 'app.collection.label.projects-count',
+		defaultMessage: '{count, plural, =0 {No projects} one {# project} other {# projects}}',
+	},
+	installAllButton: {
+		id: 'app.collection.button.install-all',
+		defaultMessage: 'Install all ({count})',
+	},
+	installFilteredButton: {
+		id: 'app.collection.button.install-filtered',
+		defaultMessage: 'Install filtered ({count})',
+	},
+	searchPlaceholder: {
+		id: 'app.collection.search.placeholder',
+		defaultMessage: 'Search collection...',
+	},
+	noProjectsLabel: {
+		id: 'app.collection.label.no-projects',
+		defaultMessage: 'No projects in collection yet',
+	},
+	noResultsLabel: {
+		id: 'app.collection.label.no-results',
+		defaultMessage: 'No projects match your search',
+	},
+	clearFiltersButton: {
+		id: 'app.collection.button.clear-filters',
+		defaultMessage: 'Clear filters',
+	},
+	notFoundLabel: {
+		id: 'app.collection.label.not-found',
+		defaultMessage: 'Collection not found',
+	},
+	gameVersionFilterLabel: {
+		id: 'search.filter_type.game_version',
+		defaultMessage: 'Game version',
+	},
+	loaderFilterLabel: {
+		id: 'search.filter_type.mod_loader',
+		defaultMessage: 'Loader',
+	},
+	showAllVersionsLabel: {
+		id: 'search.filter_type.game_version.all_versions',
+		defaultMessage: 'Show all versions',
+	},
+})
+
+const collectionId = computed(() => route.params.id)
+
+const {
+	data: collection,
+	isPending: collectionIsPending,
+	error: collectionError,
+} = useQuery({
+	queryKey: computed(() => ['collection', collectionId.value]),
+	queryFn: () => client.labrinth.collections.get(collectionId.value),
+	enabled: computed(() => !!collectionId.value),
+})
+
+watch(collectionError, (error) => {
+	if (error) handleError(error)
+})
+
+const { data: creator } = useQuery({
+	queryKey: computed(() => ['user', collection.value?.user]),
+	queryFn: () => get_user(collection.value.user),
+	enabled: computed(() => !!collection.value?.user),
+})
+
+const { data: projects, isFetching: projectsIsFetching } = useQuery({
+	queryKey: computed(() => ['collection-projects', collection.value?.projects]),
+	queryFn: async () => {
+		const fetched = await get_project_many(collection.value.projects)
+		const result = (fetched ?? []).filter((project) => !!project)
+		for (const project of result) {
+			project.categories = (project.categories ?? []).concat(project.loaders ?? [])
+		}
+		return result
+	},
+	enabled: computed(() => !!collection.value?.projects?.length),
+	placeholderData: [],
+})
+
+const { data: tags } = useQuery({
+	queryKey: ['collection-tags'],
+	queryFn: async () => {
+		const [gameVersions, loaders, categories] = await Promise.all([
+			get_game_versions(),
+			get_loaders(),
+			get_categories(),
+		])
+		return { gameVersions, loaders, categories }
+	},
+})
+
+const isLoading = computed(() => collectionIsPending.value || projectsIsFetching.value)
+
+watch(
+	collection,
+	(newCollection) => {
+		if (newCollection) {
+			breadcrumbs.setName('Collection', newCollection.name)
+		}
+	},
+	{ immediate: true },
+)
+
+const searchQuery = ref('')
+const filtersOpen = ref(false)
+const selectedFilters = ref([])
+const toggledGroups = ref([])
+
+const sortOptions = [
+	{ value: 'downloads', label: 'Downloads' },
+	{ value: 'follows', label: 'Followers' },
+	{ value: 'updated', label: 'Date updated' },
+	{ value: 'newest', label: 'Date published' },
+	{ value: 'name', label: 'Name' },
+]
+const currentSort = ref('downloads')
+
+const collectionFilterTypes = computed(() => {
+	if (!tags.value) return []
+
+	const gameVersions = new Set()
+	const loaders = new Set()
+	const categories = new Set()
+	for (const project of projects.value ?? []) {
+		project.game_versions?.forEach((version) => gameVersions.add(version))
+		project.loaders?.forEach((loader) => loaders.add(loader))
+		project.categories?.forEach((category) => categories.add(category))
+	}
+	for (const loader of loaders) {
+		categories.delete(loader)
+	}
+
+	const filterTypes = []
+
+	const gameVersionOptions = tags.value.gameVersions
+		.filter((gameVersion) => gameVersions.has(gameVersion.version))
+		.map((gameVersion) => ({
+			id: gameVersion.version,
+			toggle_group: gameVersion.version_type !== 'release' ? 'all_versions' : undefined,
+			method: 'or',
+			value: gameVersion.version,
+		}))
+	if (gameVersionOptions.length > 0) {
+		filterTypes.push({
+			id: 'game_version',
+			formatted_name: formatMessage(messages.gameVersionFilterLabel),
+			supported_project_types: [],
+			display: 'scrollable',
+			query_param: 'v',
+			supports_negative_filter: false,
+			searchable: true,
+			toggle_groups: gameVersionOptions.some((option) => option.toggle_group)
+				? [{ id: 'all_versions', formatted_name: formatMessage(messages.showAllVersionsLabel) }]
+				: [],
+			options: gameVersionOptions,
+		})
+	}
+
+	const loaderOptions = tags.value.loaders
+		.filter((loader) => loaders.has(loader.name))
+		.map((loader) => ({
+			id: loader.name,
+			formatted_name: formatLoader(formatMessage, loader.name),
+			icon: getLoaderIcon(loader.name),
+			method: 'or',
+			value: loader.name,
+		}))
+	if (loaderOptions.length > 0) {
+		filterTypes.push({
+			id: 'mod_loader',
+			formatted_name: formatMessage(messages.loaderFilterLabel),
+			supported_project_types: [],
+			display: 'scrollable',
+			query_param: 'g',
+			supports_negative_filter: true,
+			searchable: false,
+			options: loaderOptions,
+		})
+	}
+
+	const seenCategories = new Set()
+	const categoryOptions = []
+	for (const category of tags.value.categories) {
+		if (!categories.has(category.name) || seenCategories.has(category.name)) continue
+		seenCategories.add(category.name)
+		categoryOptions.push({
+			id: category.name,
+			formatted_name: formatCategory(formatMessage, category.name),
+			icon: getCategoryIcon(category.name),
+			method: 'or',
+			value: category.name,
+		})
+	}
+	if (categoryOptions.length > 0) {
+		filterTypes.push({
+			id: 'category',
+			formatted_name: formatCategoryHeader(formatMessage, 'categories'),
+			supported_project_types: [],
+			display: 'scrollable',
+			query_param: 'f',
+			supports_negative_filter: true,
+			searchable: false,
+			options: categoryOptions,
+		})
+	}
+
+	return filterTypes
+})
+
+function projectMatchesFilters(project) {
+	for (const filterType of collectionFilterTypes.value) {
+		const selected = selectedFilters.value.filter((filter) => filter.type === filterType.id)
+		if (selected.length === 0) continue
+		const values =
+			filterType.id === 'game_version'
+				? (project.game_versions ?? [])
+				: filterType.id === 'mod_loader'
+					? (project.loaders ?? [])
+					: (project.categories ?? [])
+		if (selected.some((filter) => filter.negative && values.includes(filter.option))) {
+			return false
+		}
+		const included = selected.filter((filter) => !filter.negative)
+		if (included.length > 0 && !included.some((filter) => values.includes(filter.option))) {
+			return false
+		}
+	}
+	return true
+}
+
+const hasActiveFilters = computed(
+	() => searchQuery.value.trim().length > 0 || selectedFilters.value.length > 0,
+)
+
+const displayProjects = computed(() => {
+	const query = searchQuery.value.trim().toLowerCase()
+	const filtered = (projects.value ?? []).filter(
+		(project) =>
+			(!query ||
+				project.title?.toLowerCase().includes(query) ||
+				project.description?.toLowerCase().includes(query)) &&
+			projectMatchesFilters(project),
+	)
+	return filtered.sort((a, b) => {
+		switch (currentSort.value) {
+			case 'follows':
+				return (b.followers ?? 0) - (a.followers ?? 0)
+			case 'updated':
+				return dayjs(b.updated).diff(dayjs(a.updated))
+			case 'newest':
+				return dayjs(b.published).diff(dayjs(a.published))
+			case 'name':
+				return a.title.localeCompare(b.title)
+			default:
+				return (b.downloads ?? 0) - (a.downloads ?? 0)
+		}
+	})
+})
+
+function clearSearchAndFilters() {
+	searchQuery.value = ''
+	selectedFilters.value = []
+}
+
+const installModal = ref(null)
+
+function openInstallModal() {
+	installModal.value?.show(displayProjects.value, {
+		collectionName: collection.value?.name,
+	})
+}
+
+const installingProjectIds = ref(new Set())
+
+async function installProject(project) {
+	const next = new Set(installingProjectIds.value)
+	next.add(project.id)
+	installingProjectIds.value = next
+	try {
+		await install(project.id, undefined, undefined, 'CollectionPage')
+	} catch (err) {
+		handleError(err)
+	} finally {
+		const after = new Set(installingProjectIds.value)
+		after.delete(project.id)
+		installingProjectIds.value = after
+	}
+}
+</script>

--- a/apps/app-frontend/src/pages/index.js
+++ b/apps/app-frontend/src/pages/index.js
@@ -1,7 +1,8 @@
 import Browse from './Browse.vue'
+import Collection from './Collection.vue'
 import Index from './Index.vue'
 import Servers from './Servers.vue'
 import Skins from './Skins.vue'
 import Worlds from './Worlds.vue'
 
-export { Browse, Index, Servers, Skins, Worlds }
+export { Browse, Collection, Index, Servers, Skins, Worlds }

--- a/apps/app-frontend/src/pages/instance/Mods.vue
+++ b/apps/app-frontend/src/pages/instance/Mods.vue
@@ -32,6 +32,16 @@
 					@cancel="handleModpackUpdateCancel"
 				/>
 				<ExportModal v-if="projects.length > 0" ref="exportModal" :instance="instance" />
+				<CollectionPickerModal
+					v-if="!props.isServerInstance"
+					ref="collectionPickerModal"
+					@select="handleCollectionSelected"
+				/>
+				<CollectionInstallModal
+					v-if="!props.isServerInstance"
+					ref="collectionInstallModal"
+					@installed="() => refreshContentState('must_revalidate')"
+				/>
 				<ContentUpdaterModal
 					v-if="updatingProject || updatingModpack"
 					ref="contentUpdaterModal"
@@ -99,6 +109,8 @@ import { openUrl } from '@tauri-apps/plugin-opener'
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 
+import CollectionInstallModal from '@/components/ui/CollectionInstallModal.vue'
+import CollectionPickerModal from '@/components/ui/CollectionPickerModal.vue'
 import ExportModal from '@/components/ui/ExportModal.vue'
 import ShareModalWrapper from '@/components/ui/modal/ShareModalWrapper.vue'
 import { trackEvent } from '@/helpers/analytics'
@@ -281,6 +293,22 @@ const isPackLocked = computed(
 
 const shareModal = ref<InstanceType<typeof ShareModalWrapper> | null>()
 const exportModal = ref(null)
+const collectionPickerModal = ref<InstanceType<typeof CollectionPickerModal> | null>()
+const collectionInstallModal = ref<InstanceType<typeof CollectionInstallModal> | null>()
+
+function handleAddFromCollection() {
+	collectionPickerModal.value?.show()
+}
+
+function handleCollectionSelected(
+	collection: Labrinth.Collections.Collection,
+	collectionProjects: Labrinth.Projects.v2.Project[],
+) {
+	collectionInstallModal.value?.show(collectionProjects, {
+		instance: props.instance,
+		collectionName: collection.name,
+	})
+}
 const contentUpdaterModal = ref<InstanceType<typeof ContentUpdaterModal> | null>()
 const modpackContentModal = ref<InstanceType<typeof ModpackContentModal> | null>()
 const modpackUpdateConfirmModal = ref<InstanceType<typeof ConfirmModpackUpdateModal> | null>()
@@ -1329,6 +1357,7 @@ provideContentManager({
 	refresh: () => initProjects('must_revalidate'),
 	browse: handleBrowseContent,
 	uploadFiles: handleUploadFiles,
+	addFromCollection: props.isServerInstance ? undefined : handleAddFromCollection,
 	hasUpdateSupport: true,
 	updateItem: handleUpdate,
 	bulkUpdateAll: bulkUpdateAllProjects,

--- a/apps/app-frontend/src/pages/library/Collections.vue
+++ b/apps/app-frontend/src/pages/library/Collections.vue
@@ -1,0 +1,162 @@
+<script setup lang="ts">
+import type { Labrinth } from '@modrinth/api-client'
+import { ExternalIcon, GlobeIcon, LinkIcon, LockIcon, LogInIcon } from '@modrinth/assets'
+import {
+	Avatar,
+	ButtonStyled,
+	defineMessages,
+	EmptyState,
+	injectAuth,
+	injectModrinthClient,
+	injectNotificationManager,
+	StyledInput,
+	useVIntl,
+} from '@modrinth/ui'
+import { useQuery } from '@tanstack/vue-query'
+import { computed, ref } from 'vue'
+import { useRouter } from 'vue-router'
+
+import { parseCollectionId } from '@/helpers/collections'
+
+const { formatMessage } = useVIntl()
+const { addNotification } = injectNotificationManager()
+const auth = injectAuth()
+const client = injectModrinthClient()
+const router = useRouter()
+
+const messages = defineMessages({
+	signInPrompt: {
+		id: 'app.collections.sign-in-prompt',
+		defaultMessage: 'Sign in to view your collections',
+	},
+	signInButton: {
+		id: 'app.collections.sign-in-button',
+		defaultMessage: 'Sign in',
+	},
+	noCollections: {
+		id: 'app.collections.empty',
+		defaultMessage: "You don't have any collections yet",
+	},
+	noCollectionsHint: {
+		id: 'app.collections.empty-hint',
+		defaultMessage: 'Create collections on modrinth.com and view them here',
+	},
+	projectsCount: {
+		id: 'app.collections.projects-count',
+		defaultMessage: '{count, plural, =0 {No projects} one {# project} other {# projects}}',
+	},
+	openCollectionPlaceholder: {
+		id: 'app.collections.open-collection-placeholder',
+		defaultMessage: 'Paste a collection link or ID to open any collection...',
+	},
+	openCollectionButton: {
+		id: 'app.collections.open-collection-button',
+		defaultMessage: 'Open',
+	},
+	invalidCollectionLink: {
+		id: 'app.collections.invalid-collection-link',
+		defaultMessage: 'Invalid collection link',
+	},
+	invalidCollectionLinkText: {
+		id: 'app.collections.invalid-collection-link-text',
+		defaultMessage: 'Paste a modrinth.com collection URL or a collection ID.',
+	},
+})
+
+const userId = computed(() => auth.user.value?.id)
+
+const { data: collections, isPending } = useQuery({
+	queryKey: computed(() => ['user', userId.value, 'collections']),
+	queryFn: () => client.labrinth.users_v2.getCollections(userId.value!),
+	enabled: computed(() => !!userId.value),
+})
+
+const openCollectionInput = ref('')
+
+function openCollection() {
+	const id = parseCollectionId(openCollectionInput.value)
+	if (!id) {
+		addNotification({
+			type: 'error',
+			title: formatMessage(messages.invalidCollectionLink),
+			text: formatMessage(messages.invalidCollectionLinkText),
+		})
+		return
+	}
+	openCollectionInput.value = ''
+	router.push(`/collection/${id}`)
+}
+
+function statusIcon(collection: Labrinth.Collections.Collection) {
+	switch (collection.status) {
+		case 'listed':
+			return GlobeIcon
+		case 'unlisted':
+			return LinkIcon
+		default:
+			return LockIcon
+	}
+}
+</script>
+
+<template>
+	<div class="flex flex-col gap-3">
+		<div class="flex flex-wrap items-center gap-2">
+			<StyledInput
+				v-model="openCollectionInput"
+				:icon="LinkIcon"
+				type="text"
+				autocomplete="off"
+				:spellcheck="false"
+				:placeholder="formatMessage(messages.openCollectionPlaceholder)"
+				wrapper-class="w-full flex-grow sm:w-auto"
+				@keydown.enter="openCollection"
+			/>
+			<ButtonStyled>
+				<button :disabled="!openCollectionInput.trim()" @click="openCollection">
+					<ExternalIcon aria-hidden="true" />
+					{{ formatMessage(messages.openCollectionButton) }}
+				</button>
+			</ButtonStyled>
+		</div>
+
+		<EmptyState v-if="!userId" type="empty-inbox">
+			<template #heading>{{ formatMessage(messages.signInPrompt) }}</template>
+			<template #actions>
+				<ButtonStyled color="brand">
+					<button @click="auth.requestSignIn('/library/collections')">
+						<LogInIcon />
+						{{ formatMessage(messages.signInButton) }}
+					</button>
+				</ButtonStyled>
+			</template>
+		</EmptyState>
+		<div v-else-if="isPending" class="flex flex-col gap-3">
+			<div v-for="i in 3" :key="i" class="h-20 animate-pulse rounded-2xl bg-surface-3" />
+		</div>
+		<div
+			v-else-if="collections && collections.length > 0"
+			class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3"
+		>
+			<router-link
+				v-for="collection in collections"
+				:key="collection.id"
+				:to="`/collection/${collection.id}`"
+				class="flex items-center gap-3 rounded-2xl bg-surface-3 p-4 text-primary transition-all hover:bg-surface-4 hover:brightness-105 active:scale-[0.98]"
+			>
+				<Avatar :src="collection.icon_url" size="48px" />
+				<div class="flex min-w-0 flex-col gap-1">
+					<span class="truncate font-semibold text-contrast">{{ collection.name }}</span>
+					<span class="flex items-center gap-1.5 text-sm text-secondary">
+						<component :is="statusIcon(collection)" class="size-4 shrink-0" aria-hidden="true" />
+						{{ formatMessage(messages.projectsCount, { count: collection.projects.length }) }}
+					</span>
+				</div>
+			</router-link>
+		</div>
+		<EmptyState v-else type="empty-inbox">
+			<template #heading>{{ formatMessage(messages.noCollections) }}</template>
+			<template #description>{{ formatMessage(messages.noCollectionsHint) }}</template>
+		</EmptyState>
+	</div>
+</template>

--- a/apps/app-frontend/src/pages/library/Collections.vue
+++ b/apps/app-frontend/src/pages/library/Collections.vue
@@ -1,9 +1,18 @@
 <script setup lang="ts">
 import type { Labrinth } from '@modrinth/api-client'
-import { ExternalIcon, GlobeIcon, LinkIcon, LockIcon, LogInIcon } from '@modrinth/assets'
+import {
+	ExternalIcon,
+	GlobeIcon,
+	HeartIcon,
+	LinkIcon,
+	LockIcon,
+	LogInIcon,
+	SearchIcon,
+} from '@modrinth/assets'
 import {
 	Avatar,
 	ButtonStyled,
+	commonMessages,
 	defineMessages,
 	EmptyState,
 	injectAuth,
@@ -16,7 +25,7 @@ import { useQuery } from '@tanstack/vue-query'
 import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
 
-import { parseCollectionId } from '@/helpers/collections'
+import { isCollectionLink, parseCollectionId } from '@/helpers/collections'
 
 const { formatMessage } = useVIntl()
 const { addNotification } = injectNotificationManager()
@@ -33,21 +42,17 @@ const messages = defineMessages({
 		id: 'app.collections.sign-in-button',
 		defaultMessage: 'Sign in',
 	},
-	noCollections: {
-		id: 'app.collections.empty',
-		defaultMessage: "You don't have any collections yet",
-	},
-	noCollectionsHint: {
-		id: 'app.collections.empty-hint',
-		defaultMessage: 'Create collections on modrinth.com and view them here',
+	followingCardHint: {
+		id: 'app.collections.following-card-hint',
+		defaultMessage: 'Projects you follow',
 	},
 	projectsCount: {
 		id: 'app.collections.projects-count',
 		defaultMessage: '{count, plural, =0 {No projects} one {# project} other {# projects}}',
 	},
-	openCollectionPlaceholder: {
-		id: 'app.collections.open-collection-placeholder',
-		defaultMessage: 'Paste a collection link or ID to open any collection...',
+	searchPlaceholder: {
+		id: 'app.collections.search-placeholder',
+		defaultMessage: 'Search your collections, or paste a link to open another...',
 	},
 	openCollectionButton: {
 		id: 'app.collections.open-collection-button',
@@ -71,10 +76,24 @@ const { data: collections, isPending } = useQuery({
 	enabled: computed(() => !!userId.value),
 })
 
-const openCollectionInput = ref('')
+const query = ref('')
+const showOpen = computed(() => isCollectionLink(query.value))
+
+const filteredCollections = computed(() => {
+	const q = query.value.trim().toLowerCase()
+	if (!q) return collections.value ?? []
+	return (collections.value ?? []).filter((c) => c.name.toLowerCase().includes(q))
+})
+
+const showFollowingCard = computed(() => {
+	const q = query.value.trim().toLowerCase()
+	return (
+		!q || formatMessage(commonMessages.followedProjectsLabel).toLowerCase().includes(q)
+	)
+})
 
 function openCollection() {
-	const id = parseCollectionId(openCollectionInput.value)
+	const id = parseCollectionId(query.value)
 	if (!id) {
 		addNotification({
 			type: 'error',
@@ -83,7 +102,7 @@ function openCollection() {
 		})
 		return
 	}
-	openCollectionInput.value = ''
+	query.value = ''
 	router.push(`/collection/${id}`)
 }
 
@@ -103,17 +122,18 @@ function statusIcon(collection: Labrinth.Collections.Collection) {
 	<div class="flex flex-col gap-3">
 		<div class="flex flex-wrap items-center gap-2">
 			<StyledInput
-				v-model="openCollectionInput"
-				:icon="LinkIcon"
+				v-model="query"
+				:icon="SearchIcon"
 				type="text"
 				autocomplete="off"
 				:spellcheck="false"
-				:placeholder="formatMessage(messages.openCollectionPlaceholder)"
+				clearable
+				:placeholder="formatMessage(messages.searchPlaceholder)"
 				wrapper-class="w-full flex-grow sm:w-auto"
-				@keydown.enter="openCollection"
+				@keydown.enter="showOpen && openCollection()"
 			/>
-			<ButtonStyled>
-				<button :disabled="!openCollectionInput.trim()" @click="openCollection">
+			<ButtonStyled v-if="showOpen">
+				<button @click="openCollection">
 					<ExternalIcon aria-hidden="true" />
 					{{ formatMessage(messages.openCollectionButton) }}
 				</button>
@@ -134,12 +154,25 @@ function statusIcon(collection: Labrinth.Collections.Collection) {
 		<div v-else-if="isPending" class="flex flex-col gap-3">
 			<div v-for="i in 3" :key="i" class="h-20 animate-pulse rounded-2xl bg-surface-3" />
 		</div>
-		<div
-			v-else-if="collections && collections.length > 0"
-			class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3"
-		>
+		<div v-else class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
 			<router-link
-				v-for="collection in collections"
+				v-if="showFollowingCard"
+				to="/collection/following"
+				class="flex items-center gap-3 rounded-2xl bg-surface-3 p-4 text-primary transition-all hover:bg-surface-4 hover:brightness-105 active:scale-[0.98]"
+			>
+				<Avatar src="https://cdn.modrinth.com/follow-collection.png" size="48px" />
+				<div class="flex min-w-0 flex-col gap-1">
+					<span class="truncate font-semibold text-contrast">
+						{{ formatMessage(commonMessages.followedProjectsLabel) }}
+					</span>
+					<span class="flex items-center gap-1.5 text-sm text-secondary">
+						<HeartIcon class="size-4 shrink-0" aria-hidden="true" />
+						{{ formatMessage(messages.followingCardHint) }}
+					</span>
+				</div>
+			</router-link>
+			<router-link
+				v-for="collection in filteredCollections"
 				:key="collection.id"
 				:to="`/collection/${collection.id}`"
 				class="flex items-center gap-3 rounded-2xl bg-surface-3 p-4 text-primary transition-all hover:bg-surface-4 hover:brightness-105 active:scale-[0.98]"
@@ -154,9 +187,5 @@ function statusIcon(collection: Labrinth.Collections.Collection) {
 				</div>
 			</router-link>
 		</div>
-		<EmptyState v-else type="empty-inbox">
-			<template #heading>{{ formatMessage(messages.noCollections) }}</template>
-			<template #description>{{ formatMessage(messages.noCollectionsHint) }}</template>
-		</EmptyState>
 	</div>
 </template>

--- a/apps/app-frontend/src/pages/library/Index.vue
+++ b/apps/app-frontend/src/pages/library/Index.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { PlusIcon } from '@modrinth/assets'
 import { ButtonStyled, injectNotificationManager, NavTabs } from '@modrinth/ui'
-import { inject, onUnmounted, ref, shallowRef } from 'vue'
+import { computed, inject, onUnmounted, ref, shallowRef } from 'vue'
 import { useRoute } from 'vue-router'
 
 import { NewInstanceImage } from '@/assets/icons'
@@ -17,6 +17,8 @@ const breadcrumbs = useBreadcrumbs()
 breadcrumbs.setRootContext({ name: 'Library', link: route.path })
 
 const instances = shallowRef(await list().catch(handleError))
+
+const isCollectionsTab = computed(() => route.path.startsWith('/library/collections'))
 
 const offline = ref(!navigator.onLine)
 window.addEventListener('offline', () => {
@@ -43,12 +45,13 @@ onUnmounted(() => {
 				{ label: 'Modpacks', href: `/library/modpacks` },
 				{ label: 'Servers', href: `/library/servers` },
 				{ label: 'Custom', href: `/library/custom` },
+				{ label: 'Collections', href: `/library/collections` },
 				{ label: 'Shared with me', href: `/library/shared`, shown: false },
 				{ label: 'Saved', href: `/library/saved`, shown: false },
 			]"
 		/>
-		<template v-if="instances && instances.length > 0">
-			<RouterView v-if="route.path.startsWith('/library')" :instances="instances" />
+		<template v-if="(instances && instances.length > 0) || isCollectionsTab">
+			<RouterView v-if="route.path.startsWith('/library')" :instances="instances ?? []" />
 		</template>
 		<div v-else class="no-instance">
 			<div class="icon">

--- a/apps/app-frontend/src/pages/library/index.js
+++ b/apps/app-frontend/src/pages/library/index.js
@@ -1,3 +1,4 @@
+import Collections from './Collections.vue'
 import Custom from './Custom.vue'
 import Downloaded from './Downloaded.vue'
 import Index from './Index.vue'
@@ -5,4 +6,4 @@ import Modpacks from './Modpacks.vue'
 import Overview from './Overview.vue'
 import Servers from './Servers.vue'
 
-export { Custom, Downloaded, Index, Modpacks, Overview, Servers }
+export { Collections, Custom, Downloaded, Index, Modpacks, Overview, Servers }

--- a/apps/app-frontend/src/routes.js
+++ b/apps/app-frontend/src/routes.js
@@ -133,7 +133,25 @@ export default new createRouter({
 					name: 'Custom',
 					component: Library.Custom,
 				},
+				{
+					path: 'collections',
+					name: 'Collections',
+					component: Library.Collections,
+				},
 			],
+		},
+		{
+			path: '/collection/:id',
+			name: 'Collection',
+			component: Pages.Collection,
+			props: true,
+			meta: {
+				useContext: true,
+				breadcrumb: [
+					{ name: 'Collections', link: '/library/collections' },
+					{ name: '?Collection' },
+				],
+			},
 		},
 		{
 			path: '/:projectType(mod|plugin|datapack|resourcepack|shader|modpack)/:id/:rest(.*)*',

--- a/apps/frontend/src/locales/en-US/index.json
+++ b/apps/frontend/src/locales/en-US/index.json
@@ -932,6 +932,9 @@
   "auth.verify-email.title": {
     "message": "Verify Email"
   },
+  "collection.button.clear-filters": {
+    "message": "Clear filters"
+  },
   "collection.button.edit-icon": {
     "message": "Edit icon"
   },
@@ -977,6 +980,9 @@
   "collection.label.no-projects": {
     "message": "No projects in collection yet"
   },
+  "collection.label.no-results": {
+    "message": "No projects match your search"
+  },
   "collection.label.projects-count": {
     "message": "{count, plural, =0 {No projects yet} other {<stat>{count}</stat> {type}}}"
   },
@@ -988,6 +994,9 @@
   },
   "collection.return-link.user": {
     "message": "{user}'s profile"
+  },
+  "collection.search.placeholder": {
+    "message": "Search collection..."
   },
   "collection.title": {
     "message": "{name} - Collection"
@@ -3976,6 +3985,15 @@
   },
   "search.filter.locked.server.sync": {
     "message": "Sync with server"
+  },
+  "search.filter_type.game_version": {
+    "message": "Game version"
+  },
+  "search.filter_type.game_version.all_versions": {
+    "message": "Show all versions"
+  },
+  "search.filter_type.mod_loader": {
+    "message": "Loader"
   },
   "servers.manage.content.title": {
     "message": "Content - {serverName} - Modrinth"

--- a/packages/ui/src/layouts/shared/content-tab/layout.vue
+++ b/packages/ui/src/layouts/shared/content-tab/layout.vue
@@ -5,6 +5,7 @@ import {
 	ClockArrowDownIcon,
 	ClockArrowUpIcon,
 	CodeIcon,
+	CollectionIcon,
 	CompassIcon,
 	DownloadIcon,
 	DropdownIcon,
@@ -12,6 +13,7 @@ import {
 	FilterIcon,
 	FolderOpenIcon,
 	LinkIcon,
+	PlusIcon,
 	RefreshCwIcon,
 	SearchIcon,
 	ShareIcon,
@@ -83,6 +85,14 @@ const messages = defineMessages({
 	uploadFiles: {
 		id: 'content.page-layout.upload-files',
 		defaultMessage: 'Upload files',
+	},
+	addFromCollection: {
+		id: 'content.page-layout.add-from-collection',
+		defaultMessage: 'Add from collection',
+	},
+	addContent: {
+		id: 'content.page-layout.add-content',
+		defaultMessage: 'Add content',
 	},
 	sortAlphabetical: {
 		id: 'content.page-layout.sort.alphabetical',
@@ -750,7 +760,39 @@ const confirmUnlinkModal = ref<InstanceType<typeof ConfirmUnlinkModal>>()
 										<span>{{ formatMessage(messages.browseContent) }}</span>
 									</button>
 								</ButtonStyled>
-								<ButtonStyled type="outlined">
+								<ButtonStyled v-if="ctx.addFromCollection" type="outlined">
+									<OverflowMenu
+										v-tooltip="
+											ctx.busyMessage?.value ??
+											(ctx.disableAddContent?.value ? ctx.disableAddContentTooltip : undefined)
+										"
+										:disabled="ctx.isBusy.value || ctx.disableAddContent?.value"
+										class="!h-10"
+										:options="[
+											{
+												id: 'upload-files',
+												action: () => ctx.uploadFiles(),
+											},
+											{
+												id: 'add-from-collection',
+												action: () => ctx.addFromCollection!(),
+											},
+										]"
+									>
+										<PlusIcon class="size-5" />
+										{{ formatMessage(messages.addContent) }}
+										<DropdownIcon />
+										<template #upload-files>
+											<FolderOpenIcon />
+											{{ formatMessage(messages.uploadFiles) }}
+										</template>
+										<template #add-from-collection>
+											<CollectionIcon />
+											{{ formatMessage(messages.addFromCollection) }}
+										</template>
+									</OverflowMenu>
+								</ButtonStyled>
+								<ButtonStyled v-else type="outlined">
 									<button
 										v-tooltip="
 											ctx.busyMessage?.value ??
@@ -911,6 +953,20 @@ const confirmUnlinkModal = ref<InstanceType<typeof ConfirmUnlinkModal>>()
 							>
 								<FolderOpenIcon class="size-5" />
 								{{ formatMessage(messages.uploadFiles) }}
+							</button>
+						</ButtonStyled>
+						<ButtonStyled v-if="ctx.addFromCollection" type="outlined">
+							<button
+								v-tooltip="
+									ctx.busyMessage?.value ??
+									(ctx.disableAddContent?.value ? ctx.disableAddContentTooltip : undefined)
+								"
+								:disabled="ctx.isBusy.value || ctx.disableAddContent?.value"
+								class="!h-10"
+								@click="ctx.addFromCollection"
+							>
+								<CollectionIcon class="size-5" />
+								{{ formatMessage(messages.addFromCollection) }}
 							</button>
 						</ButtonStyled>
 						<ButtonStyled color="brand">

--- a/packages/ui/src/layouts/shared/content-tab/providers/content-manager.ts
+++ b/packages/ui/src/layouts/shared/content-tab/providers/content-manager.ts
@@ -61,6 +61,9 @@ export interface ContentManagerContext {
 	browse: () => void
 	uploadFiles: () => void
 
+	// Add from collection (optional — when undefined, the option is hidden)
+	addFromCollection?: () => void
+
 	// Bulk actions (optional — when provided, used instead of one-by-one loops)
 	bulkDeleteItems?: (items: ContentItem[]) => Promise<void>
 	bulkEnableItems?: (items: ContentItem[]) => Promise<void>

--- a/packages/ui/src/locales/en-US/index.json
+++ b/packages/ui/src/locales/en-US/index.json
@@ -509,6 +509,12 @@
   "content.modpack-card.dismiss-hint": {
     "defaultMessage": "Don't show again"
   },
+  "content.page-layout.add-content": {
+    "defaultMessage": "Add content"
+  },
+  "content.page-layout.add-from-collection": {
+    "defaultMessage": "Add from collection"
+  },
   "content.page-layout.additional-content": {
     "defaultMessage": "Additional content"
   },


### PR DESCRIPTION
Fixes #978 
ADDS COLLECTIONS TO THE APP.
& adds the following collection.

It shows up in your personal library where you can pick and choose which mods to add to an installation.
It also shows up when adding mods, there is a button to add from a collection. This is extremely useful in adding many mods at once if you group them in collections rather than modpacks.
Collections can even be pasted in the search bar if you have the link and don't own the collection.