### PR TITLE
fix: strip runtime filters to be authoratative

### DIFF
--- a/apps/app-frontend/src/pages/Browse.vue
+++ b/apps/app-frontend/src/pages/Browse.vue
@@ -22,6 +22,8 @@ import {
 	preferencesDiffer,
 	provideBrowseManager,
 	requestInstall,
+	stripServerRuntimeInstallFilters,
+	stripServerRuntimeInstallOverrides,
 	useBrowseSearch,
 	useDebugLogger,
 	useVIntl,
@@ -763,11 +765,15 @@ function getCardActions(
 							project: projectResult,
 							contentType,
 							mode: isModpack ? 'immediate' : 'queue',
-							selectedFilters: isModpack ? [] : searchState.currentFilters.value,
+							selectedFilters: isModpack
+								? []
+								: stripServerRuntimeInstallFilters(searchState.currentFilters.value),
 							providedFilters: isModpack ? [] : combinedProvidedFilters.value,
 							overriddenProvidedFilterTypes: isModpack
 								? []
-								: searchState.overriddenProvidedFilterTypes.value,
+								: stripServerRuntimeInstallOverrides(
+										searchState.overriddenProvidedFilterTypes.value,
+									),
 							targetPreferences: getServerInstallTargetPreferences(contentType),
 							getProjectVersions: getInstallProjectVersions,
 							queue: serverInstallQueue,

--- a/apps/frontend/src/composables/use-server-install-content.ts
+++ b/apps/frontend/src/composables/use-server-install-content.ts
@@ -22,6 +22,8 @@ import {
 	readStoredServerInstallQueue,
 	removePendingServerContentInstall,
 	requestInstall,
+	stripServerRuntimeInstallFilters,
+	stripServerRuntimeInstallOverrides,
 	useVIntl,
 	writePendingServerContentInstallBaseline,
 	writeStoredServerInstallQueue,
@@ -604,11 +606,15 @@ export function useServerInstallContent({
 				project,
 				contentType,
 				mode: isModpack ? 'immediate' : 'queue',
-				selectedFilters: isModpack ? [] : browseSearchState.currentFilters.value,
+				selectedFilters: isModpack
+					? []
+					: stripServerRuntimeInstallFilters(browseSearchState.currentFilters.value),
 				providedFilters: isModpack ? [] : serverFilters.value,
 				overriddenProvidedFilterTypes: isModpack
 					? []
-					: browseSearchState.overriddenProvidedFilterTypes.value,
+					: stripServerRuntimeInstallOverrides(
+							browseSearchState.overriddenProvidedFilterTypes.value,
+						),
 				targetPreferences: getServerInstallTargetPreferences(contentType),
 				getProjectVersions: getInstallProjectVersions,
 				queue: serverInstallQueue,

--- a/packages/ui/src/layouts/shared/browse-tab/composables/install-logic.ts
+++ b/packages/ui/src/layouts/shared/browse-tab/composables/install-logic.ts
@@ -387,6 +387,22 @@ export function getLoaderFilterTypes(contentType: string) {
 	return []
 }
 
+const SERVER_RUNTIME_INSTALL_FILTER_TYPES = new Set([
+	'game_version',
+	'mod_loader',
+	'plugin_loader',
+	'plugin_platform',
+	'datapack_loader',
+])
+
+export function stripServerRuntimeInstallFilters(filters: readonly FilterValue[]) {
+	return filters.filter((filter) => !SERVER_RUNTIME_INSTALL_FILTER_TYPES.has(filter.type))
+}
+
+export function stripServerRuntimeInstallOverrides(filterTypes: readonly string[]) {
+	return filterTypes.filter((type) => !SERVER_RUNTIME_INSTALL_FILTER_TYPES.has(type))
+}
+
 /**
  * Merges user-selected filters with target-provided filters for install decisions.
  *


### PR DESCRIPTION
- The browse/discover flow from the server panel has two ways filters can be pre-selected
	- `providedFilters`: filters the browse UI uses because the server supplied them, like game version or loader.
	- `targetPreferences`: the actual server compatibility target used when choosing the version to install.
- Sometimes if the user overrides the provided filters it would still use targetPreferences, meaning that incorrect project versions get resolved and installed
