### PR TITLE
fix: mc account logout on stale

### DIFF
--- a/apps/app-frontend/src/pages/Skins.vue
+++ b/apps/app-frontend/src/pages/Skins.vue
@@ -1038,6 +1038,7 @@ async function checkUserChanges() {
 	try {
 		const defaultId = await get_default_user()
 		if (defaultId !== currentUserId.value) {
+			await accountsCard.value?.refreshValues()
 			await loadCurrentUser()
 			await loadCapes()
 			await loadSkins()

--- a/packages/app-lib/src/api/minecraft_auth.rs
+++ b/packages/app-lib/src/api/minecraft_auth.rs
@@ -39,7 +39,7 @@ pub async fn finish_login(
 #[tracing::instrument]
 pub async fn get_default_user() -> crate::Result<Option<uuid::Uuid>> {
     let state = State::get().await?;
-    let user = Credentials::get_active(&state.pool).await?;
+    let user = Credentials::get_default_credential(&state.pool).await?;
     Ok(user.map(|user| user.offline_profile.id))
 }
 

--- a/packages/app-lib/src/state/minecraft_auth.rs
+++ b/packages/app-lib/src/state/minecraft_auth.rs
@@ -79,6 +79,26 @@ pub enum MinecraftAuthenticationError {
     NoUserHash,
 }
 
+#[derive(Deserialize)]
+struct OAuthErrorResponse {
+    error: String,
+}
+
+impl MinecraftAuthenticationError {
+    fn is_invalid_grant(&self) -> bool {
+        matches!(
+            self,
+            Self::DeserializeResponse {
+                step: MinecraftAuthStep::RefreshOAuthToken,
+                raw,
+                status_code: StatusCode::BAD_REQUEST,
+                ..
+            } if serde_json::from_str::<OAuthErrorResponse>(raw)
+                .is_ok_and(|response| response.error == "invalid_grant")
+        )
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 pub struct MinecraftLoginFlow {
     pub verifier: String,
@@ -464,6 +484,23 @@ impl Credentials {
                         && (source.is_connect() || source.is_timeout())
                     {
                         return Ok(Some(creds));
+                    }
+
+                    if matches!(
+                        &*err.raw,
+                        ErrorKind::MinecraftAuthenticationError(source)
+                            if source.is_invalid_grant()
+                    ) {
+                        Self::remove(creds.offline_profile.id, exec).await?;
+
+                        if let Some((_, mut user)) =
+                            Self::get_all(exec).await?.into_iter().next()
+                        {
+                            user.active = true;
+                            user.upsert(exec).await?;
+                        }
+
+                        return Ok(None);
                     }
 
                     Err(err)


### PR DESCRIPTION
- When a req fails related to the currently selected minecraft account being unavailable (session revoked/expired) it will auto sign out
- This fixes blank white skin issue on skins page:
<img width="3980" height="2394" alt="image" src="https://github.com/user-attachments/assets/c8718418-224e-42af-bce9-8956c9a2cfc9" />
