### PR TITLE
fix: properly select correct databack versions

### DIFF
--- a/apps/app-frontend/src/pages/Browse.vue
+++ b/apps/app-frontend/src/pages/Browse.vue
@@ -680,7 +680,6 @@ async function chooseInstanceInstallVersion(
 	const selectedVersion = getLatestMatchingInstallVersion(
 		await getInstallProjectVersions(project.project_id),
 		selectedPreferences,
-		projectTypeValue,
 	)
 
 	if (!selectedVersion) {

--- a/packages/ui/src/layouts/shared/browse-tab/composables/install-logic.ts
+++ b/packages/ui/src/layouts/shared/browse-tab/composables/install-logic.ts
@@ -384,6 +384,7 @@ export function getLoaderFilterTypes(contentType: string) {
 	if (contentType === 'plugin') return ['plugin_loader', 'plugin_platform']
 	if (contentType === 'modpack') return ['modpack_loader']
 	if (contentType === 'shader') return ['shader_loader']
+	if (contentType === 'datapack') return ['datapack_loader']
 	return []
 }
 
@@ -454,7 +455,12 @@ export function getTargetInstallPreferences(
 
 	return normalizeInstallPreferences({
 		gameVersions: gameVersion && shouldUseTargetRuntime ? [gameVersion] : undefined,
-		loaders: loader && shouldUseTargetRuntime ? [loader] : undefined,
+		loaders:
+			contentType === 'datapack'
+				? ['datapack']
+				: loader && shouldUseTargetRuntime
+					? [loader]
+					: undefined,
 	})
 }
 
@@ -515,10 +521,9 @@ export function mergeInstallPreferences(
 export function getLatestMatchingInstallVersion(
 	versions: readonly Labrinth.Versions.v2.Version[],
 	preferences: BrowseInstallPreferences,
-	contentType: string,
 ) {
 	return [...versions]
-		.filter((version) => versionMatchesPreferences(version, preferences, contentType))
+		.filter((version) => versionMatchesPreferences(version, preferences))
 		.sort((a, b) => new Date(b.date_published).getTime() - new Date(a.date_published).getTime())[0]
 }
 
@@ -543,11 +548,7 @@ export async function resolveInstallPlan<TProject extends BrowseInstallProject>(
 	let lastError: Error | null = null
 
 	for (const candidate of candidates) {
-		const version = getLatestMatchingInstallVersion(
-			versions,
-			candidate.preferences,
-			options.contentType,
-		)
+		const version = getLatestMatchingInstallVersion(versions, candidate.preferences)
 
 		if (version) {
 			const fileName =
@@ -747,13 +748,11 @@ function hasPreferences(preferences: BrowseInstallPreferences) {
 function versionMatchesPreferences(
 	version: Labrinth.Versions.v2.Version,
 	preferences: BrowseInstallPreferences,
-	contentType: string,
 ) {
 	const gameVersionMatches =
 		!preferences.gameVersions?.length ||
 		version.game_versions.some((gameVersion) => preferences.gameVersions?.includes(gameVersion))
 	if (!gameVersionMatches) return false
-	if (contentType === 'datapack') return true
 	if (!preferences.loaders?.length) return true
 
 	const compatibleLoaders = getCompatibleLoaderAliasSet(preferences.loaders)

--- a/packages/ui/src/utils/version-compatibility.ts
+++ b/packages/ui/src/utils/version-compatibility.ts
@@ -47,11 +47,15 @@ export function versionMatchesCompatibilityTarget(
 		return false
 	}
 
+	const normalizedVersionLoaders = version.loaders.map(normalizeLoaderAlias)
+
+	if (target.projectType === 'datapack') {
+		return normalizedVersionLoaders.includes('datapack')
+	}
+
 	if (target.projectType && NON_MOD_PROJECT_TYPES.has(target.projectType)) {
 		return true
 	}
-
-	const normalizedVersionLoaders = version.loaders.map(normalizeLoaderAlias)
 
 	if (
 		target.projectType === 'modpack' &&


### PR DESCRIPTION
- Before this fix datapacks were treated like resource packs or shaders, once the game version matched, the code skipped loader checks entirely. That meant a datapack install could pick any version matching the Minecraft version, even if that version was not marked with the datapack loader - so you could get the datapack packaged as a mod, even if they were using vanilla/non-modded filters