### PR TITLE
feat(app): allow excluding content from bulk updates

### DIFF
--- a/apps/app-frontend/src/helpers/instance.ts
+++ b/apps/app-frontend/src/helpers/instance.ts
@@ -255,6 +255,18 @@ export async function toggle_disable_project(
 	})
 }
 
+export async function toggle_update_excluded_project(
+	instanceId: string,
+	projectPath: string,
+	desiredExcluded?: boolean,
+): Promise<void> {
+	return await invoke('plugin:instance|instance_toggle_update_excluded_project', {
+		instanceId,
+		projectPath,
+		desiredExcluded,
+	})
+}
+
 // Remove a project
 export async function remove_project(instanceId: string, projectPath: string): Promise<void> {
 	return await invoke('plugin:instance|instance_remove_project', { instanceId, projectPath })

--- a/apps/app-frontend/src/pages/instance/Mods.vue
+++ b/apps/app-frontend/src/pages/instance/Mods.vue
@@ -67,7 +67,7 @@
 
 <script setup lang="ts">
 import type { Labrinth } from '@modrinth/api-client'
-import { ClipboardCopyIcon, FolderOpenIcon } from '@modrinth/assets'
+import { ClipboardCopyIcon, FolderOpenIcon, LockIcon, LockOpenIcon } from '@modrinth/assets'
 import {
 	type BulkOperationStatus,
 	commonMessages,
@@ -117,6 +117,7 @@ import {
 	remove_project,
 	switch_project_version_with_dependencies,
 	toggle_disable_project,
+	toggle_update_excluded_project,
 	update_all,
 	update_managed_modrinth_version,
 } from '@/helpers/instance'
@@ -162,6 +163,14 @@ const messages = defineMessages({
 	bulkUpdateFinishing: {
 		id: 'app.instance.mods.bulk-update.finishing',
 		defaultMessage: 'Finishing update...',
+	},
+	excludeFromUpdateAll: {
+		id: 'app.instance.mods.exclude-from-update-all',
+		defaultMessage: 'Exclude from Update All',
+	},
+	includeInUpdateAll: {
+		id: 'app.instance.mods.include-in-update-all',
+		defaultMessage: 'Include in Update All',
 	},
 })
 
@@ -554,6 +563,26 @@ async function toggleDisableMod(mod: ContentItem, desiredEnabled?: boolean) {
 }
 
 const toggleDisableDebounced = toggleDisableMod
+
+async function toggleUpdateExcluded(mod: ContentItem, desiredExcluded?: boolean) {
+	if (!mod.file_path) return
+	const operation = beginContentOperation(mod)
+	if (!operation) return
+
+	try {
+		const excluded =
+			desiredExcluded !== undefined ? desiredExcluded : !(mod.update_excluded ?? false)
+		await toggle_update_excluded_project(props.instance.id, mod.file_path, excluded)
+		mod.update_excluded = excluded
+		updateLinkedModpackContentCache(mod, operation.originalFileName, mod.file_path, {
+			update_excluded: excluded,
+		})
+	} catch (err) {
+		handleError(err as Error)
+	} finally {
+		finishContentOperation(mod, operation)
+	}
+}
 
 async function removeMod(mod: ContentItem) {
 	if (!mod.file_path) return
@@ -1174,6 +1203,16 @@ function getOverflowOptions(item: ContentItem): OverflowMenuOption[] {
 		icon: FolderOpenIcon,
 		action: () => highlightModInInstance(props.instance.id, item.file_path),
 	})
+
+	if (item.file_path) {
+		options.push({
+			id: item.update_excluded
+				? formatMessage(messages.includeInUpdateAll)
+				: formatMessage(messages.excludeFromUpdateAll),
+			icon: (item.update_excluded ?? false) ? LockOpenIcon : LockIcon,
+			action: () => toggleUpdateExcluded(item),
+		})
+	}
 
 	if (item.project?.slug) {
 		options.push({

--- a/apps/app/src/api/instance.rs
+++ b/apps/app/src/api/instance.rs
@@ -42,6 +42,7 @@ pub fn init<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
             instance_switch_project_version_with_dependencies,
             instance_add_project_from_path,
             instance_toggle_disable_project,
+            instance_toggle_update_excluded_project,
             instance_remove_project,
             instance_update_managed_modrinth_version,
             instance_repair_managed_modrinth,
@@ -645,6 +646,21 @@ pub async fn instance_toggle_disable_project(
         desired_enabled,
     )
     .await?)
+}
+
+#[tauri::command]
+pub async fn instance_toggle_update_excluded_project(
+    instance_id: &str,
+    project_path: &str,
+    desired_excluded: Option<bool>,
+) -> Result<()> {
+    theseus::instance::toggle_update_excluded_project(
+        instance_id,
+        project_path,
+        desired_excluded,
+    )
+    .await?;
+    Ok(())
 }
 
 #[tauri::command]

--- a/packages/app-lib/.sqlx/query-1f0fe2b4a4c39b3083cd34f4816d2d2c7babd876d979d275ad62cf70cde678fe.json
+++ b/packages/app-lib/.sqlx/query-1f0fe2b4a4c39b3083cd34f4816d2d2c7babd876d979d275ad62cf70cde678fe.json
@@ -59,13 +59,18 @@
         "type_info": "Integer"
       },
       {
-        "name": "added_at",
+        "name": "update_excluded",
         "ordinal": 11,
         "type_info": "Integer"
       },
       {
-        "name": "modified_at",
+        "name": "added_at",
         "ordinal": 12,
+        "type_info": "Integer"
+      },
+      {
+        "name": "modified_at",
+        "ordinal": 13,
         "type_info": "Integer"
       }
     ],
@@ -80,6 +85,7 @@
       false,
       true,
       true,
+      false,
       false,
       false,
       false,

--- a/packages/app-lib/.sqlx/query-a1681a1932f01490c3282aa45a3dccdc7bb14128f797b2e3b64c43c86ee4cba8.json
+++ b/packages/app-lib/.sqlx/query-a1681a1932f01490c3282aa45a3dccdc7bb14128f797b2e3b64c43c86ee4cba8.json
@@ -59,13 +59,18 @@
         "type_info": "Integer"
       },
       {
-        "name": "added_at",
+        "name": "update_excluded",
         "ordinal": 11,
         "type_info": "Integer"
       },
       {
-        "name": "modified_at",
+        "name": "added_at",
         "ordinal": 12,
+        "type_info": "Integer"
+      },
+      {
+        "name": "modified_at",
+        "ordinal": 13,
         "type_info": "Integer"
       }
     ],
