### PR TITLE
chore(frontend): i18n pass on mostly-translated frontend components

### DIFF
--- a/apps/frontend/src/components/analytics-dashboard/analytics-messages.ts
+++ b/apps/frontend/src/components/analytics-dashboard/analytics-messages.ts
@@ -213,6 +213,10 @@ export const analyticsMessages = defineMessages({
 		id: 'analytics.filter.game-version-type.all',
 		defaultMessage: 'All',
 	},
+	dependentProjectSearchFailedTitle: {
+		id: 'analytics.filter.dependent-project-search-failed-title',
+		defaultMessage: 'Dependent projects failed to load',
+	},
 })
 
 export const analyticsStatMessages = defineMessages({

--- a/apps/frontend/src/components/analytics-dashboard/query-builder/QueryFilter.vue
+++ b/apps/frontend/src/components/analytics-dashboard/query-builder/QueryFilter.vue
@@ -492,7 +492,7 @@ watch(dependentProjectSearchError, (error) => {
 	if (!error) return
 
 	addNotification({
-		title: 'Dependent projects failed to load',
+		title: formatMessage(analyticsMessages.dependentProjectSearchFailedTitle),
 		text: getDependentProjectSearchErrorMessage(error),
 		type: 'error',
 	})

--- a/apps/frontend/src/components/ui/ModrinthFooter.vue
+++ b/apps/frontend/src/components/ui/ModrinthFooter.vue
@@ -40,6 +40,30 @@ const messages = defineMessages({
 		defaultMessage:
 			'NOT AN OFFICIAL MINECRAFT SERVICE. NOT APPROVED BY OR ASSOCIATED WITH MOJANG OR MICROSOFT.',
 	},
+	basedOnLabel: {
+		id: 'layout.footer.based-on-label',
+		defaultMessage: 'Based on',
+	},
+	unknownCommit: {
+		id: 'layout.footer.unknown-commit',
+		defaultMessage: 'unknown',
+	},
+	developerModeActivatedTitle: {
+		id: 'layout.footer.developer-mode-activated.title',
+		defaultMessage: 'Developer mode activated',
+	},
+	developerModeActivatedText: {
+		id: 'layout.footer.developer-mode-activated.text',
+		defaultMessage: 'Developer mode has been enabled',
+	},
+	developerModeDeactivatedTitle: {
+		id: 'layout.footer.developer-mode-deactivated.title',
+		defaultMessage: 'Developer mode deactivated',
+	},
+	developerModeDeactivatedText: {
+		id: 'layout.footer.developer-mode-deactivated.text',
+		defaultMessage: 'Developer mode has been disabled',
+	},
 })
 
 const socialLinks: {
@@ -215,14 +239,14 @@ function developerModeIncrement() {
 		saveFeatureFlags()
 		if (flags.value.developerMode) {
 			addNotification({
-				title: 'Developer mode activated',
-				text: 'Developer mode has been enabled',
+				title: formatMessage(messages.developerModeActivatedTitle),
+				text: formatMessage(messages.developerModeActivatedText),
 				type: 'success',
 			})
 		} else {
 			addNotification({
-				title: 'Developer mode deactivated',
-				text: 'Developer mode has been disabled',
+				title: formatMessage(messages.developerModeDeactivatedTitle),
+				text: formatMessage(messages.developerModeDeactivatedText),
 				type: 'success',
 			})
 		}
@@ -320,7 +344,7 @@ function developerModeIncrement() {
 				</div>
 			</div>
 			<p v-if="flags.developerMode" class="m-0 text-sm text-secondary">
-				Based on
+				{{ formatMessage(messages.basedOnLabel) }}
 				<a
 					v-if="config.public.owner && config.public.branch"
 					class="hover:underline"
@@ -330,7 +354,9 @@ function developerModeIncrement() {
 					{{ config.public.owner }}/{{ config.public.branch }}
 				</a>
 				@
-				<span v-if="config.public.hash === 'unknown'">unknown</span>
+				<span v-if="config.public.hash === 'unknown'">{{
+					formatMessage(messages.unknownCommit)
+				}}</span>
 				<AutoLink
 					v-else
 					class="text-link"

--- a/apps/frontend/src/components/ui/OrganizationProjectTransferModal.vue
+++ b/apps/frontend/src/components/ui/OrganizationProjectTransferModal.vue
@@ -1,6 +1,11 @@
 <template>
 	<div>
-		<NewModal ref="modalOpen" header="Transfer projects" no-padding width="60rem">
+		<NewModal
+			ref="modalOpen"
+			:header="formatMessage(messages.transferProjectsTitle)"
+			no-padding
+			width="60rem"
+		>
 			<div class="max-h-[70vh] overflow-y-auto">
 				<Table
 					class="!rounded-none !border-0"
@@ -12,7 +17,7 @@
 				>
 					<template #empty-state>
 						<div class="flex h-48 items-center justify-center text-secondary">
-							No projects available to transfer.
+							{{ formatMessage(messages.noProjectsAvailable) }}
 						</div>
 					</template>
 					<template #header-select>
@@ -38,7 +43,7 @@
 								<img
 									v-if="project.icon_url"
 									:src="project.icon_url"
-									:alt="'Icon for ' + project.title"
+									:alt="formatMessage(messages.projectIconAlt, { name: project.title })"
 									class="h-full w-full rounded object-cover"
 								/>
 								<BoxIcon v-else class="h-full w-full" />
@@ -69,8 +74,11 @@
 					<ButtonStyled color="brand">
 						<button :disabled="selectedProjects.length === 0" @click="submitTransfer()">
 							<TransferIcon />
-							Transfer {{ selectedProjects.length }}
-							{{ selectedProjects.length === 1 ? 'project' : 'projects' }}
+							{{
+								formatMessage(messages.transferSelectedProjects, {
+									count: selectedProjects.length,
+								})
+							}}
 						</button>
 					</ButtonStyled>
 				</div>
@@ -79,7 +87,7 @@
 		<ButtonStyled>
 			<button @click="show($event)">
 				<TransferIcon />
-				<span>Transfer projects</span>
+				<span>{{ formatMessage(messages.transferProjectsTitle) }}</span>
 			</button>
 		</ButtonStyled>
 	</div>
@@ -92,6 +100,7 @@ import {
 	Checkbox,
 	commonMessages,
 	CopyCode,
+	defineMessages,
 	NewModal,
 	Table,
 	useVIntl,
@@ -112,10 +121,41 @@ const props = defineProps({
 const emit = defineEmits(['submit'])
 const { formatMessage } = useVIntl()
 
+const messages = defineMessages({
+	transferProjectsTitle: {
+		id: 'organization.project-transfer.title',
+		defaultMessage: 'Transfer projects',
+	},
+	noProjectsAvailable: {
+		id: 'organization.project-transfer.no-projects-available',
+		defaultMessage: 'No projects available to transfer.',
+	},
+	projectIconAlt: {
+		id: 'organization.project-transfer.project-icon-alt',
+		defaultMessage: 'Icon for {name}',
+	},
+	transferSelectedProjects: {
+		id: 'organization.project-transfer.transfer-selected-projects',
+		defaultMessage: 'Transfer {count, plural, one {# project} other {# projects}}',
+	},
+	nameColumn: {
+		id: 'organization.project-transfer.name-column',
+		defaultMessage: 'Name',
+	},
+	idColumn: {
+		id: 'organization.project-transfer.id-column',
+		defaultMessage: 'ID',
+	},
+	typeColumn: {
+		id: 'organization.project-transfer.type-column',
+		defaultMessage: 'Type',
+	},
+})
+
 const modalOpen = ref(null)
 const selectedProjectIds = ref([])
 
-const projectTableColumns = [
+const projectTableColumns = computed(() => [
 	{
 		key: 'select',
 		width: '3rem',
@@ -124,21 +164,21 @@ const projectTableColumns = [
 	},
 	{
 		key: 'name',
-		label: 'Name',
+		label: formatMessage(messages.nameColumn),
 		width: '22rem',
 	},
 	{
 		key: 'id',
-		label: 'ID',
+		label: formatMessage(messages.idColumn),
 		width: '13rem',
 		cellClass: '!overflow-visible',
 	},
 	{
 		key: 'type',
-		label: 'Type',
+		label: formatMessage(messages.typeColumn),
 		width: '10rem',
 	},
-]
+])
 
 const transferableProjects = computed(() =>
 	props.projects.filter((project) => !isProjectTransferDisabled(project)),

--- a/apps/frontend/src/components/ui/create-project-version/stages/AddFilesStage.vue
+++ b/apps/frontend/src/components/ui/create-project-version/stages/AddFilesStage.vue
@@ -11,19 +11,21 @@
 			v-if="handlingNewFiles || !(filesToAdd.length || draftVersion.existing_files?.length)"
 		>
 			<DropzoneFileInput
-				aria-label="Upload file"
+				:aria-label="formatMessage(messages.uploadFileAriaLabel)"
 				multiple
 				:accept="acceptFileFromProjectType(projectV2.project_type)"
 				:max-size="524288000"
-				primary-prompt="Upload primary and supporting files"
-				secondary-prompt="Drag and drop files or click to browse"
+				:primary-prompt="formatMessage(messages.uploadPrimaryPrompt)"
+				:secondary-prompt="formatMessage(messages.uploadSecondaryPrompt)"
 				@change="handleNewFiles"
 			/>
 		</template>
 
 		<template v-else>
 			<div class="flex flex-col gap-2">
-				<span class="text-base font-semibold text-contrast">Primary file</span>
+				<span class="text-base font-semibold text-contrast">{{
+					formatMessage(messages.primaryFileLabel)
+				}}</span>
 				<div class="flex flex-col gap-2.5">
 					<VersionFileRow
 						v-if="primaryFile"
@@ -36,7 +38,7 @@
 					/>
 				</div>
 				<span>
-					The primary file is the default file a user downloads when installing the project.
+					{{ formatMessage(messages.primaryFileDescription) }}
 				</span>
 			</div>
 
@@ -46,16 +48,18 @@
 						{{ formatMessage(messages.addFilesAdmonition) }}
 					</Admonition>
 
-					<span class="text-base font-semibold text-contrast">Supplementary files</span>
+					<span class="text-base font-semibold text-contrast">{{
+						formatMessage(messages.supplementaryFilesLabel)
+					}}</span>
 
 					<DropzoneFileInput
-						aria-label="Upload additional file"
+						:aria-label="formatMessage(messages.uploadAdditionalFileAriaLabel)"
 						multiple
 						:accept="acceptFileFromProjectType(projectV2.project_type)"
 						:max-size="524288000"
 						size="small"
 						:primary-prompt="null"
-						secondary-prompt="Drag and drop files or click to browse"
+						:secondary-prompt="formatMessage(messages.uploadSecondaryPrompt)"
 						@change="handleNewFiles"
 					/>
 
@@ -84,8 +88,7 @@
 					</div>
 				</div>
 				<span>
-					You can optionally add supplementary files such as source code, documentation, or required
-					resource packs.
+					{{ formatMessage(messages.supplementaryFilesDescription) }}
 				</span>
 			</div>
 		</template>
@@ -124,11 +127,11 @@ const {
 	handleNewFiles,
 } = injectManageVersionContext()
 
-const editTabs: TabsTab[] = [
-	{ label: 'Metadata', value: 'metadata' },
-	{ label: 'Details', value: 'add-details' },
-	{ label: 'Files', value: 'add-files' },
-]
+const editTabs = computed<TabsTab[]>(() => [
+	{ label: formatMessage(messages.metadataTab), value: 'metadata' },
+	{ label: formatMessage(messages.detailsTab), value: 'add-details' },
+	{ label: formatMessage(messages.filesTab), value: 'add-files' },
+])
 
 function setEditTab(tab: TabsTab) {
 	modal.value?.setStage(tab.value)
@@ -170,6 +173,51 @@ const messages = defineMessages({
 		id: 'create-project-version.create-modal.stage.add-files.admonition',
 		defaultMessage:
 			'Supplementary files are for supporting resources like source code, not for alternative versions or variants.',
+	},
+	uploadFileAriaLabel: {
+		id: 'create-project-version.create-modal.stage.add-files.upload-file-aria-label',
+		defaultMessage: 'Upload file',
+	},
+	uploadAdditionalFileAriaLabel: {
+		id: 'create-project-version.create-modal.stage.add-files.upload-additional-file-aria-label',
+		defaultMessage: 'Upload additional file',
+	},
+	uploadPrimaryPrompt: {
+		id: 'create-project-version.create-modal.stage.add-files.upload-primary-prompt',
+		defaultMessage: 'Upload primary and supporting files',
+	},
+	uploadSecondaryPrompt: {
+		id: 'create-project-version.create-modal.stage.add-files.upload-secondary-prompt',
+		defaultMessage: 'Drag and drop files or click to browse',
+	},
+	primaryFileLabel: {
+		id: 'create-project-version.create-modal.stage.add-files.primary-file-label',
+		defaultMessage: 'Primary file',
+	},
+	primaryFileDescription: {
+		id: 'create-project-version.create-modal.stage.add-files.primary-file-description',
+		defaultMessage: 'The primary file is the default file a user downloads when installing the project.',
+	},
+	supplementaryFilesLabel: {
+		id: 'create-project-version.create-modal.stage.add-files.supplementary-files-label',
+		defaultMessage: 'Supplementary files',
+	},
+	supplementaryFilesDescription: {
+		id: 'create-project-version.create-modal.stage.add-files.supplementary-files-description',
+		defaultMessage:
+			'You can optionally add supplementary files such as source code, documentation, or required resource packs.',
+	},
+	metadataTab: {
+		id: 'create-project-version.create-modal.stage.add-files.metadata-tab',
+		defaultMessage: 'Metadata',
+	},
+	detailsTab: {
+		id: 'create-project-version.create-modal.stage.add-files.details-tab',
+		defaultMessage: 'Details',
+	},
+	filesTab: {
+		id: 'create-project-version.create-modal.stage.add-files.files-tab',
+		defaultMessage: 'Files',
 	},
 })
 </script>

--- a/apps/frontend/src/components/ui/create-project-version/stages/AddFilesStage.vue
+++ b/apps/frontend/src/components/ui/create-project-version/stages/AddFilesStage.vue
@@ -196,7 +196,8 @@ const messages = defineMessages({
 	},
 	primaryFileDescription: {
 		id: 'create-project-version.create-modal.stage.add-files.primary-file-description',
-		defaultMessage: 'The primary file is the default file a user downloads when installing the project.',
+		defaultMessage:
+			'The primary file is the default file a user downloads when installing the project.',
 	},
 	supplementaryFilesLabel: {
 		id: 'create-project-version.create-modal.stage.add-files.supplementary-files-label',

--- a/apps/frontend/src/components/ui/create-project-version/stages/DetailsStage.vue
+++ b/apps/frontend/src/components/ui/create-project-version/stages/DetailsStage.vue
@@ -9,7 +9,7 @@
 	<div class="flex w-full flex-col gap-6">
 		<div class="flex flex-col gap-2">
 			<span class="font-semibold text-contrast">
-				Version type <span class="text-red">*</span>
+				{{ formatMessage(messages.versionType) }} <span class="text-red">*</span>
 			</span>
 			<Chips
 				v-model="draftVersion.version_type"
@@ -22,31 +22,31 @@
 		</div>
 		<div class="flex flex-col gap-2">
 			<span class="font-semibold text-contrast">
-				Version number <span class="text-red">*</span>
+				{{ formatMessage(messages.versionNumber) }} <span class="text-red">*</span>
 			</span>
 			<StyledInput
 				id="version-number"
 				v-model="draftVersion.version_number"
 				:disabled="isUploading"
-				placeholder="Enter version number, e.g. 1.2.3-alpha.1"
+				:placeholder="formatMessage(messages.versionNumberPlaceholder)"
 				autocomplete="off"
 				:maxlength="32"
 			/>
-			<span> The version number differentiates this specific version from others. </span>
+			<span>{{ formatMessage(messages.versionNumberDescription) }}</span>
 		</div>
 		<div class="flex flex-col gap-2">
-			<span class="font-semibold text-contrast"> Version subtitle </span>
+			<span class="font-semibold text-contrast">{{ formatMessage(messages.versionSubtitle) }}</span>
 			<StyledInput
 				id="version-number"
 				v-model="draftVersion.name"
-				placeholder="Enter subtitle..."
+				:placeholder="formatMessage(messages.versionSubtitlePlaceholder)"
 				autocomplete="off"
 				:maxlength="256"
 				:disabled="isUploading"
 			/>
 		</div>
 		<div class="flex flex-col gap-2">
-			<span class="font-semibold text-contrast"> Version changelog </span>
+			<span class="font-semibold text-contrast">{{ formatMessage(messages.versionChangelog) }}</span>
 
 			<div class="w-full">
 				<MarkdownEditor
@@ -61,18 +61,70 @@
 </template>
 
 <script lang="ts" setup>
-import { Chips, MarkdownEditor, StyledInput, Tabs, type TabsTab } from '@modrinth/ui'
+import {
+	Chips,
+	defineMessages,
+	MarkdownEditor,
+	StyledInput,
+	Tabs,
+	type TabsTab,
+	useVIntl,
+} from '@modrinth/ui'
 
 import { useImageUpload } from '~/composables/image-upload.ts'
 import { injectManageVersionContext } from '~/providers/version/manage-version-modal'
 
 const { draftVersion, isUploading, editingVersion, modal } = injectManageVersionContext()
+const { formatMessage } = useVIntl()
 
-const editTabs: TabsTab[] = [
-	{ label: 'Metadata', value: 'metadata' },
-	{ label: 'Details', value: 'add-details' },
-	{ label: 'Files', value: 'add-files' },
-]
+const messages = defineMessages({
+	versionType: {
+		id: 'create-project-version.create-modal.stage.details.version-type',
+		defaultMessage: 'Version type',
+	},
+	versionNumber: {
+		id: 'create-project-version.create-modal.stage.details.version-number',
+		defaultMessage: 'Version number',
+	},
+	versionNumberPlaceholder: {
+		id: 'create-project-version.create-modal.stage.details.version-number-placeholder',
+		defaultMessage: 'Enter version number, e.g. 1.2.3-alpha.1',
+	},
+	versionNumberDescription: {
+		id: 'create-project-version.create-modal.stage.details.version-number-description',
+		defaultMessage: 'The version number differentiates this specific version from others.',
+	},
+	versionSubtitle: {
+		id: 'create-project-version.create-modal.stage.details.version-subtitle',
+		defaultMessage: 'Version subtitle',
+	},
+	versionSubtitlePlaceholder: {
+		id: 'create-project-version.create-modal.stage.details.version-subtitle-placeholder',
+		defaultMessage: 'Enter subtitle...',
+	},
+	versionChangelog: {
+		id: 'create-project-version.create-modal.stage.details.version-changelog',
+		defaultMessage: 'Version changelog',
+	},
+	metadataTab: {
+		id: 'create-project-version.create-modal.stage.details.metadata-tab',
+		defaultMessage: 'Metadata',
+	},
+	detailsTab: {
+		id: 'create-project-version.create-modal.stage.details.details-tab',
+		defaultMessage: 'Details',
+	},
+	filesTab: {
+		id: 'create-project-version.create-modal.stage.details.files-tab',
+		defaultMessage: 'Files',
+	},
+})
+
+const editTabs = computed<TabsTab[]>(() => [
+	{ label: formatMessage(messages.metadataTab), value: 'metadata' },
+	{ label: formatMessage(messages.detailsTab), value: 'add-details' },
+	{ label: formatMessage(messages.filesTab), value: 'add-files' },
+])
 
 function setEditTab(tab: TabsTab) {
 	modal.value?.setStage(tab.value)

--- a/apps/frontend/src/components/ui/create-project-version/stages/DetailsStage.vue
+++ b/apps/frontend/src/components/ui/create-project-version/stages/DetailsStage.vue
@@ -46,7 +46,9 @@
 			/>
 		</div>
 		<div class="flex flex-col gap-2">
-			<span class="font-semibold text-contrast">{{ formatMessage(messages.versionChangelog) }}</span>
+			<span class="font-semibold text-contrast">{{
+				formatMessage(messages.versionChangelog)
+			}}</span>
 
 			<div class="w-full">
 				<MarkdownEditor

--- a/apps/frontend/src/components/ui/create-project-version/stages/MetadataStage.vue
+++ b/apps/frontend/src/components/ui/create-project-version/stages/MetadataStage.vue
@@ -9,12 +9,12 @@
 	<div class="flex flex-col gap-6">
 		<div v-if="!editingVersion" class="flex flex-col gap-1">
 			<div class="flex items-center justify-between">
-				<span class="font-semibold text-contrast"> Uploaded files </span>
+				<span class="font-semibold text-contrast">{{ formatMessage(messages.uploadedFiles) }}</span>
 
 				<ButtonStyled type="transparent" size="standard">
 					<button @click="editFiles">
 						<EditIcon />
-						Edit
+						{{ formatMessage(messages.editButton) }}
 					</button>
 				</ButtonStyled>
 			</div>
@@ -43,23 +43,27 @@
 		<div class="flex flex-col gap-1">
 			<div class="flex items-center justify-between">
 				<span class="font-semibold text-contrast">
-					{{ usingDetectedLoaders ? 'Detected loaders' : 'Loaders' }}
+					{{
+						usingDetectedLoaders
+							? formatMessage(messages.detectedLoaders)
+							: formatMessage(messages.loaders)
+					}}
 				</span>
 
 				<ButtonStyled type="transparent" size="standard">
 					<button
 						v-tooltip="
 							isModpack
-								? 'Modpack loaders cannot be edited'
+								? formatMessage(messages.modpackLoadersTooltip)
 								: isResourcePack
-									? 'Resource pack loaders cannot be edited'
+									? formatMessage(messages.resourcePackLoadersTooltip)
 									: undefined
 						"
 						:disabled="isModpack || isResourcePack"
 						@click="editLoaders"
 					>
 						<EditIcon />
-						Edit
+						{{ formatMessage(messages.editButton) }}
 					</button>
 				</ButtonStyled>
 			</div>
@@ -88,9 +92,11 @@
 						v-if="!draftVersionLoaders.length && projectType === 'modpack'"
 						class="border !border-solid border-surface-5 hover:no-underline"
 					>
-						No mod loader
+						{{ formatMessage(messages.noModLoader) }}
 					</TagItem>
-					<span v-else-if="!draftVersionLoaders.length">No loaders selected.</span>
+					<span v-else-if="!draftVersionLoaders.length">{{
+						formatMessage(messages.noLoadersSelected)
+					}}</span>
 				</div>
 			</div>
 		</div>
@@ -98,17 +104,21 @@
 		<div class="flex flex-col gap-1">
 			<div class="flex items-center justify-between">
 				<span class="font-semibold text-contrast">
-					{{ usingDetectedVersions ? 'Detected versions' : 'Versions' }}
+					{{
+						usingDetectedVersions
+							? formatMessage(messages.detectedVersions)
+							: formatMessage(messages.versions)
+					}}
 				</span>
 
 				<ButtonStyled type="transparent" size="standard">
 					<button
-						v-tooltip="isModpack ? 'Modpack versions cannot be edited' : undefined"
+						v-tooltip="isModpack ? formatMessage(messages.modpackVersionsTooltip) : undefined"
 						:disabled="isModpack"
 						@click="editVersions"
 					>
 						<EditIcon />
-						Edit
+						{{ formatMessage(messages.editButton) }}
 					</button>
 				</ButtonStyled>
 			</div>
@@ -125,7 +135,9 @@
 						{{ version }}
 					</TagItem>
 
-					<span v-if="!draftVersion.game_versions.length">No versions selected.</span>
+					<span v-if="!draftVersion.game_versions.length">{{
+						formatMessage(messages.noVersionsSelected)
+					}}</span>
 				</div>
 			</div>
 		</div>
@@ -134,14 +146,16 @@
 			<div class="flex flex-col gap-1">
 				<div class="flex items-center justify-between">
 					<div class="flex items-center gap-2">
-						<span class="font-semibold text-contrast"> Environment </span>
-						<UnknownIcon v-tooltip="'Pre-filled from a previous similar version'" />
+						<span class="font-semibold text-contrast">{{
+							formatMessage(messages.environment)
+						}}</span>
+						<UnknownIcon v-tooltip="formatMessage(messages.prefilledEnvironmentTooltip)" />
 					</div>
 
 					<ButtonStyled type="transparent" size="standard">
 						<button @click="editEnvironment">
 							<EditIcon />
-							Edit
+							{{ formatMessage(messages.editButton) }}
 						</button>
 					</ButtonStyled>
 				</div>
@@ -154,7 +168,9 @@
 						<div class="text-sm font-medium">{{ environmentCopy.description }}</div>
 					</div>
 
-					<span v-else class="text-sm font-medium">No environment has been set.</span>
+					<span v-else class="text-sm font-medium">{{
+						formatMessage(messages.noEnvironmentSet)
+					}}</span>
 				</div>
 			</div>
 		</template>
@@ -163,12 +179,14 @@
 			<div class="flex flex-col gap-2.5">
 				<div class="flex flex-col gap-1">
 					<div class="flex items-center justify-between">
-						<span class="font-semibold text-contrast"> Dependencies </span>
+						<span class="font-semibold text-contrast">{{
+							formatMessage(messages.dependencies)
+						}}</span>
 
 						<ButtonStyled type="transparent" size="standard">
 							<button @click="addDependency">
 								<PlusIcon />
-								Add dependency
+								{{ formatMessage(messages.addDependency) }}
 							</button>
 						</ButtonStyled>
 					</div>
@@ -177,13 +195,13 @@
 						<DependenciesList />
 					</div>
 					<div v-else class="flex flex-col gap-1.5 gap-y-4 rounded-xl bg-surface-2 p-3 py-4">
-						<span class="text-sm font-medium">No dependencies added.</span>
+						<span class="text-sm font-medium">{{ formatMessage(messages.noDependenciesAdded) }}</span>
 					</div>
 				</div>
 
 				<div v-if="visibleSuggestedDependencies.length" class="flex flex-col gap-2.5">
 					<div class="flex items-center justify-between">
-						<span class="font-medium"> Suggested </span>
+						<span class="font-medium">{{ formatMessage(messages.suggested) }}</span>
 					</div>
 					<SuggestedDependencies @on-add-suggestion="handleAddSuggestedDependency" />
 				</div>
@@ -231,11 +249,11 @@ const { projectV2 } = injectProjectPageContext()
 const generatedState = useGeneratedState()
 const loaders = computed(() => generatedState.value.loaders)
 
-const editTabs: TabsTab[] = [
-	{ label: 'Metadata', value: 'metadata' },
-	{ label: 'Details', value: 'add-details' },
-	{ label: 'Files', value: 'add-files' },
-]
+const editTabs = computed<TabsTab[]>(() => [
+	{ label: formatMessage(messages.metadataTab), value: 'metadata' },
+	{ label: formatMessage(messages.detailsTab), value: 'add-details' },
+	{ label: formatMessage(messages.filesTab), value: 'add-files' },
+])
 
 function setEditTab(tab: TabsTab) {
 	modal.value?.setStage(tab.value)
@@ -340,6 +358,97 @@ const supplementaryExistingFiles = computed(() => {
 })
 
 const { formatMessage } = useVIntl()
+
+const messages = defineMessages({
+	uploadedFiles: {
+		id: 'create-project-version.create-modal.stage.metadata.uploaded-files',
+		defaultMessage: 'Uploaded files',
+	},
+	editButton: {
+		id: 'create-project-version.create-modal.stage.metadata.edit-button',
+		defaultMessage: 'Edit',
+	},
+	detectedLoaders: {
+		id: 'create-project-version.create-modal.stage.metadata.detected-loaders',
+		defaultMessage: 'Detected loaders',
+	},
+	loaders: {
+		id: 'create-project-version.create-modal.stage.metadata.loaders',
+		defaultMessage: 'Loaders',
+	},
+	modpackLoadersTooltip: {
+		id: 'create-project-version.create-modal.stage.metadata.modpack-loaders-tooltip',
+		defaultMessage: 'Modpack loaders cannot be edited',
+	},
+	resourcePackLoadersTooltip: {
+		id: 'create-project-version.create-modal.stage.metadata.resource-pack-loaders-tooltip',
+		defaultMessage: 'Resource pack loaders cannot be edited',
+	},
+	noModLoader: {
+		id: 'create-project-version.create-modal.stage.metadata.no-mod-loader',
+		defaultMessage: 'No mod loader',
+	},
+	noLoadersSelected: {
+		id: 'create-project-version.create-modal.stage.metadata.no-loaders-selected',
+		defaultMessage: 'No loaders selected.',
+	},
+	detectedVersions: {
+		id: 'create-project-version.create-modal.stage.metadata.detected-versions',
+		defaultMessage: 'Detected versions',
+	},
+	versions: {
+		id: 'create-project-version.create-modal.stage.metadata.versions',
+		defaultMessage: 'Versions',
+	},
+	modpackVersionsTooltip: {
+		id: 'create-project-version.create-modal.stage.metadata.modpack-versions-tooltip',
+		defaultMessage: 'Modpack versions cannot be edited',
+	},
+	noVersionsSelected: {
+		id: 'create-project-version.create-modal.stage.metadata.no-versions-selected',
+		defaultMessage: 'No versions selected.',
+	},
+	environment: {
+		id: 'create-project-version.create-modal.stage.metadata.environment',
+		defaultMessage: 'Environment',
+	},
+	prefilledEnvironmentTooltip: {
+		id: 'create-project-version.create-modal.stage.metadata.prefilled-environment-tooltip',
+		defaultMessage: 'Pre-filled from a previous similar version',
+	},
+	noEnvironmentSet: {
+		id: 'create-project-version.create-modal.stage.metadata.no-environment-set',
+		defaultMessage: 'No environment has been set.',
+	},
+	dependencies: {
+		id: 'create-project-version.create-modal.stage.metadata.dependencies',
+		defaultMessage: 'Dependencies',
+	},
+	addDependency: {
+		id: 'create-project-version.create-modal.stage.metadata.add-dependency',
+		defaultMessage: 'Add dependency',
+	},
+	noDependenciesAdded: {
+		id: 'create-project-version.create-modal.stage.metadata.no-dependencies-added',
+		defaultMessage: 'No dependencies added.',
+	},
+	suggested: {
+		id: 'create-project-version.create-modal.stage.metadata.suggested',
+		defaultMessage: 'Suggested',
+	},
+	metadataTab: {
+		id: 'create-project-version.create-modal.stage.metadata.metadata-tab',
+		defaultMessage: 'Metadata',
+	},
+	detailsTab: {
+		id: 'create-project-version.create-modal.stage.metadata.details-tab',
+		defaultMessage: 'Details',
+	},
+	filesTab: {
+		id: 'create-project-version.create-modal.stage.metadata.files-tab',
+		defaultMessage: 'Files',
+	},
+})
 
 const noEnvironmentMessage = defineMessages({
 	title: {

--- a/apps/frontend/src/components/ui/create-project-version/stages/MetadataStage.vue
+++ b/apps/frontend/src/components/ui/create-project-version/stages/MetadataStage.vue
@@ -195,7 +195,9 @@
 						<DependenciesList />
 					</div>
 					<div v-else class="flex flex-col gap-1.5 gap-y-4 rounded-xl bg-surface-2 p-3 py-4">
-						<span class="text-sm font-medium">{{ formatMessage(messages.noDependenciesAdded) }}</span>
+						<span class="text-sm font-medium">{{
+							formatMessage(messages.noDependenciesAdded)
+						}}</span>
 					</div>
 				</div>
 

--- a/apps/frontend/src/components/ui/create/ProjectCreateModal.vue
+++ b/apps/frontend/src/components/ui/create/ProjectCreateModal.vue
@@ -246,6 +246,18 @@ const messages = defineMessages({
 		id: 'create.project.missing-fields-tooltip',
 		defaultMessage: 'Missing fields: {fields}',
 	},
+	unknownUser: {
+		id: 'create.project.unknown-user',
+		defaultMessage: 'Unknown user',
+	},
+	userAvatarAlt: {
+		id: 'create.project.user-avatar-alt',
+		defaultMessage: 'User Avatar',
+	},
+	organizationIconAlt: {
+		id: 'create.project.organization-icon-alt',
+		defaultMessage: '{name} Icon',
+	},
 })
 
 const props = defineProps<{
@@ -318,7 +330,7 @@ const cancel = () => {
 
 const userOption = computed(() => ({
 	value: 'self',
-	label: auth.value.user?.username || 'Unknown user',
+	label: auth.value.user?.username || formatMessage(messages.unknownUser),
 	icon: auth.value.user?.avatar_url
 		? markRaw(
 				defineAsyncComponent(() =>
@@ -326,7 +338,7 @@ const userOption = computed(() => ({
 						setup: () => () =>
 							h('img', {
 								src: auth.value.user?.avatar_url,
-								alt: 'User Avatar',
+								alt: formatMessage(messages.userAvatarAlt),
 								class: 'h-5 w-5 rounded-full',
 							}),
 					}),
@@ -357,7 +369,7 @@ async function fetchOrganizations() {
 								setup: () => () =>
 									h('img', {
 										src: org.icon_url,
-										alt: `${org.name} Icon`,
+										alt: formatMessage(messages.organizationIconAlt, { name: org.name }),
 										class: 'h-5 w-5 rounded',
 									}),
 							}),

--- a/apps/frontend/src/components/ui/dashboard/CreatorTaxFormModal.vue
+++ b/apps/frontend/src/components/ui/dashboard/CreatorTaxFormModal.vue
@@ -137,7 +137,9 @@
 				</div>
 				<div class="flex w-full flex-row justify-stretch gap-2">
 					<ButtonStyled>
-						<button class="w-full text-contrast" @click="handleClose">{{ closeButtonText }}</button>
+						<button class="w-full text-contrast" @click="handleClose">
+							{{ props.closeButtonText ?? formatMessage(messages.closeButton) }}
+						</button>
 					</ButtonStyled>
 					<ButtonStyled color="green">
 						<button class="w-full text-contrast" @click="downloadTaxForm">
@@ -182,7 +184,7 @@ const props = withDefaults(
 		emitSuccessOnClose?: boolean
 	}>(),
 	{
-		closeButtonText: 'Close',
+		closeButtonText: undefined,
 		emitSuccessOnClose: true,
 	},
 )
@@ -267,6 +269,18 @@ const messages = defineMessages({
 	downloadButton: {
 		id: 'dashboard.creator-tax-form-modal.confirmation.download-button',
 		defaultMessage: 'Download {formType}',
+	},
+	closeButton: {
+		id: 'dashboard.creator-tax-form-modal.close-button',
+		defaultMessage: 'Close',
+	},
+	incompleteTitle: {
+		id: 'dashboard.creator-tax-form-modal.incomplete.title',
+		defaultMessage: 'Tax form incomplete',
+	},
+	incompleteText: {
+		id: 'dashboard.creator-tax-form-modal.incomplete.text',
+		defaultMessage: 'You have not completed the tax form. Please try again.',
 	},
 })
 
@@ -371,8 +385,8 @@ async function continueForm() {
 			}
 
 			addNotification({
-				title: 'Tax form incomplete',
-				text: 'You have not completed the tax form. Please try again.',
+				title: formatMessage(messages.incompleteTitle),
+				text: formatMessage(messages.incompleteText),
 				type: 'warning',
 			})
 		}

--- a/apps/frontend/src/components/ui/dashboard/CreatorWithdrawModal.vue
+++ b/apps/frontend/src/components/ui/dashboard/CreatorWithdrawModal.vue
@@ -54,7 +54,7 @@
 			<MuralpayDetailsStage v-else-if="currentStage === 'muralpay-details'" />
 			<LegacyPaypalDetailsStage v-else-if="currentStage === 'paypal-details'" />
 			<CompletionStage v-else-if="currentStage === 'completion'" />
-			<div v-else>Something went wrong</div>
+			<div v-else>{{ formatMessage(commonMessages.errorNotificationTitle) }}</div>
 		</div>
 		<template #actions>
 			<div v-if="currentStage === 'completion'" class="mt-4 flex w-full gap-3">
@@ -96,7 +96,7 @@
 	</NewModal>
 	<CreatorTaxFormModal
 		ref="taxFormModal"
-		close-button-text="Continue"
+		:close-button-text="formatMessage(commonMessages.continueButton)"
 		@success="onTaxFormSuccess"
 		@cancelled="onTaxFormCancelled"
 	/>

--- a/apps/frontend/src/components/ui/dashboard/withdraw-stages/MuralpayKycStage.vue
+++ b/apps/frontend/src/components/ui/dashboard/withdraw-stages/MuralpayKycStage.vue
@@ -99,7 +99,7 @@
 						v-model="formData.dateOfBirth"
 						:max-date="maxDate"
 						autocomplete="bday"
-						placeholder="Select date of birth"
+						:placeholder="formatMessage(messages.dateOfBirthPlaceholder)"
 						wrapper-class="w-full"
 					/>
 				</div>
@@ -162,7 +162,7 @@
 						:options="subdivisionOptions"
 						:placeholder="formatMessage(formFieldPlaceholders.statePlaceholder)"
 						searchable
-						search-placeholder="Search subdivisions..."
+						:search-placeholder="formatMessage(messages.searchSubdivisionsPlaceholder)"
 					/>
 					<StyledInput
 						v-else
@@ -201,7 +201,7 @@
 						:options="countryOptions"
 						:placeholder="formatMessage(formFieldPlaceholders.countryPlaceholder)"
 						searchable
-						search-placeholder="Search countries..."
+						:search-placeholder="formatMessage(messages.searchCountriesPlaceholder)"
 					/>
 				</div>
 			</div>
@@ -360,6 +360,18 @@ const messages = defineMessages({
 	businessEntity: {
 		id: 'dashboard.creator-withdraw-modal.kyc.business-entity',
 		defaultMessage: 'Business entity',
+	},
+	dateOfBirthPlaceholder: {
+		id: 'dashboard.creator-withdraw-modal.kyc.date-of-birth-placeholder',
+		defaultMessage: 'Select date of birth',
+	},
+	searchSubdivisionsPlaceholder: {
+		id: 'dashboard.creator-withdraw-modal.kyc.search-subdivisions-placeholder',
+		defaultMessage: 'Search subdivisions...',
+	},
+	searchCountriesPlaceholder: {
+		id: 'dashboard.creator-withdraw-modal.kyc.search-countries-placeholder',
+		defaultMessage: 'Search countries...',
 	},
 })
 </script>

--- a/apps/frontend/src/components/ui/dashboard/withdraw-stages/TremendousDetailsStage.vue
+++ b/apps/frontend/src/components/ui/dashboard/withdraw-stages/TremendousDetailsStage.vue
@@ -58,7 +58,11 @@
 				<Combobox
 					v-model="selectedGiftCardId"
 					:options="rewardOptions"
-					:placeholder="formatMessage(messages.selectCategoryPlaceholder, { category: categoryLabel.toLowerCase() })"
+					:placeholder="
+						formatMessage(messages.selectCategoryPlaceholder, {
+							category: categoryLabel.toLowerCase(),
+						})
+					"
 					searchable
 					:search-placeholder="
 						formatMessage(messages.searchCategoryPlaceholder, {

--- a/apps/frontend/src/components/ui/dashboard/withdraw-stages/TremendousDetailsStage.vue
+++ b/apps/frontend/src/components/ui/dashboard/withdraw-stages/TremendousDetailsStage.vue
@@ -58,9 +58,13 @@
 				<Combobox
 					v-model="selectedGiftCardId"
 					:options="rewardOptions"
-					:placeholder="`Select ${categoryLabel.toLowerCase()}`"
+					:placeholder="formatMessage(messages.selectCategoryPlaceholder, { category: categoryLabel.toLowerCase() })"
 					searchable
-					:search-placeholder="`Search ${categoryLabelPlural.toLowerCase()}...`"
+					:search-placeholder="
+						formatMessage(messages.searchCategoryPlaceholder, {
+							category: categoryLabelPlural.toLowerCase(),
+						})
+					"
 					class="h-10"
 				>
 					<template #selected>
@@ -90,47 +94,21 @@
 				</Combobox>
 			</div>
 			<span v-if="selectedMethodDetails" class="text-secondary">
-				{{ formatMoney(displayMinUsd)
-				}}<template v-if="selectedMethodCurrencyCode && selectedMethodCurrencyCode !== 'USD'"
-					>({{
-						formatAmountForDisplay(
-							displayMinLocal,
-							selectedMethodCurrencyCode,
-							selectedMethodExchangeRate,
-						)
-					}})</template
-				>
-				min<template v-if="displayMinUsd <= roundedMaxAmount"
-					>, {{ formatMoney(displayMaxUsd)
-					}}<template v-if="selectedMethodCurrencyCode && selectedMethodCurrencyCode !== 'USD'"
-						>({{
-							formatAmountForDisplay(
-								displayMaxLocal,
-								selectedMethodCurrencyCode,
-								selectedMethodExchangeRate,
-							)
-						}})</template
-					>
-					max</template
-				>
-				withdrawal amount.
+				<template v-if="displayMinUsd <= roundedMaxAmount">{{
+					formatMessage(messages.withdrawalAmountMinMax, {
+						min: minAmountDisplay,
+						max: maxAmountDisplay,
+					})
+				}}</template>
+				<template v-else>{{
+					formatMessage(messages.withdrawalAmountMinOnly, { min: minAmountDisplay })
+				}}</template>
 			</span>
 			<span
 				v-if="selectedMethodDetails && effectiveMinAmount > roundedMaxAmount"
 				class="text-sm text-red"
 			>
-				You need at least
-				{{ formatMoney(displayMinUsd)
-				}}<template v-if="selectedMethodCurrencyCode && selectedMethodCurrencyCode !== 'USD'"
-					>({{
-						formatAmountForDisplay(
-							displayMinLocal,
-							selectedMethodCurrencyCode,
-							selectedMethodExchangeRate,
-						)
-					}})</template
-				>
-				to use this gift card.
+				{{ formatMessage(messages.needAtLeastGiftCard, { min: minAmountDisplay }) }}
 			</span>
 		</div>
 
@@ -280,19 +258,13 @@
 					v-if="!useDenominationSuggestions && denominationOptions.length === 0"
 					class="text-error text-sm"
 				>
-					<template v-if="rawFixedDenominationMin !== null">
-						The minimum denomination is
-						{{
-							formatAmountForDisplay(
-								rawFixedDenominationMin,
-								selectedMethodCurrencyCode,
-								selectedMethodExchangeRate,
-							)
-						}}<template v-if="selectedMethodCurrencyCode && selectedMethodCurrencyCode !== 'USD'">
-							({{ formatMoney(convertToUsd(rawFixedDenominationMin)) }})</template
-						>, which exceeds your balance of {{ formatMoney(roundedMaxAmount) }}.
-					</template>
-					<template v-else>No denominations available for your current balance</template>
+					<template v-if="rawFixedDenominationMin !== null">{{
+						formatMessage(messages.minimumDenominationExceedsBalance, {
+							min: minDenominationDisplay,
+							balance: formatMoney(roundedMaxAmount),
+						})
+					}}</template>
+					<template v-else>{{ formatMessage(messages.noDenominationsAvailable) }}</template>
 				</span>
 			</div>
 
@@ -683,11 +655,48 @@ const noSuggestionsMessage = computed(() => {
 				selectedMethodCurrencyCode.value,
 				selectedMethodExchangeRate.value,
 			)
-			return `No denominations near this amount. The highest available is ${maxInLocal}.`
+			return formatMessage(messages.noSuggestionsWithMax, { max: maxInLocal })
 		}
-		return 'No denominations near this amount'
+		return formatMessage(messages.noSuggestionsNoMax)
 	}
 	return null
+})
+
+const minAmountDisplay = computed(() => {
+	const base = formatMoney(displayMinUsd.value)
+	if (selectedMethodCurrencyCode.value && selectedMethodCurrencyCode.value !== 'USD') {
+		return `${base} (${formatAmountForDisplay(
+			displayMinLocal.value,
+			selectedMethodCurrencyCode.value,
+			selectedMethodExchangeRate.value,
+		)})`
+	}
+	return base
+})
+
+const maxAmountDisplay = computed(() => {
+	const base = formatMoney(displayMaxUsd.value)
+	if (selectedMethodCurrencyCode.value && selectedMethodCurrencyCode.value !== 'USD') {
+		return `${base} (${formatAmountForDisplay(
+			displayMaxLocal.value,
+			selectedMethodCurrencyCode.value,
+			selectedMethodExchangeRate.value,
+		)})`
+	}
+	return base
+})
+
+const minDenominationDisplay = computed(() => {
+	if (rawFixedDenominationMin.value === null) return ''
+	const local = formatAmountForDisplay(
+		rawFixedDenominationMin.value,
+		selectedMethodCurrencyCode.value,
+		selectedMethodExchangeRate.value,
+	)
+	if (selectedMethodCurrencyCode.value && selectedMethodCurrencyCode.value !== 'USD') {
+		return `${local} (${formatMoney(convertToUsd(rawFixedDenominationMin.value))})`
+	}
+	return local
 })
 
 const hasSelectedDenomination = computed(() => {
@@ -1123,6 +1132,42 @@ const messages = defineMessages({
 	selectDenominationRequired: {
 		id: 'dashboard.creator-withdraw-modal.tremendous-details.select-denomination-required',
 		defaultMessage: 'Please select a denomination to continue',
+	},
+	selectCategoryPlaceholder: {
+		id: 'dashboard.creator-withdraw-modal.tremendous-details.select-category-placeholder',
+		defaultMessage: 'Select {category}',
+	},
+	searchCategoryPlaceholder: {
+		id: 'dashboard.creator-withdraw-modal.tremendous-details.search-category-placeholder',
+		defaultMessage: 'Search {category}...',
+	},
+	withdrawalAmountMinMax: {
+		id: 'dashboard.creator-withdraw-modal.tremendous-details.withdrawal-amount-min-max',
+		defaultMessage: '{min} min, {max} max withdrawal amount.',
+	},
+	withdrawalAmountMinOnly: {
+		id: 'dashboard.creator-withdraw-modal.tremendous-details.withdrawal-amount-min-only',
+		defaultMessage: '{min} min withdrawal amount.',
+	},
+	needAtLeastGiftCard: {
+		id: 'dashboard.creator-withdraw-modal.tremendous-details.need-at-least-gift-card',
+		defaultMessage: 'You need at least {min} to use this gift card.',
+	},
+	minimumDenominationExceedsBalance: {
+		id: 'dashboard.creator-withdraw-modal.tremendous-details.minimum-denomination-exceeds-balance',
+		defaultMessage: 'The minimum denomination is {min}, which exceeds your balance of {balance}.',
+	},
+	noDenominationsAvailable: {
+		id: 'dashboard.creator-withdraw-modal.tremendous-details.no-denominations-available',
+		defaultMessage: 'No denominations available for your current balance',
+	},
+	noSuggestionsWithMax: {
+		id: 'dashboard.creator-withdraw-modal.tremendous-details.no-suggestions-with-max',
+		defaultMessage: 'No denominations near this amount. The highest available is {max}.',
+	},
+	noSuggestionsNoMax: {
+		id: 'dashboard.creator-withdraw-modal.tremendous-details.no-suggestions-no-max',
+		defaultMessage: 'No denominations near this amount',
 	},
 })
 </script>

--- a/apps/frontend/src/components/ui/servers/marketing/ServerPlanSelector.vue
+++ b/apps/frontend/src/components/ui/servers/marketing/ServerPlanSelector.vue
@@ -27,10 +27,14 @@ const messages = defineMessages({
 		id: 'hosting.plan.select-plan',
 		defaultMessage: 'Select plan',
 	},
-	billedInterval: {
-		id: 'servers.purchase.step.plan.billed',
+	perMonthBilling: {
+		id: 'servers.purchase.step.plan.per-month-billing',
 		defaultMessage:
-			'billed {interval, select, monthly {monthly} quarterly {quarterly} yearly {yearly} other {{interval}}}',
+			'/ month{interval, select, monthly {} other {, billed {interval, select, quarterly {quarterly} yearly {yearly} other {{interval}}}}}',
+	},
+	mostPopularBadge: {
+		id: 'servers.purchase.step.plan.most-popular',
+		defaultMessage: 'Most popular',
 	},
 })
 
@@ -131,15 +135,13 @@ const billingMonths = computed(() => {
 						v-if="plans[plan].mostPopular"
 						class="rounded-full bg-brand-highlight px-2 py-1 text-xs font-bold text-brand"
 					>
-						Most popular
+						{{ formatMessage(messages.mostPopularBadge) }}
 					</div>
 				</div>
 				<span class="m-0 text-2xl font-bold text-contrast">
 					{{ formatPrice(price / billingMonths, currency, true) }}
 					<span class="text-lg font-semibold text-secondary">
-						/ month<template v-if="interval !== 'monthly'"
-							>, {{ formatMessage(messages.billedInterval, { interval }) }}</template
-						>
+						{{ formatMessage(messages.perMonthBilling, { interval }) }}
 					</span>
 				</span>
 				<p class="m-0 max-w-[18rem]">{{ formatMessage(plans[plan].description) }}</p>

--- a/apps/frontend/src/locales/de-CH/index.json
+++ b/apps/frontend/src/locales/de-CH/index.json
@@ -4067,9 +4067,6 @@
   "servers.plan.small.description": {
     "message": "Perfekt für 1 - 5 Freunde mit ein par leichten Mods."
   },
-  "servers.purchase.step.plan.billed": {
-    "message": "abgerechnet {interval, select, monthly {monthly} quarterly {quarterly} yearly {yearly} other {{interval}}}"
-  },
   "settings.account.button.complete-setup": {
     "message": "Einrichtung abschliessen"
   },

--- a/apps/frontend/src/locales/de-DE/index.json
+++ b/apps/frontend/src/locales/de-DE/index.json
@@ -4067,9 +4067,6 @@
   "servers.plan.small.description": {
     "message": "Perfekt für 1–5 Freunde mit ein paar kleinen Mods."
   },
-  "servers.purchase.step.plan.billed": {
-    "message": "{interval, select, monthly {monatlich} quarterly {vierteljährlich} yearly {jährlich} other {{interval}}} abgerechnet"
-  },
   "settings.account.button.complete-setup": {
     "message": "Einrichtung abschließen"
   },

--- a/apps/frontend/src/locales/en-US/index.json
+++ b/apps/frontend/src/locales/en-US/index.json
@@ -251,6 +251,9 @@
   "analytics.empty.select-project": {
     "message": "Select at least one project to view data"
   },
+  "analytics.filter.dependent-project-search-failed-title": {
+    "message": "Dependent projects failed to load"
+  },
   "analytics.filter.game-version-type": {
     "message": "Game version type"
   },
@@ -947,6 +950,12 @@
   "auth.verify-email.title": {
     "message": "Verify Email"
   },
+  "collection.aria-label.upload-icon": {
+    "message": "Upload icon"
+  },
+  "collection.button.discover-mods": {
+    "message": "Discover mods"
+  },
   "collection.button.edit-icon": {
     "message": "Edit icon"
   },
@@ -1121,6 +1130,135 @@
   "create-project-version.create-modal.stage.add-files.admonition": {
     "message": "Supplementary files are for supporting resources like source code, not for alternative versions or variants."
   },
+  "create-project-version.create-modal.stage.add-files.details-tab": {
+    "message": "Details"
+  },
+  "create-project-version.create-modal.stage.add-files.files-tab": {
+    "message": "Files"
+  },
+  "create-project-version.create-modal.stage.add-files.metadata-tab": {
+    "message": "Metadata"
+  },
+  "create-project-version.create-modal.stage.add-files.primary-file-description": {
+    "message": "The primary file is the default file a user downloads when installing the project."
+  },
+  "create-project-version.create-modal.stage.add-files.primary-file-label": {
+    "message": "Primary file"
+  },
+  "create-project-version.create-modal.stage.add-files.supplementary-files-description": {
+    "message": "You can optionally add supplementary files such as source code, documentation, or required resource packs."
+  },
+  "create-project-version.create-modal.stage.add-files.supplementary-files-label": {
+    "message": "Supplementary files"
+  },
+  "create-project-version.create-modal.stage.add-files.upload-additional-file-aria-label": {
+    "message": "Upload additional file"
+  },
+  "create-project-version.create-modal.stage.add-files.upload-file-aria-label": {
+    "message": "Upload file"
+  },
+  "create-project-version.create-modal.stage.add-files.upload-primary-prompt": {
+    "message": "Upload primary and supporting files"
+  },
+  "create-project-version.create-modal.stage.add-files.upload-secondary-prompt": {
+    "message": "Drag and drop files or click to browse"
+  },
+  "create-project-version.create-modal.stage.details.details-tab": {
+    "message": "Details"
+  },
+  "create-project-version.create-modal.stage.details.files-tab": {
+    "message": "Files"
+  },
+  "create-project-version.create-modal.stage.details.metadata-tab": {
+    "message": "Metadata"
+  },
+  "create-project-version.create-modal.stage.details.version-changelog": {
+    "message": "Version changelog"
+  },
+  "create-project-version.create-modal.stage.details.version-number": {
+    "message": "Version number"
+  },
+  "create-project-version.create-modal.stage.details.version-number-description": {
+    "message": "The version number differentiates this specific version from others."
+  },
+  "create-project-version.create-modal.stage.details.version-number-placeholder": {
+    "message": "Enter version number, e.g. 1.2.3-alpha.1"
+  },
+  "create-project-version.create-modal.stage.details.version-subtitle": {
+    "message": "Version subtitle"
+  },
+  "create-project-version.create-modal.stage.details.version-subtitle-placeholder": {
+    "message": "Enter subtitle..."
+  },
+  "create-project-version.create-modal.stage.details.version-type": {
+    "message": "Version type"
+  },
+  "create-project-version.create-modal.stage.metadata.add-dependency": {
+    "message": "Add dependency"
+  },
+  "create-project-version.create-modal.stage.metadata.dependencies": {
+    "message": "Dependencies"
+  },
+  "create-project-version.create-modal.stage.metadata.details-tab": {
+    "message": "Details"
+  },
+  "create-project-version.create-modal.stage.metadata.detected-loaders": {
+    "message": "Detected loaders"
+  },
+  "create-project-version.create-modal.stage.metadata.detected-versions": {
+    "message": "Detected versions"
+  },
+  "create-project-version.create-modal.stage.metadata.edit-button": {
+    "message": "Edit"
+  },
+  "create-project-version.create-modal.stage.metadata.environment": {
+    "message": "Environment"
+  },
+  "create-project-version.create-modal.stage.metadata.files-tab": {
+    "message": "Files"
+  },
+  "create-project-version.create-modal.stage.metadata.loaders": {
+    "message": "Loaders"
+  },
+  "create-project-version.create-modal.stage.metadata.metadata-tab": {
+    "message": "Metadata"
+  },
+  "create-project-version.create-modal.stage.metadata.modpack-loaders-tooltip": {
+    "message": "Modpack loaders cannot be edited"
+  },
+  "create-project-version.create-modal.stage.metadata.modpack-versions-tooltip": {
+    "message": "Modpack versions cannot be edited"
+  },
+  "create-project-version.create-modal.stage.metadata.no-dependencies-added": {
+    "message": "No dependencies added."
+  },
+  "create-project-version.create-modal.stage.metadata.no-environment-set": {
+    "message": "No environment has been set."
+  },
+  "create-project-version.create-modal.stage.metadata.no-loaders-selected": {
+    "message": "No loaders selected."
+  },
+  "create-project-version.create-modal.stage.metadata.no-mod-loader": {
+    "message": "No mod loader"
+  },
+  "create-project-version.create-modal.stage.metadata.no-versions-selected": {
+    "message": "No versions selected."
+  },
+  "create-project-version.create-modal.stage.metadata.prefilled-environment-tooltip": {
+    "message": "Pre-filled from a previous similar version"
+  },
+  "create-project-version.create-modal.stage.metadata.resource-pack-loaders-tooltip": {
+    "message": "Resource pack loaders cannot be edited"
+  },
+  "create-project-version.create-modal.stage.metadata.suggested": {
+    "message": "Suggested"
+  },
+  "create-project-version.create-modal.stage.metadata.uploaded-files": {
+    "message": "Uploaded files"
+  },
+  "create-project-version.create-modal.stage.metadata.versions": {
+    "message": "Versions"
+  },
   "create.collection.collection-info": {
     "message": "Your new collection will be created as a public collection with {count, plural, =0 {no projects} one {# project} other {# projects}}."
   },
@@ -1217,6 +1355,9 @@
   "create.project.name-placeholder": {
     "message": "Enter project name..."
   },
+  "create.project.organization-icon-alt": {
+    "message": "{name} Icon"
+  },
   "create.project.owner-description": {
     "message": "Set the project owner as yourself or an organization you're a member of."
   },
@@ -1247,8 +1388,14 @@
   "create.project.type-server": {
     "message": "Server"
   },
+  "create.project.unknown-user": {
+    "message": "Unknown user"
+  },
   "create.project.url-label": {
     "message": "URL"
+  },
+  "create.project.user-avatar-alt": {
+    "message": "User Avatar"
   },
   "create.project.visibility-description": {
     "message": "The visibility of your project after it has been approved."
@@ -1331,6 +1478,9 @@
   "dashboard.collections.sort.recently-updated": {
     "message": "Recently Updated"
   },
+  "dashboard.creator-tax-form-modal.close-button": {
+    "message": "Close"
+  },
   "dashboard.creator-tax-form-modal.confirmation.download-button": {
     "message": "Download {formType}"
   },
@@ -1357,6 +1507,12 @@
   },
   "dashboard.creator-tax-form-modal.header": {
     "message": "Tax form"
+  },
+  "dashboard.creator-tax-form-modal.incomplete.text": {
+    "message": "You have not completed the tax form. Please try again."
+  },
+  "dashboard.creator-tax-form-modal.incomplete.title": {
+    "message": "Tax form incomplete"
   },
   "dashboard.creator-tax-form-modal.security.description": {
     "message": "Modrinth uses third-party provider Track1099 to securely collect and store your tax forms. <security-link>Learn more here.</security-link>"
@@ -1397,6 +1553,9 @@
   "dashboard.creator-withdraw-modal.kyc.business-entity": {
     "message": "Business entity"
   },
+  "dashboard.creator-withdraw-modal.kyc.date-of-birth-placeholder": {
+    "message": "Select date of birth"
+  },
   "dashboard.creator-withdraw-modal.kyc.entity-description": {
     "message": "A business entity refers to a registered organization such as a corporation, partnership, or LLC."
   },
@@ -1405,6 +1564,12 @@
   },
   "dashboard.creator-withdraw-modal.kyc.private-individual": {
     "message": "Private individual"
+  },
+  "dashboard.creator-withdraw-modal.kyc.search-countries-placeholder": {
+    "message": "Search countries..."
+  },
+  "dashboard.creator-withdraw-modal.kyc.search-subdivisions-placeholder": {
+    "message": "Search subdivisions..."
   },
   "dashboard.creator-withdraw-modal.method-selection.country-placeholder": {
     "message": "Select your country"
@@ -1541,6 +1706,21 @@
   "dashboard.creator-withdraw-modal.tremendous-details.enter-denomination-placeholder": {
     "message": "Enter amount"
   },
+  "dashboard.creator-withdraw-modal.tremendous-details.minimum-denomination-exceeds-balance": {
+    "message": "The minimum denomination is {min}, which exceeds your balance of {balance}."
+  },
+  "dashboard.creator-withdraw-modal.tremendous-details.need-at-least-gift-card": {
+    "message": "You need at least {min} to use this gift card."
+  },
+  "dashboard.creator-withdraw-modal.tremendous-details.no-denominations-available": {
+    "message": "No denominations available for your current balance"
+  },
+  "dashboard.creator-withdraw-modal.tremendous-details.no-suggestions-no-max": {
+    "message": "No denominations near this amount"
+  },
+  "dashboard.creator-withdraw-modal.tremendous-details.no-suggestions-with-max": {
+    "message": "No denominations near this amount. The highest available is {max}."
+  },
   "dashboard.creator-withdraw-modal.tremendous-details.payment-method": {
     "message": "Payment method"
   },
@@ -1555,6 +1735,12 @@
   },
   "dashboard.creator-withdraw-modal.tremendous-details.search-amount-label": {
     "message": "Search amount"
+  },
+  "dashboard.creator-withdraw-modal.tremendous-details.search-category-placeholder": {
+    "message": "Search {category}..."
+  },
+  "dashboard.creator-withdraw-modal.tremendous-details.select-category-placeholder": {
+    "message": "Select {category}"
   },
   "dashboard.creator-withdraw-modal.tremendous-details.select-denomination-hint": {
     "message": "Select a denomination:"
@@ -1573,6 +1759,12 @@
   },
   "dashboard.creator-withdraw-modal.tremendous-details.usd-paypal-warning-message": {
     "message": "You selected USD for PayPal International. <direct-paypal-link>Switch to direct PayPal</direct-paypal-link> for better fees (≈2% instead of ≈6%)."
+  },
+  "dashboard.creator-withdraw-modal.tremendous-details.withdrawal-amount-min-max": {
+    "message": "{min} min, {max} max withdrawal amount."
+  },
+  "dashboard.creator-withdraw-modal.tremendous-details.withdrawal-amount-min-only": {
+    "message": "{min} min withdrawal amount."
   },
   "dashboard.creator-withdraw-modal.withdraw-button": {
     "message": "Withdraw"
@@ -2237,6 +2429,24 @@
   "hosting-marketing.medal.text-secondary": {
     "message": "Limited-time offer. No credit card required. Available for US servers."
   },
+  "hosting-marketing.notification.error-fetching-payment-data-title": {
+    "message": "Error fetching payment data"
+  },
+  "hosting-marketing.notification.invalid-product-text": {
+    "message": "The selected product was found but lacks necessary data. Please contact support."
+  },
+  "hosting-marketing.notification.invalid-product-title": {
+    "message": "Invalid product"
+  },
+  "hosting-marketing.notification.server-capacity-full-text": {
+    "message": "We are currently at capacity. Please try again later."
+  },
+  "hosting-marketing.notification.server-capacity-full-title": {
+    "message": "Server Capacity Full"
+  },
+  "hosting-marketing.notification.unexpected-error-text": {
+    "message": "An unexpected error occurred"
+  },
   "hosting-marketing.pick-customized-plan": {
     "message": "Pick a customized plan with just the specs you need."
   },
@@ -2555,6 +2765,21 @@
   "layout.footer.about.status": {
     "message": "Status"
   },
+  "layout.footer.based-on-label": {
+    "message": "Based on"
+  },
+  "layout.footer.developer-mode-activated.text": {
+    "message": "Developer mode has been enabled"
+  },
+  "layout.footer.developer-mode-activated.title": {
+    "message": "Developer mode activated"
+  },
+  "layout.footer.developer-mode-deactivated.text": {
+    "message": "Developer mode has been disabled"
+  },
+  "layout.footer.developer-mode-deactivated.title": {
+    "message": "Developer mode deactivated"
+  },
   "layout.footer.legal": {
     "message": "Legal"
   },
@@ -2623,6 +2848,9 @@
   },
   "layout.footer.social.x": {
     "message": "X"
+  },
+  "layout.footer.unknown-commit": {
+    "message": "unknown"
   },
   "layout.menu-toggle.action": {
     "message": "Toggle menu"
@@ -2696,8 +2924,26 @@
   "moderation.exclude-technical-review": {
     "message": "Exclude TR"
   },
+  "moderation.generic-projects-label": {
+    "message": "projects"
+  },
+  "moderation.items-per-page-placeholder": {
+    "message": "Items per page"
+  },
   "moderation.moderate": {
     "message": "Moderate"
+  },
+  "moderation.notification.no-projects-available-text": {
+    "message": "All projects in queue are already moderated or locked by others."
+  },
+  "moderation.notification.no-projects-available-title": {
+    "message": "No projects available"
+  },
+  "moderation.notification.skipped-projects-text": {
+    "message": "{count, plural, one {Skipped # project} other {Skipped # projects}} already moderated or locked by others."
+  },
+  "moderation.notification.skipped-projects-title": {
+    "message": "Skipped projects"
   },
   "moderation.page.external-projects": {
     "message": "External projects"
@@ -2713,6 +2959,9 @@
   },
   "moderation.page.technicalReview": {
     "message": "Tech review"
+  },
+  "moderation.showing-projects-range": {
+    "message": "Showing {start}–{end} of {total} {type}"
   },
   "modpack-scan-modal.clear-all-groups": {
     "message": "Clear All Groups"
@@ -3040,6 +3289,45 @@
   },
   "organization.label.projects": {
     "message": "projects"
+  },
+  "organization.project-transfer.id-column": {
+    "message": "ID"
+  },
+  "organization.project-transfer.name-column": {
+    "message": "Name"
+  },
+  "organization.project-transfer.no-projects-available": {
+    "message": "No projects available to transfer."
+  },
+  "organization.project-transfer.project-icon-alt": {
+    "message": "Icon for {name}"
+  },
+  "organization.project-transfer.title": {
+    "message": "Transfer projects"
+  },
+  "organization.project-transfer.transfer-selected-projects": {
+    "message": "Transfer {count, plural, one {# project} other {# projects}}"
+  },
+  "organization.project-transfer.type-column": {
+    "message": "Type"
+  },
+  "organization.projects.none": {
+    "message": "This organization doesn't have any projects yet."
+  },
+  "organization.projects.none-with-create-prompt": {
+    "message": "This organization doesn't have any projects yet. Would you like to <create-link>create one</create-link>?"
+  },
+  "profile.admin.edit-role-header": {
+    "message": "Edit role"
+  },
+  "profile.admin.select-role-placeholder": {
+    "message": "Select a role"
+  },
+  "profile.admin.update-role-failed-message": {
+    "message": "An error occurred while updating the user role. Please try again."
+  },
+  "profile.admin.update-role-failed-title": {
+    "message": "Failed to update role"
   },
   "profile.bio.fallback.creator": {
     "message": "A Modrinth creator."
@@ -3695,6 +3983,102 @@
   "project.settings.permissions.sort.status": {
     "message": "Status"
   },
+  "project.settings.server.bedrock-address-label": {
+    "message": "Bedrock address"
+  },
+  "project.settings.server.cannot-save-text": {
+    "message": "The Java server must be reachable before saving. Please ensure the ping succeeds."
+  },
+  "project.settings.server.cannot-save-title": {
+    "message": "Cannot save"
+  },
+  "project.settings.server.details-heading": {
+    "message": "Server details"
+  },
+  "project.settings.server.enter-address-placeholder": {
+    "message": "Enter address"
+  },
+  "project.settings.server.java-address-label": {
+    "message": "Java address"
+  },
+  "project.settings.server.languages-label": {
+    "message": "Languages"
+  },
+  "project.settings.server.latency-label": {
+    "message": "Latency: {latency}ms"
+  },
+  "project.settings.server.optional-label": {
+    "message": "optional"
+  },
+  "project.settings.server.ping-failed-message": {
+    "message": "We couldn't ping this server. It may be blocked by your host so try refreshing a few times. If it still doesn't respond please <support-link>contact support</support-link>."
+  },
+  "project.settings.server.refresh-ping-tooltip": {
+    "message": "Refresh ping"
+  },
+  "project.settings.server.region-label": {
+    "message": "Region"
+  },
+  "project.settings.server.select-languages-placeholder": {
+    "message": "Select languages"
+  },
+  "project.settings.server.select-region-placeholder": {
+    "message": "Select region"
+  },
+  "project.settings.server.server-online": {
+    "message": "Server is online!"
+  },
+  "project.settings.server.srv-records-hint": {
+    "message": "If you have <srv-tooltip>[SRV records]</srv-tooltip>, you do not need to add a port. Otherwise if you have a port which isn't 25565, you can include it as :12345"
+  },
+  "project.settings.server.srv-records-tooltip": {
+    "message": "The address you enter here may have DNS SRV records _minecraft._tcp.'{'your domain'}' which point to your Minecraft server address and port."
+  },
+  "project.settings.tags.all-tags-selected-warning": {
+    "message": "You've selected all {count} available tags. Please select only the tags that truly apply to your project."
+  },
+  "project.settings.tags.categories-description": {
+    "message": "Select all categories that reflect the themes or function of your {type}."
+  },
+  "project.settings.tags.featured-tags": {
+    "message": "Featured tags"
+  },
+  "project.settings.tags.featured-tags-description": {
+    "message": "You can feature up to 3 of your most relevant tags. Other tags may be promoted to featured if you do not select all 3."
+  },
+  "project.settings.tags.features-description": {
+    "message": "Select all of the features that your {type} makes use of."
+  },
+  "project.settings.tags.multiple-resolution-tags-warning": {
+    "message": "You've selected {count} resolution tags ({tags}). Resource packs should typically only have one resolution tag."
+  },
+  "project.settings.tags.performance-impact-description": {
+    "message": "Select the realistic performance impact of your {type}. Select multiple if the {type} is configurable to different levels of performance impact."
+  },
+  "project.settings.tags.resolutions-description": {
+    "message": "Select the resolution(s) of textures in your {type}."
+  },
+  "project.settings.tags.select-at-least-one-category": {
+    "message": "Select at least one category in order to feature a category."
+  },
+  "project.settings.tags.tagging-importance-description": {
+    "message": "Accurate tagging is important to help people find your {type}. Make sure to select all tags that apply."
+  },
+  "project.settings.tags.title": {
+    "message": "Tags"
+  },
+  "project.settings.tags.too-many-tags-project-warning": {
+    "message": "You've selected {count} tags. Consider reducing to 8 or fewer to keep your project focused and easier to discover."
+  },
+  "project.settings.tags.too-many-tags-server-hard-warning": {
+    "message": "You've selected {count} tags. Please reduce to 18 or fewer to keep your server focused and easier to discover."
+  },
+  "project.settings.tags.too-many-tags-server-soft-warning": {
+    "message": "You've selected {count} tags. Consider reducing to 12 or fewer to keep your server focused and easier to discover."
+  },
+  "project.settings.tags.upload-version-first": {
+    "message": "Please upload a version first in order to select tags!"
+  },
   "project.settings.title": {
     "message": "Settings"
   },
@@ -3704,8 +4088,50 @@
   "project.status.archived.message": {
     "message": "{title} has been archived. {title} will not receive any further updates unless the author decides to unarchive the project."
   },
+  "project.versions.copy-id-option": {
+    "message": "Copy ID"
+  },
+  "project.versions.copy-link-option": {
+    "message": "Copy link"
+  },
+  "project.versions.copy-maven-coordinates-option": {
+    "message": "Copy Maven coordinates"
+  },
+  "project.versions.delete-button": {
+    "message": "Delete"
+  },
+  "project.versions.delete-confirm.description": {
+    "message": "This will remove this version forever (like really forever)."
+  },
+  "project.versions.delete-confirm.title": {
+    "message": "Are you sure you want to delete this version?"
+  },
+  "project.versions.edit-details-option": {
+    "message": "Edit details"
+  },
+  "project.versions.edit-files-option": {
+    "message": "Edit files"
+  },
+  "project.versions.edit-metadata-option": {
+    "message": "Edit metadata"
+  },
+  "project.versions.edit-version-tooltip": {
+    "message": "Edit version"
+  },
+  "project.versions.open-in-new-tab-option": {
+    "message": "Open in new tab"
+  },
+  "project.versions.share-option": {
+    "message": "Share"
+  },
   "project.versions.title": {
     "message": "Versions"
+  },
+  "project.versions.version-deleted-text": {
+    "message": "The version has been successfully deleted."
+  },
+  "project.versions.version-deleted-title": {
+    "message": "Version deleted"
   },
   "project.versions.withheld-versions-warning.description": {
     "message": "{count, plural, one {This version is} other {These versions are}} currently withheld and not publicly listed. Please provide proof that you have permission to redistribute certain files included in the modpack {count, plural, one {version} other {versions}}."
@@ -4121,8 +4547,11 @@
   "servers.plan.small.description": {
     "message": "Perfect for 1–5 friends with a few light mods."
   },
-  "servers.purchase.step.plan.billed": {
-    "message": "billed {interval, select, monthly {monthly} quarterly {quarterly} yearly {yearly} other {{interval}}}"
+  "servers.purchase.step.plan.most-popular": {
+    "message": "Most popular"
+  },
+  "servers.purchase.step.plan.per-month-billing": {
+    "message": "/ month{interval, select, monthly {} other {, billed {interval, select, quarterly {quarterly} yearly {yearly} other {{interval}}}}}"
   },
   "settings.account.button.complete-setup": {
     "message": "Complete setup"
@@ -4966,6 +5395,18 @@
   },
   "version.environment.unknown.title": {
     "message": "Unknown environment"
+  },
+  "version.notification.deleted-text": {
+    "message": "The version has been successfully deleted."
+  },
+  "version.notification.deleted-title": {
+    "message": "Version deleted"
+  },
+  "version.notification.packaging-success-text": {
+    "message": "Your data pack was successfully packaged as a mod! Make sure to playtest to check for errors."
+  },
+  "version.notification.packaging-success-title": {
+    "message": "Packaging Success"
   },
   "version.package-as-mod.button": {
     "message": "Package as mod"

--- a/apps/frontend/src/locales/en-US/index.json
+++ b/apps/frontend/src/locales/en-US/index.json
@@ -4032,7 +4032,7 @@
     "message": "If you have <srv-tooltip>[SRV records]</srv-tooltip>, you do not need to add a port. Otherwise if you have a port which isn't 25565, you can include it as :12345"
   },
   "project.settings.server.srv-records-tooltip": {
-    "message": "The address you enter here may have DNS SRV records _minecraft._tcp.'{'your domain'}' which point to your Minecraft server address and port."
+    "message": "The address you enter here may have DNS SRV records _minecraft._tcp.(your domain) which point to your Minecraft server address and port."
   },
   "project.settings.tags.all-tags-selected-warning": {
     "message": "You've selected all {count} available tags. Please select only the tags that truly apply to your project."

--- a/apps/frontend/src/locales/en-US/index.json
+++ b/apps/frontend/src/locales/en-US/index.json
@@ -2924,26 +2924,8 @@
   "moderation.exclude-technical-review": {
     "message": "Exclude TR"
   },
-  "moderation.generic-projects-label": {
-    "message": "projects"
-  },
-  "moderation.items-per-page-placeholder": {
-    "message": "Items per page"
-  },
   "moderation.moderate": {
     "message": "Moderate"
-  },
-  "moderation.notification.no-projects-available-text": {
-    "message": "All projects in queue are already moderated or locked by others."
-  },
-  "moderation.notification.no-projects-available-title": {
-    "message": "No projects available"
-  },
-  "moderation.notification.skipped-projects-text": {
-    "message": "{count, plural, one {Skipped # project} other {Skipped # projects}} already moderated or locked by others."
-  },
-  "moderation.notification.skipped-projects-title": {
-    "message": "Skipped projects"
   },
   "moderation.page.external-projects": {
     "message": "External projects"
@@ -2959,9 +2941,6 @@
   },
   "moderation.page.technicalReview": {
     "message": "Tech review"
-  },
-  "moderation.showing-projects-range": {
-    "message": "Showing {start}–{end} of {total} {type}"
   },
   "modpack-scan-modal.clear-all-groups": {
     "message": "Clear All Groups"
@@ -3316,18 +3295,6 @@
   },
   "organization.projects.none-with-create-prompt": {
     "message": "This organization doesn't have any projects yet. Would you like to <create-link>create one</create-link>?"
-  },
-  "profile.admin.edit-role-header": {
-    "message": "Edit role"
-  },
-  "profile.admin.select-role-placeholder": {
-    "message": "Select a role"
-  },
-  "profile.admin.update-role-failed-message": {
-    "message": "An error occurred while updating the user role. Please try again."
-  },
-  "profile.admin.update-role-failed-title": {
-    "message": "Failed to update role"
   },
   "profile.bio.fallback.creator": {
     "message": "A Modrinth creator."

--- a/apps/frontend/src/locales/en-US/index.json
+++ b/apps/frontend/src/locales/en-US/index.json
@@ -4032,7 +4032,7 @@
     "message": "If you have <srv-tooltip>[SRV records]</srv-tooltip>, you do not need to add a port. Otherwise if you have a port which isn't 25565, you can include it as :12345"
   },
   "project.settings.server.srv-records-tooltip": {
-    "message": "The address you enter here may have DNS SRV records _minecraft._tcp.(your domain) which point to your Minecraft server address and port."
+    "message": "The address you enter here may have DNS SRV records _minecraft._tcp.{your domain} which point to your Minecraft server address and port."
   },
   "project.settings.tags.all-tags-selected-warning": {
     "message": "You've selected all {count} available tags. Please select only the tags that truly apply to your project."

--- a/apps/frontend/src/locales/en-US/index.json
+++ b/apps/frontend/src/locales/en-US/index.json
@@ -3999,7 +3999,7 @@
     "message": "If you have <srv-tooltip>[SRV records]</srv-tooltip>, you do not need to add a port. Otherwise if you have a port which isn't 25565, you can include it as :12345"
   },
   "project.settings.server.srv-records-tooltip": {
-    "message": "The address you enter here may have DNS SRV records _minecraft._tcp.{your domain} which point to your Minecraft server address and port."
+    "message": "The address you enter here may have DNS SRV records _minecraft._tcp.(your domain) which point to your Minecraft server address and port."
   },
   "project.settings.tags.all-tags-selected-warning": {
     "message": "You've selected all {count} available tags. Please select only the tags that truly apply to your project."

--- a/apps/frontend/src/locales/es-419/index.json
+++ b/apps/frontend/src/locales/es-419/index.json
@@ -4067,9 +4067,6 @@
   "servers.plan.small.description": {
     "message": "Perfecto para 1–5 amigos con algunos mods ligeros."
   },
-  "servers.purchase.step.plan.billed": {
-    "message": "facturado {interval, select, monthly {mensual} quarterly {trimestral} yearly {anual} other {{interval}}}"
-  },
   "settings.account.button.complete-setup": {
     "message": "Finalizar configuración"
   },

--- a/apps/frontend/src/locales/es-ES/index.json
+++ b/apps/frontend/src/locales/es-ES/index.json
@@ -3788,9 +3788,6 @@
   "servers.plan.small.description": {
     "message": "Perfecto para 1–5 amigos con algunas modificaciones ligeras."
   },
-  "servers.purchase.step.plan.billed": {
-    "message": "facturado {interval, select, monthly {mensual} quarterly {trimestral} yearly {anual} other {{interval}}}"
-  },
   "settings.account.button.complete-setup": {
     "message": "Configuración completa"
   },

--- a/apps/frontend/src/locales/fr-FR/index.json
+++ b/apps/frontend/src/locales/fr-FR/index.json
@@ -4073,9 +4073,6 @@
   "servers.plan.small.description": {
     "message": "Parfait pour 1–5 amis et quelques mods légers."
   },
-  "servers.purchase.step.plan.billed": {
-    "message": "facturé {interval, select, monthly {mensuellement} quarterly {trimestriellement} yearly {annuellement} other {{interval}}}"
-  },
   "settings.account.button.complete-setup": {
     "message": "Terminer la configuration"
   },

--- a/apps/frontend/src/locales/it-IT/index.json
+++ b/apps/frontend/src/locales/it-IT/index.json
@@ -4040,9 +4040,6 @@
   "servers.plan.small.description": {
     "message": "Perfetto per 1–5 giocatori e qualche mod leggera."
   },
-  "servers.purchase.step.plan.billed": {
-    "message": "addebitato {interval, select, monthly {mensilmente} quarterly {trimerstralmente} yearly {annualmente} other {{interval}}}"
-  },
   "settings.account.button.complete-setup": {
     "message": "Completa la configurazione"
   },

--- a/apps/frontend/src/locales/ko-KR/index.json
+++ b/apps/frontend/src/locales/ko-KR/index.json
@@ -4067,9 +4067,6 @@
   "servers.plan.small.description": {
     "message": "1–5명의 친구와 적은 수의 가벼운 모드에 적합합니다."
   },
-  "servers.purchase.step.plan.billed": {
-    "message": "{interval, select, monthly {월간 결제} quarterly {분기별 결제} yearly {연간 결제} other {{interval} 결제}}"
-  },
   "settings.account.button.complete-setup": {
     "message": "설정 완료"
   },

--- a/apps/frontend/src/locales/ms-MY/index.json
+++ b/apps/frontend/src/locales/ms-MY/index.json
@@ -3572,9 +3572,6 @@
   "servers.plan.small.description": {
     "message": "Sesuai untuk 1–5 rakan dengan beberapa mod ringan."
   },
-  "servers.purchase.step.plan.billed": {
-    "message": "dibilkan {interval, select, monthly {monthly} quarterly {quarterly} yearly {yearly} other {{interval}}}"
-  },
   "settings.account.button.complete-setup": {
     "message": "Lengkapkan persediaan"
   },

--- a/apps/frontend/src/locales/pl-PL/index.json
+++ b/apps/frontend/src/locales/pl-PL/index.json
@@ -4058,9 +4058,6 @@
   "servers.plan.small.description": {
     "message": "Idealny dla 1–5 przyjaciół z kilkoma lekkimi modami."
   },
-  "servers.purchase.step.plan.billed": {
-    "message": "naliczane {interval, select, monthly {miesięcznie} quarterly {co kwartał} yearly {rocznie} other {{interval}}}"
-  },
   "settings.account.button.complete-setup": {
     "message": "Zakończ ustawianie"
   },

--- a/apps/frontend/src/locales/pt-BR/index.json
+++ b/apps/frontend/src/locales/pt-BR/index.json
@@ -4073,9 +4073,6 @@
   "servers.plan.small.description": {
     "message": "Perfeito para 1–5 amigos e alguns mods leves."
   },
-  "servers.purchase.step.plan.billed": {
-    "message": "cobrado {interval, select, monthly {mensalmente} quarterly {trimestralmente} yearly {anualmente} other {{interval}}}"
-  },
   "settings.account.button.complete-setup": {
     "message": "Terminar configuração"
   },

--- a/apps/frontend/src/locales/ru-RU/index.json
+++ b/apps/frontend/src/locales/ru-RU/index.json
@@ -4046,9 +4046,6 @@
   "servers.plan.small.description": {
     "message": "Для 1–5 друзей и пары лёгких модов."
   },
-  "servers.purchase.step.plan.billed": {
-    "message": "{interval, select, monthly {на месяц} quarterly {на 3 месяца} yearly {на год} other {оплата {interval}}}"
-  },
   "settings.account.button.complete-setup": {
     "message": "Завершить настройку"
   },

--- a/apps/frontend/src/locales/sr-CS/index.json
+++ b/apps/frontend/src/locales/sr-CS/index.json
@@ -1730,9 +1730,6 @@
   "servers.plan.small.description": {
     "message": "Savršeno za 1–5 prijatelja sa nekoliko lakih modova."
   },
-  "servers.purchase.step.plan.billed": {
-    "message": "naplaćuje se {interval, select, monthly {mesečno} quarterly {kvartalno} yearly {godišnje} other {{interval}}}"
-  },
   "settings.account.delete.section.description": {
     "message": "Kad obrišeš svoj račun, povratka nema. Brisanjem računa sa naših servera biće uklonjeni svi povezani podaci, izuzev projekata."
   },

--- a/apps/frontend/src/locales/sv-SE/index.json
+++ b/apps/frontend/src/locales/sv-SE/index.json
@@ -3425,9 +3425,6 @@
   "servers.plan.small.description": {
     "message": "Perfekt för 1–5 vänner med några få lätta moddar."
   },
-  "servers.purchase.step.plan.billed": {
-    "message": "fakturerad {interval, select, monthly {månadsvis} quarterly {kvartalvis} yearly {årligen} other {{interval}}}"
-  },
   "settings.account.delete.confirm.proceed": {
     "message": "Radera kontot"
   },

--- a/apps/frontend/src/locales/tr-TR/index.json
+++ b/apps/frontend/src/locales/tr-TR/index.json
@@ -4013,9 +4013,6 @@
   "servers.plan.small.description": {
     "message": "1–5 arkadaş ve birkaç hafif mod için mükemmel."
   },
-  "servers.purchase.step.plan.billed": {
-    "message": "{interval, select, monthly {monthly} quarterly {quarterly} yearly {yearly} other {{interval}}} faturalandırıldı"
-  },
   "settings.account.button.complete-setup": {
     "message": "Kurulumu tamamla"
   },

--- a/apps/frontend/src/locales/uk-UA/index.json
+++ b/apps/frontend/src/locales/uk-UA/index.json
@@ -4064,9 +4064,6 @@
   "servers.plan.small.description": {
     "message": "Прекрасно підходить для 1–5 друзів із кількома легкими модами."
   },
-  "servers.purchase.step.plan.billed": {
-    "message": "оплата {interval, select, monthly {щомісяця} quarterly {щокварталу} yearly {щороку} other {{interval}}}"
-  },
   "settings.account.button.complete-setup": {
     "message": "Завершити налаштування"
   },

--- a/apps/frontend/src/locales/vi-VN/index.json
+++ b/apps/frontend/src/locales/vi-VN/index.json
@@ -3695,9 +3695,6 @@
   "servers.plan.small.description": {
     "message": "Hoàn hảo cho 1–5 người bạn với một vài mod nhẹ."
   },
-  "servers.purchase.step.plan.billed": {
-    "message": "trả tiền hàng {interval, select, monthly {tháng} quarterly {quý (3 tháng)} yearly {năm} other {{interval}}}"
-  },
   "settings.account.button.complete-setup": {
     "message": "Hoàn tất thiết lập"
   },

--- a/apps/frontend/src/locales/zh-CN/index.json
+++ b/apps/frontend/src/locales/zh-CN/index.json
@@ -4067,9 +4067,6 @@
   "servers.plan.small.description": {
     "message": "适合 1–5 位朋友使用，加少量轻量模组。"
   },
-  "servers.purchase.step.plan.billed": {
-    "message": "计费{interval, select, monthly {按月} quarterly {按季度} yearly {按年} other {{interval}}}"
-  },
   "settings.account.button.complete-setup": {
     "message": "完成设置"
   },

--- a/apps/frontend/src/locales/zh-TW/index.json
+++ b/apps/frontend/src/locales/zh-TW/index.json
@@ -4073,9 +4073,6 @@
   "servers.plan.small.description": {
     "message": "適合 1 到 5 位好友及少量輕量模組。"
   },
-  "servers.purchase.step.plan.billed": {
-    "message": "按{interval, select, monthly {月} quarterly {季} yearly {年} other {{interval}}}計費"
-  },
   "settings.account.button.complete-setup": {
     "message": "完成設定"
   },

--- a/apps/frontend/src/pages/[type]/[project]/settings/server.vue
+++ b/apps/frontend/src/pages/[type]/[project]/settings/server.vue
@@ -120,14 +120,13 @@
 					</div>
 					<div v-else class="mt-2 text-sm">
 						<IntlFormatted :message-id="messages.srvRecordsHint">
-							<template #srv-tooltip>
-								<InfoIcon
+							<template #srv-tooltip="{ children }"
+								><component :is="() => normalizeChildren(children)" /><InfoIcon
 									v-tooltip="{
 										content: formatMessage(messages.srvRecordsTooltip),
 										popperClass: 'max-w-xs',
 									}"
-								/>
-							</template>
+							/></template>
 						</IntlFormatted>
 					</div>
 				</div>
@@ -253,7 +252,7 @@ const messages = defineMessages({
 	srvRecordsTooltip: {
 		id: 'project.settings.server.srv-records-tooltip',
 		defaultMessage:
-			"The address you enter here may have DNS SRV records _minecraft._tcp.'{'your domain'}' which point to your Minecraft server address and port.",
+			'The address you enter here may have DNS SRV records _minecraft._tcp.(your domain) which point to your Minecraft server address and port.',
 	},
 	bedrockAddressLabel: {
 		id: 'project.settings.server.bedrock-address-label',

--- a/apps/frontend/src/pages/[type]/[project]/settings/server.vue
+++ b/apps/frontend/src/pages/[type]/[project]/settings/server.vue
@@ -265,7 +265,8 @@ const messages = defineMessages({
 	},
 	cannotSaveText: {
 		id: 'project.settings.server.cannot-save-text',
-		defaultMessage: 'The Java server must be reachable before saving. Please ensure the ping succeeds.',
+		defaultMessage:
+			'The Java server must be reachable before saving. Please ensure the ping succeeds.',
 	},
 })
 

--- a/apps/frontend/src/pages/[type]/[project]/settings/server.vue
+++ b/apps/frontend/src/pages/[type]/[project]/settings/server.vue
@@ -252,7 +252,7 @@ const messages = defineMessages({
 	srvRecordsTooltip: {
 		id: 'project.settings.server.srv-records-tooltip',
 		defaultMessage:
-			'The address you enter here may have DNS SRV records _minecraft._tcp.(your domain) which point to your Minecraft server address and port.',
+			'The address you enter here may have DNS SRV records _minecraft._tcp.{your domain} which point to your Minecraft server address and port.',
 	},
 	bedrockAddressLabel: {
 		id: 'project.settings.server.bedrock-address-label',

--- a/apps/frontend/src/pages/[type]/[project]/settings/server.vue
+++ b/apps/frontend/src/pages/[type]/[project]/settings/server.vue
@@ -3,19 +3,21 @@
 		<ConfirmLeaveModal ref="confirmLeaveModal" />
 		<section class="universal-card">
 			<div class="flex flex-col gap-6">
-				<div class="text-2xl font-semibold text-contrast">Server details</div>
+				<div class="text-2xl font-semibold text-contrast">
+					{{ formatMessage(messages.serverDetailsHeading) }}
+				</div>
 
 				<!-- Region -->
 				<div class="max-w-[600px]">
 					<label for="server-region">
-						<span class="label__title">Region</span>
+						<span class="label__title">{{ formatMessage(messages.regionLabel) }}</span>
 					</label>
 					<Combobox
 						id="server-region"
 						v-model="region"
 						:options="regionOptions"
 						searchable
-						placeholder="Select region"
+						:placeholder="formatMessage(messages.selectRegionPlaceholder)"
 						:disabled="!hasPermission"
 					/>
 				</div>
@@ -24,7 +26,10 @@
 				<div class="max-w-[600px]">
 					<label for="server-language">
 						<span class="label__title"
-							>Languages <span class="font-normal text-secondary">(optional)</span></span
+							>{{ formatMessage(messages.languagesLabel) }}
+							<span class="font-normal text-secondary"
+								>({{ formatMessage(messages.optionalLabel) }})</span
+							></span
 						>
 					</label>
 					<MultiSelect
@@ -34,7 +39,7 @@
 						searchable
 						include-select-all-option
 						:max-tag-rows="2"
-						placeholder="Select languages"
+						:placeholder="formatMessage(messages.selectLanguagesPlaceholder)"
 						:disabled="!hasPermission"
 					/>
 				</div>
@@ -43,7 +48,9 @@
 				<div class="max-w-[600px]">
 					<div class="flex items-center justify-between">
 						<label for="java-address">
-							<span class="label__title !m-0 !text-contrast">Java address</span>
+							<span class="label__title !m-0 !text-contrast">{{
+								formatMessage(messages.javaAddressLabel)
+							}}</span>
 						</label>
 					</div>
 					<div
@@ -58,7 +65,7 @@
 						<StyledInput
 							id="java-address"
 							v-model="javaAddress"
-							placeholder="Enter address"
+							:placeholder="formatMessage(messages.enterAddressPlaceholder)"
 							:disabled="!hasPermission"
 							wrapper-class="flex-grow"
 							autocomplete="off"
@@ -80,7 +87,7 @@
 							color="oranges"
 						>
 							<button
-								v-tooltip="'Refresh ping'"
+								v-tooltip="formatMessage(messages.refreshPingTooltip)"
 								:disabled="javaPingLoading"
 								@click="pingJavaServer"
 							>
@@ -92,34 +99,36 @@
 							v-if="javaPingResult !== null && !javaPingLoading && javaPingResult.online"
 							class="mt-0.5 flex items-center gap-1.5 text-green"
 						>
-							Server is online!
+							{{ formatMessage(messages.serverOnline) }}
 							<template v-if="javaPingResult.latency">
-								Latency: {{ javaPingResult.latency }}ms
+								{{ formatMessage(messages.latencyLabel, { latency: javaPingResult.latency }) }}
 							</template>
 						</div>
 						<div v-else-if="javaPingResult !== null && !javaPingLoading" class="mt-0.5 text-orange">
-							We couldn’t ping this server. It may be blocked by your host so try refreshing a few
-							times. If it still doesn’t respond please
-							<a
-								class="inline underline"
-								href="https://support.modrinth.com"
-								target="_blank"
-								rel="noopener noreferrer"
-							>
-								contact support</a
-							>.
+							<IntlFormatted :message-id="messages.pingFailedMessage">
+								<template #support-link="{ children }">
+									<a
+										class="inline underline"
+										href="https://support.modrinth.com"
+										target="_blank"
+										rel="noopener noreferrer"
+										><component :is="() => normalizeChildren(children)"
+									/></a>
+								</template>
+							</IntlFormatted>
 						</div>
 					</div>
 					<div v-else class="mt-2 text-sm">
-						If you have [SRV records]
-						<InfoIcon
-							v-tooltip="{
-								content:
-									'The address you enter here may have DNS SRV records _minecraft._tcp.{your domain} which point to your Minecraft server address and port.',
-								popperClass: 'max-w-xs',
-							}"
-						/>, you do not need to add a port. Otherwise if you have a port which isn't 25565, you
-						can include it as :12345
+						<IntlFormatted :message-id="messages.srvRecordsHint">
+							<template #srv-tooltip>
+								<InfoIcon
+									v-tooltip="{
+										content: formatMessage(messages.srvRecordsTooltip),
+										popperClass: 'max-w-xs',
+									}"
+								/>
+							</template>
+						</IntlFormatted>
 					</div>
 				</div>
 
@@ -127,15 +136,17 @@
 				<div class="max-w-[600px]">
 					<label for="bedrock-address">
 						<span class="label__title !text-contrast"
-							>Bedrock address
-							<span class="font-normal text-secondary">(optional)</span>
+							>{{ formatMessage(messages.bedrockAddressLabel) }}
+							<span class="font-normal text-secondary"
+								>({{ formatMessage(messages.optionalLabel) }})</span
+							>
 						</span>
 					</label>
 					<div class="mt-2 flex items-center gap-2">
 						<StyledInput
 							id="bedrock-address"
 							v-model="bedrockAddress"
-							placeholder="Enter address"
+							:placeholder="formatMessage(messages.enterAddressPlaceholder)"
 							:disabled="!hasPermission"
 							wrapper-class="flex-grow"
 							autocomplete="off"
@@ -163,10 +174,13 @@ import {
 	ButtonStyled,
 	Combobox,
 	ConfirmLeaveModal,
+	defineMessages,
 	injectModrinthClient,
 	injectNotificationManager,
 	injectProjectPageContext,
+	IntlFormatted,
 	MultiSelect,
+	normalizeChildren,
 	SERVER_LANGUAGES,
 	SERVER_REGIONS,
 	StyledInput,
@@ -180,6 +194,80 @@ import CompatibilityCard from '~/components/ui/project-settings/CompatibilityCar
 const PING_TIMEOUT_MS = 5000
 
 const { formatMessage, locale } = useVIntl()
+
+const messages = defineMessages({
+	serverDetailsHeading: {
+		id: 'project.settings.server.details-heading',
+		defaultMessage: 'Server details',
+	},
+	regionLabel: {
+		id: 'project.settings.server.region-label',
+		defaultMessage: 'Region',
+	},
+	selectRegionPlaceholder: {
+		id: 'project.settings.server.select-region-placeholder',
+		defaultMessage: 'Select region',
+	},
+	languagesLabel: {
+		id: 'project.settings.server.languages-label',
+		defaultMessage: 'Languages',
+	},
+	optionalLabel: {
+		id: 'project.settings.server.optional-label',
+		defaultMessage: 'optional',
+	},
+	selectLanguagesPlaceholder: {
+		id: 'project.settings.server.select-languages-placeholder',
+		defaultMessage: 'Select languages',
+	},
+	javaAddressLabel: {
+		id: 'project.settings.server.java-address-label',
+		defaultMessage: 'Java address',
+	},
+	enterAddressPlaceholder: {
+		id: 'project.settings.server.enter-address-placeholder',
+		defaultMessage: 'Enter address',
+	},
+	refreshPingTooltip: {
+		id: 'project.settings.server.refresh-ping-tooltip',
+		defaultMessage: 'Refresh ping',
+	},
+	serverOnline: {
+		id: 'project.settings.server.server-online',
+		defaultMessage: 'Server is online!',
+	},
+	latencyLabel: {
+		id: 'project.settings.server.latency-label',
+		defaultMessage: 'Latency: {latency}ms',
+	},
+	pingFailedMessage: {
+		id: 'project.settings.server.ping-failed-message',
+		defaultMessage:
+			"We couldn't ping this server. It may be blocked by your host so try refreshing a few times. If it still doesn't respond please <support-link>contact support</support-link>.",
+	},
+	srvRecordsHint: {
+		id: 'project.settings.server.srv-records-hint',
+		defaultMessage:
+			"If you have <srv-tooltip>[SRV records]</srv-tooltip>, you do not need to add a port. Otherwise if you have a port which isn't 25565, you can include it as :12345",
+	},
+	srvRecordsTooltip: {
+		id: 'project.settings.server.srv-records-tooltip',
+		defaultMessage:
+			"The address you enter here may have DNS SRV records _minecraft._tcp.'{'your domain'}' which point to your Minecraft server address and port.",
+	},
+	bedrockAddressLabel: {
+		id: 'project.settings.server.bedrock-address-label',
+		defaultMessage: 'Bedrock address',
+	},
+	cannotSaveTitle: {
+		id: 'project.settings.server.cannot-save-title',
+		defaultMessage: 'Cannot save',
+	},
+	cannotSaveText: {
+		id: 'project.settings.server.cannot-save-text',
+		defaultMessage: 'The Java server must be reachable before saving. Please ensure the ping succeeds.',
+	},
+})
 
 const client = injectModrinthClient()
 const { addNotification } = injectNotificationManager()
@@ -391,8 +479,8 @@ function resetChanges() {
 async function handleSave() {
 	if (javaAddress.value.trim() && !javaPingResult.value?.online) {
 		addNotification({
-			title: 'Cannot save',
-			text: 'The Java server must be reachable before saving. Please ensure the ping succeeds.',
+			title: formatMessage(messages.cannotSaveTitle),
+			text: formatMessage(messages.cannotSaveText),
 			type: 'error',
 		})
 		return

--- a/apps/frontend/src/pages/[type]/[project]/settings/server.vue
+++ b/apps/frontend/src/pages/[type]/[project]/settings/server.vue
@@ -252,7 +252,7 @@ const messages = defineMessages({
 	srvRecordsTooltip: {
 		id: 'project.settings.server.srv-records-tooltip',
 		defaultMessage:
-			'The address you enter here may have DNS SRV records _minecraft._tcp.{your domain} which point to your Minecraft server address and port.',
+			'The address you enter here may have DNS SRV records _minecraft._tcp.(your domain) which point to your Minecraft server address and port.',
 	},
 	bedrockAddressLabel: {
 		id: 'project.settings.server.bedrock-address-label',

--- a/apps/frontend/src/pages/[type]/[project]/settings/tags.vue
+++ b/apps/frontend/src/pages/[type]/[project]/settings/tags.vue
@@ -102,7 +102,9 @@
 				</template>
 				<div class="label">
 					<h4>
-						<span class="label__title"><StarIcon /> {{ formatMessage(messages.featuredTags) }}</span>
+						<span class="label__title"
+							><StarIcon /> {{ formatMessage(messages.featuredTags) }}</span
+						>
 					</h4>
 					<span class="label__description">{{
 						formatMessage(messages.featuredTagsDescription)

--- a/apps/frontend/src/pages/[type]/[project]/settings/tags.vue
+++ b/apps/frontend/src/pages/[type]/[project]/settings/tags.vue
@@ -4,7 +4,7 @@
 		<section class="universal-card">
 			<div class="label">
 				<h3>
-					<span class="label__title size-card-header">Tags</span>
+					<span class="label__title size-card-header">{{ formatMessage(messages.tagsTitle) }}</span>
 				</h3>
 			</div>
 
@@ -27,16 +27,18 @@
 			</div>
 
 			<p>
-				Accurate tagging is important to help people find your
-				{{ formatProjectType(project.project_type).toLowerCase() }}. Make sure to select all tags
-				that apply.
+				{{
+					formatMessage(messages.taggingImportanceDescription, {
+						type: formatProjectType(project.project_type).toLowerCase(),
+					})
+				}}
 			</p>
 
 			<p
 				v-if="project.versions.length === 0 && projectV3?.minecraft_server == null"
 				class="known-errors"
 			>
-				Please upload a version first in order to select tags!
+				{{ formatMessage(messages.uploadVersionFirst) }}
 			</p>
 			<template v-else>
 				<template v-for="header in Object.keys(categoryLists)" :key="`categories-${header}`">
@@ -46,22 +48,32 @@
 						</h4>
 						<span class="label__description">
 							<template v-if="header === 'categories'">
-								Select all categories that reflect the themes or function of your
-								{{ formatProjectType(project.project_type).toLowerCase() }}.
+								{{
+									formatMessage(messages.categoriesDescription, {
+										type: formatProjectType(project.project_type).toLowerCase(),
+									})
+								}}
 							</template>
 							<template v-else-if="header === 'features'">
-								Select all of the features that your
-								{{ formatProjectType(project.project_type).toLowerCase() }} makes use of.
+								{{
+									formatMessage(messages.featuresDescription, {
+										type: formatProjectType(project.project_type).toLowerCase(),
+									})
+								}}
 							</template>
 							<template v-else-if="header === 'resolutions'">
-								Select the resolution(s) of textures in your
-								{{ formatProjectType(project.project_type).toLowerCase() }}.
+								{{
+									formatMessage(messages.resolutionsDescription, {
+										type: formatProjectType(project.project_type).toLowerCase(),
+									})
+								}}
 							</template>
 							<template v-else-if="header === 'performance impact'">
-								Select the realistic performance impact of your
-								{{ formatProjectType(project.project_type).toLowerCase() }}. Select multiple if the
-								{{ formatProjectType(project.project_type).toLowerCase() }} is configurable to
-								different levels of performance impact.
+								{{
+									formatMessage(messages.performanceImpactDescription, {
+										type: formatProjectType(project.project_type).toLowerCase(),
+									})
+								}}
 							</template>
 						</span>
 					</div>
@@ -90,15 +102,14 @@
 				</template>
 				<div class="label">
 					<h4>
-						<span class="label__title"><StarIcon /> Featured tags</span>
+						<span class="label__title"><StarIcon /> {{ formatMessage(messages.featuredTags) }}</span>
 					</h4>
-					<span class="label__description">
-						You can feature up to 3 of your most relevant tags. Other tags may be promoted to
-						featured if you do not select all 3.
-					</span>
+					<span class="label__description">{{
+						formatMessage(messages.featuredTagsDescription)
+					}}</span>
 				</div>
 				<p v-if="current.selectedTags.length < 1">
-					Select at least one category in order to feature a category.
+					{{ formatMessage(messages.selectAtLeastOneCategory) }}
 				</p>
 				<div class="category-list input-div">
 					<Checkbox
@@ -145,6 +156,7 @@ import {
 import {
 	Checkbox,
 	ConfirmLeaveModal,
+	defineMessages,
 	formatCategory,
 	formatCategoryHeader,
 	FormattedTag,
@@ -166,6 +178,77 @@ interface Category {
 
 const tags = useGeneratedState()
 const { formatMessage, locale } = useVIntl()
+
+const messages = defineMessages({
+	tagsTitle: {
+		id: 'project.settings.tags.title',
+		defaultMessage: 'Tags',
+	},
+	taggingImportanceDescription: {
+		id: 'project.settings.tags.tagging-importance-description',
+		defaultMessage:
+			'Accurate tagging is important to help people find your {type}. Make sure to select all tags that apply.',
+	},
+	uploadVersionFirst: {
+		id: 'project.settings.tags.upload-version-first',
+		defaultMessage: 'Please upload a version first in order to select tags!',
+	},
+	categoriesDescription: {
+		id: 'project.settings.tags.categories-description',
+		defaultMessage: 'Select all categories that reflect the themes or function of your {type}.',
+	},
+	featuresDescription: {
+		id: 'project.settings.tags.features-description',
+		defaultMessage: 'Select all of the features that your {type} makes use of.',
+	},
+	resolutionsDescription: {
+		id: 'project.settings.tags.resolutions-description',
+		defaultMessage: 'Select the resolution(s) of textures in your {type}.',
+	},
+	performanceImpactDescription: {
+		id: 'project.settings.tags.performance-impact-description',
+		defaultMessage:
+			'Select the realistic performance impact of your {type}. Select multiple if the {type} is configurable to different levels of performance impact.',
+	},
+	featuredTags: {
+		id: 'project.settings.tags.featured-tags',
+		defaultMessage: 'Featured tags',
+	},
+	featuredTagsDescription: {
+		id: 'project.settings.tags.featured-tags-description',
+		defaultMessage:
+			'You can feature up to 3 of your most relevant tags. Other tags may be promoted to featured if you do not select all 3.',
+	},
+	selectAtLeastOneCategory: {
+		id: 'project.settings.tags.select-at-least-one-category',
+		defaultMessage: 'Select at least one category in order to feature a category.',
+	},
+	tooManyTagsServerHardWarning: {
+		id: 'project.settings.tags.too-many-tags-server-hard-warning',
+		defaultMessage:
+			"You've selected {count} tags. Please reduce to 18 or fewer to keep your server focused and easier to discover.",
+	},
+	tooManyTagsServerSoftWarning: {
+		id: 'project.settings.tags.too-many-tags-server-soft-warning',
+		defaultMessage:
+			"You've selected {count} tags. Consider reducing to 12 or fewer to keep your server focused and easier to discover.",
+	},
+	tooManyTagsProjectWarning: {
+		id: 'project.settings.tags.too-many-tags-project-warning',
+		defaultMessage:
+			"You've selected {count} tags. Consider reducing to 8 or fewer to keep your project focused and easier to discover.",
+	},
+	multipleResolutionTagsWarning: {
+		id: 'project.settings.tags.multiple-resolution-tags-warning',
+		defaultMessage:
+			"You've selected {count} resolution tags ({tags}). Resource packs should typically only have one resolution tag.",
+	},
+	allTagsSelectedWarning: {
+		id: 'project.settings.tags.all-tags-selected-warning',
+		defaultMessage:
+			"You've selected all {count} available tags. Please select only the tags that truly apply to your project.",
+	},
+})
 
 const { projectV2: project, projectV3, patchProject } = injectProjectPageContext()
 
@@ -268,12 +351,12 @@ const tooManyTagsWarning = computed(() => {
 	const tagCount = current.value.selectedTags.length
 	if (projectV3?.value?.minecraft_server != null) {
 		if (tagCount > 18) {
-			return `You've selected ${tagCount} tags. Please reduce to 18 or fewer to keep your server focused and easier to discover.`
+			return formatMessage(messages.tooManyTagsServerHardWarning, { count: tagCount })
 		} else if (tagCount > 12) {
-			return `You've selected ${tagCount} tags. Consider reducing to 12 or fewer to keep your server focused and easier to discover.`
+			return formatMessage(messages.tooManyTagsServerSoftWarning, { count: tagCount })
 		}
 	} else if (tagCount > 8) {
-		return `You've selected ${tagCount} tags. Consider reducing to 8 or fewer to keep your project focused and easier to discover.`
+		return formatMessage(messages.tooManyTagsProjectWarning, { count: tagCount })
 	}
 	return null
 })
@@ -286,14 +369,15 @@ const multipleResolutionTagsWarning = computed(() => {
 	)
 
 	if (resolutionTags.length > 1) {
-		return `You've selected ${resolutionTags.length} resolution tags (${resolutionTags
+		const tagsList = resolutionTags
 			.map((t) => t.name)
 			.join(', ')
 			.replace('8x-', '8x or lower')
-			.replace(
-				'512x+',
-				'512x or higher',
-			)}). Resource packs should typically only have one resolution tag.`
+			.replace('512x+', '512x or higher')
+		return formatMessage(messages.multipleResolutionTagsWarning, {
+			count: resolutionTags.length,
+			tags: tagsList,
+		})
 	}
 	return null
 })
@@ -310,7 +394,9 @@ const allTagsSelectedWarning = computed(() => {
 		totalSelectedTags === categoriesForProjectType.length &&
 		categoriesForProjectType.length > 0
 	) {
-		return `You've selected all ${categoriesForProjectType.length} available tags. Please select only the tags that truly apply to your project.`
+		return formatMessage(messages.allTagsSelectedWarning, {
+			count: categoriesForProjectType.length,
+		})
 	}
 	return null
 })

--- a/apps/frontend/src/pages/[type]/[project]/settings/versions.vue
+++ b/apps/frontend/src/pages/[type]/[project]/settings/versions.vue
@@ -8,10 +8,10 @@
 		<ConfirmModal
 			v-if="currentMember"
 			ref="deleteVersionModal"
-			title="Are you sure you want to delete this version?"
-			description="This will remove this version forever (like really forever)."
+			:title="formatMessage(messages.deleteVersionConfirmTitle)"
+			:description="formatMessage(messages.deleteVersionConfirmDescription)"
 			:has-to-type="false"
-			proceed-label="Delete"
+			:proceed-label="formatMessage(messages.deleteButton)"
 			@proceed="deleteVersion()"
 		/>
 		<Admonition
@@ -69,7 +69,7 @@
 			<template #actions="{ version }">
 				<ButtonStyled circular type="transparent">
 					<OverflowMenu
-						v-tooltip="'Edit version'"
+						v-tooltip="formatMessage(messages.editVersionTooltip)"
 						class="hover:!bg-button-bg [&>svg]:!text-green"
 						:dropdown-id="`${baseDropdownId}-edit-${version.id}`"
 						:options="[
@@ -86,26 +86,26 @@
 								action: () => handleOpenEditVersionModal(version.id, project.id, 'add-files'),
 							},
 						]"
-						aria-label="Edit version"
+						:aria-label="formatMessage(messages.editVersionTooltip)"
 					>
 						<EditIcon aria-hidden="true" />
 						<template #edit-files>
 							<FileIcon aria-hidden="true" />
-							Edit files
+							{{ formatMessage(messages.editFilesOption) }}
 						</template>
 						<template #edit-details>
 							<InfoIcon aria-hidden="true" />
-							Edit details
+							{{ formatMessage(messages.editDetailsOption) }}
 						</template>
 						<template #edit-metadata>
 							<BoxIcon aria-hidden="true" />
-							Edit metadata
+							{{ formatMessage(messages.editMetadataOption) }}
 						</template>
 					</OverflowMenu>
 				</ButtonStyled>
 				<ButtonStyled circular type="transparent">
 					<OverflowMenu
-						v-tooltip="'More options'"
+						v-tooltip="formatMessage(commonMessages.moreOptionsButton)"
 						class="hover:!bg-button-bg"
 						:dropdown-id="`${baseDropdownId}-${version.id}`"
 						:options="[
@@ -192,52 +192,52 @@
 								shown: !!currentMember,
 							},
 						]"
-						aria-label="More options"
+						:aria-label="formatMessage(commonMessages.moreOptionsButton)"
 					>
 						<MoreVerticalIcon aria-hidden="true" />
 						<template #download>
 							<DownloadIcon aria-hidden="true" />
-							Download
+							{{ formatMessage(commonMessages.downloadButton) }}
 						</template>
 						<template #new-tab>
 							<ExternalIcon aria-hidden="true" />
-							Open in new tab
+							{{ formatMessage(messages.openInNewTabOption) }}
 						</template>
 						<template #copy-link>
 							<LinkIcon aria-hidden="true" />
-							Copy link
+							{{ formatMessage(messages.copyLinkOption) }}
 						</template>
 						<template #share>
 							<ShareIcon aria-hidden="true" />
-							Share
+							{{ formatMessage(messages.shareOption) }}
 						</template>
 						<template #report>
 							<ReportIcon aria-hidden="true" />
-							Report
+							{{ formatMessage(commonMessages.reportButton) }}
 						</template>
 						<template #edit-files>
 							<FileIcon aria-hidden="true" />
-							Edit files
+							{{ formatMessage(messages.editFilesOption) }}
 						</template>
 						<template #edit-details>
 							<InfoIcon aria-hidden="true" />
-							Edit details
+							{{ formatMessage(messages.editDetailsOption) }}
 						</template>
 						<template #edit-metadata>
 							<BoxIcon aria-hidden="true" />
-							Edit metadata
+							{{ formatMessage(messages.editMetadataOption) }}
 						</template>
 						<template #delete>
 							<TrashIcon aria-hidden="true" />
-							Delete
+							{{ formatMessage(commonMessages.deleteLabel) }}
 						</template>
 						<template #copy-id>
 							<ClipboardCopyIcon aria-hidden="true" />
-							Copy ID
+							{{ formatMessage(messages.copyIdOption) }}
 						</template>
 						<template #copy-maven>
 							<ClipboardCopyIcon aria-hidden="true" />
-							Copy Maven coordinates
+							{{ formatMessage(messages.copyMavenCoordinatesOption) }}
 						</template>
 					</OverflowMenu>
 				</ButtonStyled>
@@ -336,6 +336,7 @@ import {
 import {
 	Admonition,
 	ButtonStyled,
+	commonMessages,
 	commonProjectSettingsMessages,
 	ConfirmModal,
 	defineMessages,
@@ -444,13 +445,13 @@ async function deleteVersion() {
 		await client.labrinth.versions_v3.deleteVersion(id)
 
 		addNotification({
-			title: 'Version deleted',
-			text: 'The version has been successfully deleted.',
+			title: formatMessage(messages.versionDeletedTitle),
+			text: formatMessage(messages.versionDeletedText),
 			type: 'success',
 		})
 	} catch (err: any) {
 		addNotification({
-			title: 'An error occurred',
+			title: formatMessage(commonMessages.errorNotificationTitle),
 			text: err.data ? err.data.description : err,
 			type: 'error',
 		})
@@ -476,6 +477,62 @@ const messages = defineMessages({
 		id: 'project.versions.withheld-versions-warning.description',
 		defaultMessage:
 			'{count, plural, one {This version is} other {These versions are}} currently withheld and not publicly listed. Please provide proof that you have permission to redistribute certain files included in the modpack {count, plural, one {version} other {versions}}.',
+	},
+	deleteVersionConfirmTitle: {
+		id: 'project.versions.delete-confirm.title',
+		defaultMessage: 'Are you sure you want to delete this version?',
+	},
+	deleteVersionConfirmDescription: {
+		id: 'project.versions.delete-confirm.description',
+		defaultMessage: 'This will remove this version forever (like really forever).',
+	},
+	deleteButton: {
+		id: 'project.versions.delete-button',
+		defaultMessage: 'Delete',
+	},
+	editVersionTooltip: {
+		id: 'project.versions.edit-version-tooltip',
+		defaultMessage: 'Edit version',
+	},
+	editFilesOption: {
+		id: 'project.versions.edit-files-option',
+		defaultMessage: 'Edit files',
+	},
+	editDetailsOption: {
+		id: 'project.versions.edit-details-option',
+		defaultMessage: 'Edit details',
+	},
+	editMetadataOption: {
+		id: 'project.versions.edit-metadata-option',
+		defaultMessage: 'Edit metadata',
+	},
+	openInNewTabOption: {
+		id: 'project.versions.open-in-new-tab-option',
+		defaultMessage: 'Open in new tab',
+	},
+	copyLinkOption: {
+		id: 'project.versions.copy-link-option',
+		defaultMessage: 'Copy link',
+	},
+	shareOption: {
+		id: 'project.versions.share-option',
+		defaultMessage: 'Share',
+	},
+	copyIdOption: {
+		id: 'project.versions.copy-id-option',
+		defaultMessage: 'Copy ID',
+	},
+	copyMavenCoordinatesOption: {
+		id: 'project.versions.copy-maven-coordinates-option',
+		defaultMessage: 'Copy Maven coordinates',
+	},
+	versionDeletedTitle: {
+		id: 'project.versions.version-deleted-title',
+		defaultMessage: 'Version deleted',
+	},
+	versionDeletedText: {
+		id: 'project.versions.version-deleted-text',
+		defaultMessage: 'The version has been successfully deleted.',
 	},
 })
 </script>

--- a/apps/frontend/src/pages/[type]/[project]/version/[version].vue
+++ b/apps/frontend/src/pages/[type]/[project]/version/[version].vue
@@ -832,8 +832,8 @@ const deleteVersionMutation = useMutation({
 	mutationFn: () => client.labrinth.versions_v3.deleteVersion(version.value!.id),
 	onSuccess: async () => {
 		addNotification({
-			title: 'Version deleted',
-			text: 'The version has been successfully deleted.',
+			title: formatMessage(messages.versionDeletedTitle),
+			text: formatMessage(messages.versionDeletedText),
 			type: 'success',
 		})
 		await invalidate()
@@ -841,7 +841,7 @@ const deleteVersionMutation = useMutation({
 	},
 	onError: (err: { data?: { description?: string } }) => {
 		addNotification({
-			title: 'An error occurred',
+			title: formatMessage(commonMessages.errorNotificationTitle),
 			text: err.data?.description ?? String(err),
 			type: 'error',
 		})
@@ -894,8 +894,8 @@ const createDataPackVersionMutation = useMutation({
 		packageModal.value?.hide()
 
 		addNotification({
-			title: 'Packaging Success',
-			text: 'Your data pack was successfully packaged as a mod! Make sure to playtest to check for errors.',
+			title: formatMessage(messages.packagingSuccessTitle),
+			text: formatMessage(messages.packagingSuccessText),
 			type: 'success',
 		})
 
@@ -906,7 +906,7 @@ const createDataPackVersionMutation = useMutation({
 	},
 	onError: (err: { data?: { description?: string } }) => {
 		addNotification({
-			title: 'An error occurred',
+			title: formatMessage(commonMessages.errorNotificationTitle),
 			text: err.data?.description ?? String(err),
 			type: 'error',
 		})
@@ -938,6 +938,23 @@ const messages = defineMessages({
 	noPrimaryFile: {
 		id: 'version.download.no-primary-file',
 		defaultMessage: 'Error: No primary file found',
+	},
+	versionDeletedTitle: {
+		id: 'version.notification.deleted-title',
+		defaultMessage: 'Version deleted',
+	},
+	versionDeletedText: {
+		id: 'version.notification.deleted-text',
+		defaultMessage: 'The version has been successfully deleted.',
+	},
+	packagingSuccessTitle: {
+		id: 'version.notification.packaging-success-title',
+		defaultMessage: 'Packaging Success',
+	},
+	packagingSuccessText: {
+		id: 'version.notification.packaging-success-text',
+		defaultMessage:
+			'Your data pack was successfully packaged as a mod! Make sure to playtest to check for errors.',
 	},
 	downloadVersion: {
 		id: 'version.download.version',

--- a/apps/frontend/src/pages/collection/[collection].vue
+++ b/apps/frontend/src/pages/collection/[collection].vue
@@ -72,7 +72,7 @@
 							:show-icon="false"
 							accept="image/png,image/jpeg,image/gif,image/webp"
 							class="hidden"
-							aria-label="Upload icon"
+							:aria-label="formatMessage(messages.uploadIconAriaLabel)"
 							@change="showPreviewImage"
 						/>
 					</div>
@@ -371,7 +371,7 @@
 					<ButtonStyled v-if="auth.user && auth.user.id === creator.id" color="brand">
 						<nuxt-link class="mx-auto w-min" to="/discover/mods">
 							<CompassIcon class="size-5" />
-							Discover mods
+							{{ formatMessage(messages.discoverModsButton) }}
 						</nuxt-link>
 					</ButtonStyled>
 				</template>
@@ -533,6 +533,14 @@ const messages = defineMessages({
 	noProjectsLabel: {
 		id: 'collection.label.no-projects',
 		defaultMessage: 'No projects in collection yet',
+	},
+	discoverModsButton: {
+		id: 'collection.button.discover-mods',
+		defaultMessage: 'Discover mods',
+	},
+	uploadIconAriaLabel: {
+		id: 'collection.aria-label.upload-icon',
+		defaultMessage: 'Upload icon',
 	},
 	projectsCountLabel: {
 		id: 'collection.label.projects-count',

--- a/apps/frontend/src/pages/hosting/index.vue
+++ b/apps/frontend/src/pages/hosting/index.vue
@@ -680,6 +680,30 @@ const formatPrice = useFormatPrice()
 const flags = useFeatureFlags()
 
 const messages = defineMessages({
+	errorFetchingPaymentDataTitle: {
+		id: 'hosting-marketing.notification.error-fetching-payment-data-title',
+		defaultMessage: 'Error fetching payment data',
+	},
+	unexpectedErrorText: {
+		id: 'hosting-marketing.notification.unexpected-error-text',
+		defaultMessage: 'An unexpected error occurred',
+	},
+	serverCapacityFullTitle: {
+		id: 'hosting-marketing.notification.server-capacity-full-title',
+		defaultMessage: 'Server Capacity Full',
+	},
+	serverCapacityFullText: {
+		id: 'hosting-marketing.notification.server-capacity-full-text',
+		defaultMessage: 'We are currently at capacity. Please try again later.',
+	},
+	invalidProductTitle: {
+		id: 'hosting-marketing.notification.invalid-product-title',
+		defaultMessage: 'Invalid product',
+	},
+	invalidProductText: {
+		id: 'hosting-marketing.notification.invalid-product-text',
+		defaultMessage: 'The selected product was found but lacks necessary data. Please contact support.',
+	},
 	hostWithModrinth: {
 		id: 'hosting-marketing.hero.host-with-modrinth',
 		defaultMessage: 'Host your next server with Modrinth Hosting',
@@ -1106,7 +1130,7 @@ const startTyping = () => {
 
 const handleError = (err) => {
 	addNotification({
-		title: 'An error occurred',
+		title: formatMessage(commonMessages.errorNotificationTitle),
 		type: 'error',
 		text: err.message ?? (err.data ? err.data.description : err),
 	})
@@ -1124,9 +1148,9 @@ async function fetchPaymentData() {
 	} catch (error) {
 		console.error('Error fetching payment data:', error)
 		addNotification({
-			title: 'Error fetching payment data',
+			title: formatMessage(messages.errorFetchingPaymentDataTitle),
 			type: 'error',
-			text: error.message || 'An unexpected error occurred',
+			text: error.message || formatMessage(messages.unexpectedErrorText),
 		})
 	}
 }
@@ -1177,9 +1201,9 @@ const selectProduct = async (product) => {
 
 	if ((product === 'custom' && isCustomAtCapacity.value) || isAtCapacity.value) {
 		addNotification({
-			title: 'Server Capacity Full',
+			title: formatMessage(messages.serverCapacityFullTitle),
 			type: 'error',
-			text: 'We are currently at capacity. Please try again later.',
+			text: formatMessage(messages.serverCapacityFullText),
 		})
 		return
 	}
@@ -1192,9 +1216,9 @@ const selectProduct = async (product) => {
 		(product !== 'custom' && !selectedPlan.metadata)
 	) {
 		addNotification({
-			title: 'Invalid product',
+			title: formatMessage(messages.invalidProductTitle),
 			type: 'error',
-			text: 'The selected product was found but lacks necessary data. Please contact support.',
+			text: formatMessage(messages.invalidProductText),
 		})
 		return
 	}

--- a/apps/frontend/src/pages/hosting/index.vue
+++ b/apps/frontend/src/pages/hosting/index.vue
@@ -702,7 +702,8 @@ const messages = defineMessages({
 	},
 	invalidProductText: {
 		id: 'hosting-marketing.notification.invalid-product-text',
-		defaultMessage: 'The selected product was found but lacks necessary data. Please contact support.',
+		defaultMessage:
+			'The selected product was found but lacks necessary data. Please contact support.',
 	},
 	hostWithModrinth: {
 		id: 'hosting-marketing.hero.host-with-modrinth',

--- a/apps/frontend/src/pages/moderation/index.vue
+++ b/apps/frontend/src/pages/moderation/index.vue
@@ -58,7 +58,7 @@
 						class="!w-full flex-grow sm:!w-[160px] sm:flex-grow-0 lg:!w-[140px]"
 						trigger-class="!h-10"
 						:options="itemsPerPageOptions"
-						placeholder="Items per page"
+						:placeholder="formatMessage(messages.itemsPerPagePlaceholder)"
 						@select="goToPage(1)"
 					>
 						<template #selected>
@@ -77,7 +77,7 @@
 					>
 						<ScaleIcon class="flex-shrink-0" />
 						<span class="hidden sm:inline">{{ formatMessage(messages.moderate) }}</span>
-						<span class="sm:hidden">Moderate</span>
+						<span class="sm:hidden">{{ formatMessage(messages.moderate) }}</span>
 					</button>
 				</ButtonStyled>
 			</div>
@@ -86,9 +86,16 @@
 		<div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
 			<div class="flex flex-wrap items-center gap-3">
 				<div v-if="totalProjects > 0">
-					Showing {{ pageStart }}–{{ pageEnd }} of {{ totalProjects }}
 					{{
-						currentFilterType === DEFAULT_FILTER_TYPE ? 'projects' : currentFilterType.toLowerCase()
+						formatMessage(messages.showingProjectsRange, {
+							start: pageStart,
+							end: pageEnd,
+							total: totalProjects,
+							type:
+								currentFilterType === DEFAULT_FILTER_TYPE
+									? formatMessage(messages.genericProjectsLabel)
+									: currentFilterType.toLowerCase(),
+						})
 					}}
 				</div>
 				<div class="flex items-center gap-2 text-sm font-semibold text-secondary">
@@ -189,6 +196,35 @@ const messages = defineMessages({
 	excludeTechnicalReview: {
 		id: 'moderation.exclude-technical-review',
 		defaultMessage: 'Exclude TR',
+	},
+	itemsPerPagePlaceholder: {
+		id: 'moderation.items-per-page-placeholder',
+		defaultMessage: 'Items per page',
+	},
+	skippedProjectsTitle: {
+		id: 'moderation.notification.skipped-projects-title',
+		defaultMessage: 'Skipped projects',
+	},
+	skippedProjectsText: {
+		id: 'moderation.notification.skipped-projects-text',
+		defaultMessage:
+			'{count, plural, one {Skipped # project} other {Skipped # projects}} already moderated or locked by others.',
+	},
+	noProjectsAvailableTitle: {
+		id: 'moderation.notification.no-projects-available-title',
+		defaultMessage: 'No projects available',
+	},
+	noProjectsAvailableText: {
+		id: 'moderation.notification.no-projects-available-text',
+		defaultMessage: 'All projects in queue are already moderated or locked by others.',
+	},
+	genericProjectsLabel: {
+		id: 'moderation.generic-projects-label',
+		defaultMessage: 'projects',
+	},
+	showingProjectsRange: {
+		id: 'moderation.showing-projects-range',
+		defaultMessage: 'Showing {start}–{end} of {total} {type}',
 	},
 })
 
@@ -498,8 +534,8 @@ function goToPage(page: number) {
 function notifySkippedProjects(skippedCount: number) {
 	if (skippedCount <= 0) return
 	addNotification({
-		title: 'Skipped projects',
-		text: `Skipped ${skippedCount} project(s) already moderated or locked by others.`,
+		title: formatMessage(messages.skippedProjectsTitle),
+		text: formatMessage(messages.skippedProjectsText, { count: skippedCount }),
 		type: 'info',
 		autoCloseMs: 2000,
 	})
@@ -577,8 +613,8 @@ async function moderateAllInFilter() {
 
 	if (!targetProjectId) {
 		addNotification({
-			title: 'No projects available',
-			text: 'All projects in queue are already moderated or locked by others.',
+			title: formatMessage(messages.noProjectsAvailableTitle),
+			text: formatMessage(messages.noProjectsAvailableText),
 			type: 'warning',
 		})
 		return
@@ -601,8 +637,8 @@ async function startFromProject(projectId: string) {
 
 	if (!targetProjectId) {
 		addNotification({
-			title: 'No projects available',
-			text: 'All projects in queue are already moderated or locked by others.',
+			title: formatMessage(messages.noProjectsAvailableTitle),
+			text: formatMessage(messages.noProjectsAvailableText),
 			type: 'warning',
 		})
 		return

--- a/apps/frontend/src/pages/moderation/index.vue
+++ b/apps/frontend/src/pages/moderation/index.vue
@@ -58,7 +58,7 @@
 						class="!w-full flex-grow sm:!w-[160px] sm:flex-grow-0 lg:!w-[140px]"
 						trigger-class="!h-10"
 						:options="itemsPerPageOptions"
-						:placeholder="formatMessage(messages.itemsPerPagePlaceholder)"
+						placeholder="Items per page"
 						@select="goToPage(1)"
 					>
 						<template #selected>
@@ -77,7 +77,7 @@
 					>
 						<ScaleIcon class="flex-shrink-0" />
 						<span class="hidden sm:inline">{{ formatMessage(messages.moderate) }}</span>
-						<span class="sm:hidden">{{ formatMessage(messages.moderate) }}</span>
+						<span class="sm:hidden">Moderate</span>
 					</button>
 				</ButtonStyled>
 			</div>
@@ -86,16 +86,9 @@
 		<div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
 			<div class="flex flex-wrap items-center gap-3">
 				<div v-if="totalProjects > 0">
+					Showing {{ pageStart }}–{{ pageEnd }} of {{ totalProjects }}
 					{{
-						formatMessage(messages.showingProjectsRange, {
-							start: pageStart,
-							end: pageEnd,
-							total: totalProjects,
-							type:
-								currentFilterType === DEFAULT_FILTER_TYPE
-									? formatMessage(messages.genericProjectsLabel)
-									: currentFilterType.toLowerCase(),
-						})
+						currentFilterType === DEFAULT_FILTER_TYPE ? 'projects' : currentFilterType.toLowerCase()
 					}}
 				</div>
 				<div class="flex items-center gap-2 text-sm font-semibold text-secondary">
@@ -196,35 +189,6 @@ const messages = defineMessages({
 	excludeTechnicalReview: {
 		id: 'moderation.exclude-technical-review',
 		defaultMessage: 'Exclude TR',
-	},
-	itemsPerPagePlaceholder: {
-		id: 'moderation.items-per-page-placeholder',
-		defaultMessage: 'Items per page',
-	},
-	skippedProjectsTitle: {
-		id: 'moderation.notification.skipped-projects-title',
-		defaultMessage: 'Skipped projects',
-	},
-	skippedProjectsText: {
-		id: 'moderation.notification.skipped-projects-text',
-		defaultMessage:
-			'{count, plural, one {Skipped # project} other {Skipped # projects}} already moderated or locked by others.',
-	},
-	noProjectsAvailableTitle: {
-		id: 'moderation.notification.no-projects-available-title',
-		defaultMessage: 'No projects available',
-	},
-	noProjectsAvailableText: {
-		id: 'moderation.notification.no-projects-available-text',
-		defaultMessage: 'All projects in queue are already moderated or locked by others.',
-	},
-	genericProjectsLabel: {
-		id: 'moderation.generic-projects-label',
-		defaultMessage: 'projects',
-	},
-	showingProjectsRange: {
-		id: 'moderation.showing-projects-range',
-		defaultMessage: 'Showing {start}–{end} of {total} {type}',
 	},
 })
 
@@ -534,8 +498,8 @@ function goToPage(page: number) {
 function notifySkippedProjects(skippedCount: number) {
 	if (skippedCount <= 0) return
 	addNotification({
-		title: formatMessage(messages.skippedProjectsTitle),
-		text: formatMessage(messages.skippedProjectsText, { count: skippedCount }),
+		title: 'Skipped projects',
+		text: `Skipped ${skippedCount} project(s) already moderated or locked by others.`,
 		type: 'info',
 		autoCloseMs: 2000,
 	})
@@ -613,8 +577,8 @@ async function moderateAllInFilter() {
 
 	if (!targetProjectId) {
 		addNotification({
-			title: formatMessage(messages.noProjectsAvailableTitle),
-			text: formatMessage(messages.noProjectsAvailableText),
+			title: 'No projects available',
+			text: 'All projects in queue are already moderated or locked by others.',
 			type: 'warning',
 		})
 		return
@@ -637,8 +601,8 @@ async function startFromProject(projectId: string) {
 
 	if (!targetProjectId) {
 		addNotification({
-			title: formatMessage(messages.noProjectsAvailableTitle),
-			text: formatMessage(messages.noProjectsAvailableText),
+			title: 'No projects available',
+			text: 'All projects in queue are already moderated or locked by others.',
 			type: 'warning',
 		})
 		return

--- a/apps/frontend/src/pages/organization/[organization].vue
+++ b/apps/frontend/src/pages/organization/[organization].vue
@@ -205,11 +205,16 @@
 					<UpToDate class="icon" />
 					<br />
 					<span class="preserve-lines text">
-						This organization doesn't have any projects yet.
 						<template v-if="isPermission(currentMember?.permissions, 1 << 4)">
-							Would you like to
-							<a class="link" @click="modal_creation?.show()">create one</a>?
+							<IntlFormatted :message-id="messages.noProjectsWithCreatePrompt">
+								<template #create-link="{ children }">
+									<a class="link" @click="modal_creation?.show()"
+										><component :is="() => normalizeChildren(children)"
+									/></a>
+								</template>
+							</IntlFormatted>
 						</template>
+						<template v-else>{{ formatMessage(messages.noProjects) }}</template>
 					</span>
 				</div>
 			</div>
@@ -233,8 +238,11 @@ import {
 	Avatar,
 	ButtonStyled,
 	commonMessages,
+	defineMessages,
 	injectModrinthClient,
+	IntlFormatted,
 	NavTabs,
+	normalizeChildren,
 	PROJECT_DEP_MARKER_QUERY,
 	ProjectCard,
 	ProjectCardList,
@@ -265,6 +273,18 @@ type ProjectV3 = Labrinth.Projects.v3.Project & {
 
 const vintl = useVIntl()
 const { formatMessage } = vintl
+
+const messages = defineMessages({
+	noProjects: {
+		id: 'organization.projects.none',
+		defaultMessage: "This organization doesn't have any projects yet.",
+	},
+	noProjectsWithCreatePrompt: {
+		id: 'organization.projects.none-with-create-prompt',
+		defaultMessage:
+			"This organization doesn't have any projects yet. Would you like to <create-link>create one</create-link>?",
+	},
+})
 
 const { formatCompactNumber } = useCompactNumber()
 

--- a/apps/frontend/src/pages/report.vue
+++ b/apps/frontend/src/pages/report.vue
@@ -288,6 +288,7 @@ import {
 	AutoLink,
 	Avatar,
 	ButtonStyled,
+	commonMessages,
 	defineMessage,
 	defineMessages,
 	formatReportItemType,
@@ -480,7 +481,7 @@ const submitReport = async () => {
 
 		if (error instanceof Error) {
 			addNotification({
-				title: 'An error occurred',
+				title: formatMessage(commonMessages.errorNotificationTitle),
 				text: error.message,
 				type: 'error',
 			})
@@ -505,7 +506,7 @@ const submitReport = async () => {
 
 		if (error instanceof Error) {
 			addNotification({
-				title: 'An error occurred',
+				title: formatMessage(commonMessages.errorNotificationTitle),
 				text: error.message,
 				type: 'error',
 			})

--- a/apps/frontend/src/pages/user/[user].vue
+++ b/apps/frontend/src/pages/user/[user].vue
@@ -2,10 +2,14 @@
 	<div v-if="user">
 		<ModalCreation ref="modal_creation" />
 		<CollectionCreateModal ref="modal_collection_creation" />
-		<NewModal ref="editRoleModal" header="Edit role">
+		<NewModal ref="editRoleModal" :header="formatMessage(messages.editRoleHeader)">
 			<div class="flex w-80 flex-col gap-4">
 				<div class="flex flex-col gap-2">
-					<Combobox v-model="selectedRole" :options="roleOptions" placeholder="Select a role" />
+					<Combobox
+						v-model="selectedRole"
+						:options="roleOptions"
+						:placeholder="formatMessage(messages.selectRolePlaceholder)"
+					/>
 				</div>
 				<div class="flex justify-end gap-2">
 					<ButtonStyled>
@@ -417,6 +421,22 @@ const messages = defineMessages({
 		id: 'profile.label.saving',
 		defaultMessage: 'Saving...',
 	},
+	editRoleHeader: {
+		id: 'profile.admin.edit-role-header',
+		defaultMessage: 'Edit role',
+	},
+	selectRolePlaceholder: {
+		id: 'profile.admin.select-role-placeholder',
+		defaultMessage: 'Select a role',
+	},
+	updateRoleFailedTitle: {
+		id: 'profile.admin.update-role-failed-title',
+		defaultMessage: 'Failed to update role',
+	},
+	updateRoleFailedMessage: {
+		id: 'profile.admin.update-role-failed-message',
+		defaultMessage: 'An error occurred while updating the user role. Please try again.',
+	},
 	emailLabel: {
 		id: 'profile.details.label.email',
 		defaultMessage: 'Email',
@@ -746,8 +766,8 @@ function saveRoleEdit() {
 
 			addNotification({
 				type: 'error',
-				title: 'Failed to update role',
-				message: 'An error occurred while updating the user role. Please try again.',
+				title: formatMessage(messages.updateRoleFailedTitle),
+				message: formatMessage(messages.updateRoleFailedMessage),
 			})
 		})
 		.finally(() => {

--- a/apps/frontend/src/pages/user/[user].vue
+++ b/apps/frontend/src/pages/user/[user].vue
@@ -2,14 +2,10 @@
 	<div v-if="user">
 		<ModalCreation ref="modal_creation" />
 		<CollectionCreateModal ref="modal_collection_creation" />
-		<NewModal ref="editRoleModal" :header="formatMessage(messages.editRoleHeader)">
+		<NewModal ref="editRoleModal" header="Edit role">
 			<div class="flex w-80 flex-col gap-4">
 				<div class="flex flex-col gap-2">
-					<Combobox
-						v-model="selectedRole"
-						:options="roleOptions"
-						:placeholder="formatMessage(messages.selectRolePlaceholder)"
-					/>
+					<Combobox v-model="selectedRole" :options="roleOptions" placeholder="Select a role" />
 				</div>
 				<div class="flex justify-end gap-2">
 					<ButtonStyled>
@@ -421,22 +417,6 @@ const messages = defineMessages({
 		id: 'profile.label.saving',
 		defaultMessage: 'Saving...',
 	},
-	editRoleHeader: {
-		id: 'profile.admin.edit-role-header',
-		defaultMessage: 'Edit role',
-	},
-	selectRolePlaceholder: {
-		id: 'profile.admin.select-role-placeholder',
-		defaultMessage: 'Select a role',
-	},
-	updateRoleFailedTitle: {
-		id: 'profile.admin.update-role-failed-title',
-		defaultMessage: 'Failed to update role',
-	},
-	updateRoleFailedMessage: {
-		id: 'profile.admin.update-role-failed-message',
-		defaultMessage: 'An error occurred while updating the user role. Please try again.',
-	},
 	emailLabel: {
 		id: 'profile.details.label.email',
 		defaultMessage: 'Email',
@@ -766,8 +746,8 @@ function saveRoleEdit() {
 
 			addNotification({
 				type: 'error',
-				title: formatMessage(messages.updateRoleFailedTitle),
-				message: formatMessage(messages.updateRoleFailedMessage),
+				title: 'Failed to update role',
+				message: 'An error occurred while updating the user role. Please try again.',
 			})
 		})
 		.finally(() => {


### PR DESCRIPTION
This is an i18n only pass on frontend components and pages that were already mostly translated, replacing leftover hard coded strings. On purpose, no logic changes were made, should keep this easy to review.