### PR TITLE
fix: add margin to devinfo section

### DIFF
--- a/apps/frontend/src/pages/[type]/[project]/version/[version].vue
+++ b/apps/frontend/src/pages/[type]/[project]/version/[version].vue
@@ -388,7 +388,7 @@
 						projectV3.project_types.includes('mod') ||
 						projectV3.project_types.includes('plugin')
 					"
-					class="flex flex-col overflow-hidden rounded-2xl border-[1px] border-solid border-surface-4 bg-surface-2 p-0"
+					class="mb-4 flex flex-col overflow-hidden rounded-2xl border-[1px] border-solid border-surface-4 bg-surface-2 p-0"
 				>
 					<button
 						class="group m-0 flex w-full min-w-0 appearance-none items-center gap-3 rounded-2xl rounded-b-none bg-surface-3 p-4 text-left outline-offset-[-3px]"


### PR DESCRIPTION
## fixes #6748 

### before
<img width="468" height="145" alt="image" src="https://github.com/user-attachments/assets/a5acb0e3-4278-463d-aed9-927786366719" />

### after 
<img width="465" height="240" alt="image" src="https://github.com/user-attachments/assets/49a56caa-a369-4b79-b3d6-c7e72e1cd015" />