@@ -80,6 +85,7 @@
       false,
       true,
       true,
+      false,
       false,
       false,
       false,

--- a/packages/app-lib/.sqlx/query-eff7928f6ef38c2fa7d59897814a157bbe19a6f443e34c1452119f2bb6a3e1e1.json
+++ b/packages/app-lib/.sqlx/query-eff7928f6ef38c2fa7d59897814a157bbe19a6f443e34c1452119f2bb6a3e1e1.json
@@ -59,13 +59,18 @@
         "type_info": "Integer"
       },
       {
-        "name": "added_at",
+        "name": "update_excluded",
         "ordinal": 11,
         "type_info": "Integer"
       },
       {
-        "name": "modified_at",
+        "name": "added_at",
         "ordinal": 12,
+        "type_info": "Integer"
+      },
+      {
+        "name": "modified_at",
+        "ordinal": 13,
         "type_info": "Integer"
       }
     ],
@@ -80,6 +85,7 @@
       false,
       true,
       true,
+      false,
       false,
       false,
       false,

--- a/packages/app-lib/.sqlx/query-fc66a319ea16fccf820b98c68275848b1954daecbda0fe05953183cd939a9e43.json
+++ b/packages/app-lib/.sqlx/query-fc66a319ea16fccf820b98c68275848b1954daecbda0fe05953183cd939a9e43.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\n\t\tUPDATE instance_content_entries\n\t\tSET update_excluded = ?, modified_at = ?\n\t\tWHERE content_set_id = ? AND file_id = ?\n\t\t",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 4
+    },
+    "nullable": []
+  },
+  "hash": "fc66a319ea16fccf820b98c68275848b1954daecbda0fe05953183cd939a9e43"
+}

--- a/packages/app-lib/migrations/20260710120000_content-entry-update-excluded.sql
+++ b/packages/app-lib/migrations/20260710120000_content-entry-update-excluded.sql
@@ -1,0 +1,1 @@
+ALTER TABLE instance_content_entries ADD COLUMN update_excluded INTEGER NOT NULL DEFAULT 0;

