### PR TITLE
docs: corrections to GetLatestVersionFromHash and GetLatestVersionsFromHashes documentation

### DIFF
--- a/apps/docs/public/openapi.yaml
+++ b/apps/docs/public/openapi.yaml
@@ -563,12 +563,18 @@ components:
           type: array
           items:
             type: string
-            example: [fabric]
+          example: [fabric]
         game_versions:
           type: array
           items:
             type: string
           example: ['1.18', 1.18.1]
+        version_types:
+          type: array
+          items:
+            type: string
+          enum: [release, alpha, beta]
+          example: [release]
       required:
         - loaders
         - game_versions
@@ -612,6 +618,12 @@ components:
               items:
                 type: string
               example: ['1.18', 1.18.1]
+            version_types:
+              type: array
+              items:
+                type: string
+              enum: [release, alpha, beta]
+              example: [release]
           required:
             - loaders
             - game_versions
@@ -2865,7 +2877,7 @@ paths:
               $ref: '#/components/schemas/HashList'
   /version_files/update:
     post:
-      summary: Latest versions of multiple project from hashes, loader(s), and game version(s)
+      summary: Latest versions of multiple projects from hashes, loader(s), and game version(s)
       description: This is the same as [`/version_file/{hash}/update`](#operation/getLatestVersionFromHash) except it accepts multiple hashes.
       operationId: getLatestVersionsFromHashes
       tags:


### PR DESCRIPTION
### Explanation
Currently, the API documentation for the [`GetLatestVersionFromHash`](https://docs.modrinth.com/api/operations/getlatestversionfromhash/) and [`GetLatestVersionsFromHashes`](https://docs.modrinth.com/api/operations/getlatestversionsfromhashes/) endpoints contain a number of small inaccuracies and errors. These include minor typos, formatting errors, and undocumented parameters.

### Changes
* Fixed an incorrectly indented line preventing the example for the equest body parameter `loaders` from rendering on the `GetLatestVersionFromHash` page
* Added the request body parameter `version_types` with type, enum, and example for both endpoints
* Corrected `GetLatestVersionsFromHashes` summary from "Latest versions of multiple project from hashes, loader(s), and game version(s)" to "Latest versions of multiple **<ins>projects</ins>** from hashes, loader(s), and game version(s)"