### PR TITLE
Fix vertical mis-aligned badge in notifcations

### DIFF
--- a/packages/ui/src/components/base/SimpleBadge.vue
+++ b/packages/ui/src/components/base/SimpleBadge.vue
@@ -1,5 +1,5 @@
 <template>
-	<span class="inline-flex items-center gap-1 font-semibold text-secondary">
+	<span class="inline-flex items-center gap-1 align-middle font-semibold text-secondary">
 		<component :is="icon" v-if="icon" :aria-hidden="true" class="shrink-0" />
 		{{ formattedName }}
 	</span>


### PR DESCRIPTION
Fixes a simple vertical mis-alignment so the badge appeared at the top of the line instead of middle aligning with text.


## After

<img width="639" height="47" alt="image" src="https://github.com/user-attachments/assets/e45b1b61-9400-4b97-891b-14498d5cef93" />


## Before

<img width="681" height="55" alt="image" src="https://github.com/user-attachments/assets/e767cd74-04ee-461e-a502-7dcb42dd0f0d" />