--- a/packages/app-lib/src/api/instance.rs
+++ b/packages/app-lib/src/api/instance.rs
@@ -28,7 +28,8 @@ pub use self::projects::{
     add_project_from_version, install_project_with_dependencies,
     remove_project, repair_managed_modrinth,
     switch_project_version_with_dependencies, toggle_disable_project,
-    update_all_projects, update_managed_modrinth_version, update_project,
+    toggle_update_excluded_project, update_all_projects,
+    update_managed_modrinth_version, update_project,
 };
 pub use self::run::{
     QuickPlayType, kill, run, try_update_playtime_by_instance_id,

--- a/packages/app-lib/src/api/instance/projects.rs
+++ b/packages/app-lib/src/api/instance/projects.rs
@@ -233,6 +233,25 @@ pub async fn toggle_disable_project(
 }
 
 #[tracing::instrument]
+pub async fn toggle_update_excluded_project(
+    instance_id: &str,
+    project: &str,
+    desired_excluded: Option<bool>,
+) -> crate::Result<()> {
+    let state = State::get().await?;
+    crate::state::instances::commands::toggle_update_excluded_project(
+        instance_id,
+        project,
+        desired_excluded,
+        &state,
+    )
+    .await?;
+    emit_instance(instance_id, InstancePayloadType::Edited).await?;
+
+    Ok(())
+}
+
+#[tracing::instrument]
 pub async fn remove_project(
     instance_id: &str,
     project: &str,

--- a/packages/app-lib/src/state/instance_types.rs
+++ b/packages/app-lib/src/state/instance_types.rs
@@ -118,6 +118,7 @@ pub struct ContentFile {
     pub hash: String,
     pub file_name: String,
     pub enabled: bool,
+    pub update_excluded: bool,
     pub size: u64,
     pub metadata: Option<FileMetadata>,
     pub update_version_id: Option<String>,

--- a/packages/app-lib/src/state/instances/adapters/sqlite/content_rows.rs
+++ b/packages/app-lib/src/state/instances/adapters/sqlite/content_rows.rs
@@ -136,6 +136,7 @@ pub(crate) struct ContentEntryRow {
     pub server_requirement: String,
     pub client_requirement: String,
     pub enabled: i64,
+    pub update_excluded: i64,
     pub added_at: i64,
     pub modified_at: i64,
 }
@@ -160,6 +161,7 @@ impl TryFrom<ContentEntryRow> for ContentEntry {
                 &row.client_requirement,
             )?,
             enabled: row.enabled == 1,
+            update_excluded: row.update_excluded == 1,
             added_at: timestamp(row.added_at),
             modified_at: timestamp(row.modified_at),
         })
@@ -947,6 +949,32 @@ pub(crate) async fn set_content_entry_enabled_for_file(
 		WHERE content_set_id = ? AND file_id = ?
 		",
         enabled,
+        modified_at,
+        content_set_id,
+        file_id,
+    )
+    .execute(pool)
+    .await?;
+
+    Ok(result.rows_affected() > 0)
+}
+
+pub(crate) async fn set_content_entry_update_excluded_for_file(
+    content_set_id: &str,
+    file_id: &str,
+    update_excluded: bool,
+    pool: &SqlitePool,
+) -> crate::Result<bool> {
+    let update_excluded = i64::from(update_excluded);
+    let modified_at = Utc::now().timestamp();
+
+    let result = sqlx::query!(
+        "
+		UPDATE instance_content_entries
+		SET update_excluded = ?, modified_at = ?
+		WHERE content_set_id = ? AND file_id = ?
+		",
+        update_excluded,
         modified_at,
         content_set_id,
         file_id,

--- a/packages/app-lib/src/state/instances/commands/apply_content_install.rs
+++ b/packages/app-lib/src/state/instances/commands/apply_content_install.rs
@@ -690,6 +690,55 @@ pub(crate) async fn toggle_disable_project(
     Ok(new_path)
 }
 
+pub(crate) async fn toggle_update_excluded_project(
+    instance_id: &str,
+    project_path: &str,
+    desired_excluded: Option<bool>,
+    state: &State,
+) -> crate::Result<()> {
+    let scope = resolve_content_scope(instance_id, None, state).await?;
+    let file = content_rows::get_instance_file_by_relative_path(
+        &scope.instance.id,
+        project_path,
+        &state.pool,
+    )
+    .await?
+    .ok_or_else(|| {
+        crate::ErrorKind::InputError(format!(
+            "Could not find project file for '{project_path}' in instance"
+        ))
+    })?;
+
+    let excluded = match desired_excluded {
+        Some(v) => v,
+        None => {
+            let entries = content_rows::get_content_entries(
+                &scope.content_set_id,
+                &state.pool,
+            )
+            .await?;
+            let current = entries
+                .iter()
+                .find(|entry| {
+                    entry.file_id.as_deref() == Some(file.id.as_str())
+                })
+                .map(|entry| entry.update_excluded)
+                .unwrap_or(false);
+            !current
+        }
+    };
+
+    content_rows::set_content_entry_update_excluded_for_file(
+        &scope.content_set_id,
+        &file.id,
+        excluded,
+        &state.pool,
+    )
+    .await?;
+
+    Ok(())
+}
+
 pub(crate) async fn remove_project(
     instance_id: &str,
     project_path: &str,

--- a/packages/app-lib/src/state/instances/commands/apply_content_update.rs
+++ b/packages/app-lib/src/state/instances/commands/apply_content_update.rs
@@ -412,7 +412,11 @@ async fn bulk_updateable_project_paths(
     )
     .await?;
 
-    Ok(items.into_iter().map(|item| item.file_path).collect())
+    Ok(items
+        .into_iter()
+        .filter(|item| !item.update_excluded)
+        .map(|item| item.file_path)
+        .collect())
 }
 
 async fn installed_projects(

--- a/packages/app-lib/src/state/instances/commands/list_content.rs
+++ b/packages/app-lib/src/state/instances/commands/list_content.rs
@@ -527,6 +527,7 @@ pub(crate) async fn dependencies_to_content_items(
                 owner,
                 has_update: false,
                 update_version_id: None,
+                update_excluded: false,
                 date_added: None,
             })
         })
