### PR TITLE
fix: ignore notfound errors

### DIFF
--- a/packages/app-lib/src/state/instances/commands/apply_content_install.rs
+++ b/packages/app-lib/src/state/instances/commands/apply_content_install.rs
@@ -711,7 +711,11 @@ pub(crate) async fn remove_project(
     )
     .await?;
 
-    io::remove_file(base.join(project_path)).await?;
+    match io::remove_file(base.join(project_path)).await {
+        Ok(()) => {}
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+        Err(err) => return Err(err.into()),
+    }
 
     if let Some(file) = file {
         content_rows::remove_content_entries_for_file(


### PR DESCRIPTION
- ignores notfound errors if a modpack content item was deleted when downgrading
- this used to happen after the modpack installing is done but its not fast enough and causes issues with some modpacks