### PR TITLE
fix: added project type switcher to mobile

### DIFF
--- a/apps/frontend/src/pages/discover.vue
+++ b/apps/frontend/src/pages/discover.vue
@@ -54,7 +54,7 @@ const selectableProjectTypes = [
 				v-if="!flags.projectTypesPrimaryNav && allowTabChanging"
 				:links="selectableProjectTypes"
 				replace
-				class="hidden md:flex"
+				class="flex"
 			/>
 		</section>
 		<NuxtPage />


### PR DESCRIPTION
I changed one line of code so the project type switcher on desktop web app (mod, resource pack, etc.) is on mobile because I wanna look at a different project type easily 