@@ -735,6 +736,9 @@ async fn content_projects_for_scope(
                 enabled: entry.map_or(file.enabled, |entry| {
                     entry.enabled && file.enabled
                 }),
+                update_excluded: entry.map_or(false, |entry| {
+                    entry.update_excluded
+                }),
                 size: file.size,
                 metadata: file_metadata_from_entry_or_cache(entry, metadata),
                 project_type,
@@ -899,6 +903,7 @@ async fn content_files_to_content_items(
                 owner,
                 has_update: file.update_version_id.is_some(),
                 update_version_id: file.update_version_id.clone(),
+                update_excluded: file.update_excluded,
                 date_added: modification_times[index].clone(),
             }
         })

--- a/packages/app-lib/src/state/instances/content.rs
+++ b/packages/app-lib/src/state/instances/content.rs
@@ -14,6 +14,7 @@ pub struct ContentItem {
     pub owner: Option<ContentItemOwner>,
     pub has_update: bool,
     pub update_version_id: Option<String>,
+    pub update_excluded: bool,
     pub date_added: Option<String>,
 }
 

--- a/packages/app-lib/src/state/instances/model/content_entry.rs
+++ b/packages/app-lib/src/state/instances/model/content_entry.rs
@@ -47,6 +47,7 @@ pub struct ContentEntry {
     pub server_requirement: ContentRequirement,
     pub client_requirement: ContentRequirement,
     pub enabled: bool,
+    pub update_excluded: bool,
     pub added_at: DateTime<Utc>,
     pub modified_at: DateTime<Utc>,
 }

--- a/packages/ui/src/layouts/shared/content-tab/types.ts
+++ b/packages/ui/src/layouts/shared/content-tab/types.ts
@@ -65,6 +65,7 @@ export interface ContentItem extends Omit<
 	project_type: string
 	has_update: boolean
 	update_version_id: string | null
+	update_excluded?: boolean
 	date_added?: string
 	environment?: string
 	pack_client_retained?: boolean


### PR DESCRIPTION
adds an "Exclude from Update All" option to the overflow menu for mods/resourcepacks/shaders. stored in a new `update_excluded` column on `instance_content_entries`, existing installs default to 0 so nothing breaks. bulk update skips excluded items, per-item update still works.