### PR TITLE
refactor(i18n): use common messages for generic button labels

### DIFF
--- a/apps/app-frontend/src/components/ui/modal/ModrinthAccountRequiredModal.vue
+++ b/apps/app-frontend/src/components/ui/modal/ModrinthAccountRequiredModal.vue
@@ -73,7 +73,7 @@
 				<div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
 					<Button type="outlined" class="w-full" native-type="button" @click="modal?.hide()">
 						<XIcon aria-hidden="true" />
-						{{ formatMessage(messages.cancelButton) }}
+						{{ formatMessage(commonMessages.cancelButton) }}
 					</Button>
 					<Button
 						class="w-full"
@@ -106,7 +106,14 @@
 
 <script setup lang="ts">
 import { LogInIcon, RefreshCwIcon, SpinnerIcon, UserPlusIcon, XIcon } from '@modrinth/assets'
-import { Button, defineMessages, IntlFormatted, NewModal, useVIntl } from '@modrinth/ui'
+import {
+	Button,
+	commonMessages,
+	defineMessages,
+	IntlFormatted,
+	NewModal,
+	useVIntl,
+} from '@modrinth/ui'
 import { openUrl } from '@tauri-apps/plugin-opener'
 import { ref } from 'vue'
 
@@ -244,10 +251,6 @@ const messages = defineMessages({
 	waitingForBrowser: {
 		id: 'modal.modrinth-account-required.waiting-for-browser',
 		defaultMessage: 'Waiting for browser confirmation...',
-	},
-	cancelButton: {
-		id: 'modal.modrinth-account-required.cancel-button',
-		defaultMessage: 'Cancel',
 	},
 	openBrowserAgainButton: {
 		id: 'modal.modrinth-account-required.open-browser-again-button',

--- a/apps/app-frontend/src/locales/da-DK/index.json
+++ b/apps/app-frontend/src/locales/da-DK/index.json
@@ -1112,9 +1112,6 @@
   "minecraft-required.sign-in": {
     "message": "Log ind på Microsoft"
   },
-  "modal.modrinth-account-required.cancel-button": {
-    "message": "Annuller"
-  },
   "modal.modrinth-account-required.continue-in-browser-heading": {
     "message": "Fortsæt i din browser"
   },

--- a/apps/app-frontend/src/locales/de-CH/index.json
+++ b/apps/app-frontend/src/locales/de-CH/index.json
@@ -1853,9 +1853,6 @@
   "modal.modrinth-account-required.browser-description": {
     "message": "Ein neuer Tab zum Anmelden wurde geöffnet. Schließe die Anmeldung dort ab und kehren anschließend zur App zurück."
   },
-  "modal.modrinth-account-required.cancel-button": {
-    "message": "Abbrechen"
-  },
   "modal.modrinth-account-required.continue-in-browser-heading": {
     "message": "Im Browser fortfahren"
   },

--- a/apps/app-frontend/src/locales/de-DE/index.json
+++ b/apps/app-frontend/src/locales/de-DE/index.json
@@ -1853,9 +1853,6 @@
   "modal.modrinth-account-required.browser-description": {
     "message": "Ein neuer Tab zum Anmelden wurde geöffnet. Schließe die Anmeldung dort ab und kehren anschließend zur App zurück."
   },
-  "modal.modrinth-account-required.cancel-button": {
-    "message": "Abbrechen"
-  },
   "modal.modrinth-account-required.continue-in-browser-heading": {
     "message": "Im Browser fortfahren"
   },

--- a/apps/app-frontend/src/locales/en-US/index.json
+++ b/apps/app-frontend/src/locales/en-US/index.json
@@ -1880,9 +1880,6 @@
   "modal.modrinth-account-required.browser-description": {
     "message": "A new tab opened to sign in. Complete the sign in there, then return to the app."
   },
-  "modal.modrinth-account-required.cancel-button": {
-    "message": "Cancel"
-  },
   "modal.modrinth-account-required.continue-in-browser-heading": {
     "message": "Continue in your browser"
   },

--- a/apps/app-frontend/src/locales/es-419/index.json
+++ b/apps/app-frontend/src/locales/es-419/index.json
@@ -1481,9 +1481,6 @@
   "minecraft-required.sign-in": {
     "message": "Iniciar sesión con Microsoft"
   },
-  "modal.modrinth-account-required.cancel-button": {
-    "message": "Cancelar"
-  },
   "modal.modrinth-account-required.header": {
     "message": "Cuenta requerida"
   },

--- a/apps/app-frontend/src/locales/fr-FR/index.json
+++ b/apps/app-frontend/src/locales/fr-FR/index.json
@@ -1754,9 +1754,6 @@
   "modal.modrinth-account-required.browser-description": {
     "message": "A nouvel onglet a été ouvert pour vous connecter. Finissez la connexion, puis retournez dans l'application."
   },
-  "modal.modrinth-account-required.cancel-button": {
-    "message": "Annuler"
-  },
   "modal.modrinth-account-required.continue-in-browser-heading": {
     "message": "Continuer dans votre navigateur"
   },

--- a/apps/app-frontend/src/locales/hu-HU/index.json
+++ b/apps/app-frontend/src/locales/hu-HU/index.json
@@ -1856,9 +1856,6 @@
   "modal.modrinth-account-required.browser-description": {
     "message": "Megnyílt egy új lap a bejelentkezéshez. Végezd el ott a bejelentkezést, majd térj vissza az alkalmazásba."
   },
-  "modal.modrinth-account-required.cancel-button": {
-    "message": "Mégse"
-  },
   "modal.modrinth-account-required.continue-in-browser-heading": {
     "message": "Folytatás a böngészőben"
   },

--- a/apps/app-frontend/src/locales/it-IT/index.json
+++ b/apps/app-frontend/src/locales/it-IT/index.json
@@ -1853,9 +1853,6 @@
   "modal.modrinth-account-required.browser-description": {
     "message": "Si è aperta una nuova scheda per effettuare l'accesso. Poi torna all'app."
   },
-  "modal.modrinth-account-required.cancel-button": {
-    "message": "Annulla"
-  },
   "modal.modrinth-account-required.continue-in-browser-heading": {
     "message": "Continua nel browser"
   },

--- a/apps/app-frontend/src/locales/ja-JP/index.json
+++ b/apps/app-frontend/src/locales/ja-JP/index.json
@@ -1853,9 +1853,6 @@
   "modal.modrinth-account-required.browser-description": {
     "message": "サインイン用のタブが開きました。そちらでサインインを完了してから、アプリに戻ってください。"
   },
-  "modal.modrinth-account-required.cancel-button": {
-    "message": "キャンセル"
-  },
   "modal.modrinth-account-required.continue-in-browser-heading": {
     "message": "ブラウザで続行"
   },

--- a/apps/app-frontend/src/locales/ko-KR/index.json
+++ b/apps/app-frontend/src/locales/ko-KR/index.json
@@ -1853,9 +1853,6 @@
   "modal.modrinth-account-required.browser-description": {
     "message": "로그인을 위한 새 탭이 열렸습니다. 해당 탭에서 로그인을 완료한 후 앱 돌아오세요."
   },
-  "modal.modrinth-account-required.cancel-button": {
-    "message": "취소"
-  },
   "modal.modrinth-account-required.continue-in-browser-heading": {
     "message": "브라우저에서 계속 진행"
   },

--- a/apps/app-frontend/src/locales/nl-NL/index.json
+++ b/apps/app-frontend/src/locales/nl-NL/index.json
@@ -1763,9 +1763,6 @@
   "modal.modrinth-account-required.browser-description": {
     "message": "Er is een nieuw tabblad geopend om je aan te melden. Log daar in en ga vervolgens terug naar de app."
   },
-  "modal.modrinth-account-required.cancel-button": {
-    "message": "Annuleren"
-  },
   "modal.modrinth-account-required.continue-in-browser-heading": {
     "message": "Doorgaan in je browser"
   },

--- a/apps/app-frontend/src/locales/pl-PL/index.json
+++ b/apps/app-frontend/src/locales/pl-PL/index.json
@@ -1619,9 +1619,6 @@
   "minecraft-required.sign-in": {
     "message": "Zaloguj się do Microsoft"
   },
-  "modal.modrinth-account-required.cancel-button": {
-    "message": "Anuluj"
-  },
   "modal.modrinth-account-required.continue-in-browser-heading": {
     "message": "Kontynuuj w przeglądarce"
   },

--- a/apps/app-frontend/src/locales/pt-BR/index.json
+++ b/apps/app-frontend/src/locales/pt-BR/index.json
@@ -1856,9 +1856,6 @@
   "modal.modrinth-account-required.browser-description": {
     "message": "Uma nova aba foi aberta para iniciar sessão. Conclua lá, então volte ao aplicativo."
   },
-  "modal.modrinth-account-required.cancel-button": {
-    "message": "Cancelar"
-  },
   "modal.modrinth-account-required.continue-in-browser-heading": {
     "message": "Continuar em seu navegador"
   },

--- a/apps/app-frontend/src/locales/ru-RU/index.json
+++ b/apps/app-frontend/src/locales/ru-RU/index.json
@@ -1844,9 +1844,6 @@
   "modal.modrinth-account-required.browser-description": {
     "message": "Открылась вкладка для входа. Завершение вход и вернитесь в приложение."
   },
-  "modal.modrinth-account-required.cancel-button": {
-    "message": "Отмена"
-  },
   "modal.modrinth-account-required.continue-in-browser-heading": {
     "message": "Продолжите в браузере"
   },

--- a/apps/app-frontend/src/locales/sv-SE/index.json
+++ b/apps/app-frontend/src/locales/sv-SE/index.json
@@ -1640,9 +1640,6 @@
   "minecraft-required.sign-in": {
     "message": "Logga in på Microsoft"
   },
-  "modal.modrinth-account-required.cancel-button": {
-    "message": "Avbryt"
-  },
   "modal.modrinth-account-required.continue-in-browser-heading": {
     "message": "Fortsätt i din webbläsare"
   },

--- a/apps/app-frontend/src/locales/tr-TR/index.json
+++ b/apps/app-frontend/src/locales/tr-TR/index.json
@@ -1457,9 +1457,6 @@
   "minecraft-required.sign-in": {
     "message": "Microsoft'a giriş yap"
   },
-  "modal.modrinth-account-required.cancel-button": {
-    "message": "İptal"
-  },
   "modal.modrinth-account-required.continue-in-browser-heading": {
     "message": "Tarayıcında devam et"
   },

--- a/apps/app-frontend/src/locales/uk-UA/index.json
+++ b/apps/app-frontend/src/locales/uk-UA/index.json
@@ -1853,9 +1853,6 @@
   "modal.modrinth-account-required.browser-description": {
     "message": "Відкрилася нова вкладка, де ви зможете ввійти. Увійдіть, тоді поверніться до застосунку."
   },
-  "modal.modrinth-account-required.cancel-button": {
-    "message": "Скасувати"
-  },
   "modal.modrinth-account-required.continue-in-browser-heading": {
     "message": "Продовжити у браузері"
   },

--- a/apps/app-frontend/src/locales/zh-CN/index.json
+++ b/apps/app-frontend/src/locales/zh-CN/index.json
@@ -1856,9 +1856,6 @@
   "modal.modrinth-account-required.browser-description": {
     "message": "一个新的标签页已打开，你需要在那里完成登录，然后回到Modrinth app。"
   },
-  "modal.modrinth-account-required.cancel-button": {
-    "message": "取消"
-  },
   "modal.modrinth-account-required.continue-in-browser-heading": {
     "message": "请在你的浏览器中继续"
   },

--- a/apps/app-frontend/src/locales/zh-TW/index.json
+++ b/apps/app-frontend/src/locales/zh-TW/index.json
@@ -1856,9 +1856,6 @@
   "modal.modrinth-account-required.browser-description": {
     "message": "一個新分頁已開啟供你登入。請在該分頁完成登入，然後返回應用程式。"
   },
-  "modal.modrinth-account-required.cancel-button": {
-    "message": "取消"
-  },
   "modal.modrinth-account-required.continue-in-browser-heading": {
     "message": "在瀏覽器中繼續"
   },

--- a/apps/frontend/src/components/ui/dashboard/CreatorTaxFormModal.vue
+++ b/apps/frontend/src/components/ui/dashboard/CreatorTaxFormModal.vue
@@ -133,7 +133,7 @@
 				</div>
 				<div class="flex w-full flex-row justify-stretch gap-2">
 					<Button class="w-full text-contrast" @click="handleClose">
-						{{ props.closeButtonText ?? formatMessage(messages.closeButton) }}
+						{{ props.closeButtonText ?? formatMessage(commonMessages.closeButton) }}
 					</Button>
 					<Button
 						type="colored"
@@ -266,10 +266,6 @@ const messages = defineMessages({
 	downloadButton: {
 		id: 'dashboard.creator-tax-form-modal.confirmation.download-button',
 		defaultMessage: 'Download {formType}',
-	},
-	closeButton: {
-		id: 'dashboard.creator-tax-form-modal.close-button',
-		defaultMessage: 'Close',
 	},
 	incompleteTitle: {
 		id: 'dashboard.creator-tax-form-modal.incomplete.title',

--- a/apps/frontend/src/components/ui/moderation/ModpackScanModal.vue
+++ b/apps/frontend/src/components/ui/moderation/ModpackScanModal.vue
@@ -11,6 +11,7 @@ import { Button, IconButton } from '@modrinth/ui'
 import {
 	Combobox,
 	type ComboboxOption,
+	commonMessages,
 	ConfirmModal,
 	defineMessages,
 	injectModrinthClient,
@@ -61,10 +62,6 @@ const messages = defineMessages({
 		id: 'modpack-scan-modal.scanning',
 		defaultMessage: 'Scanning...',
 	},
-	success: {
-		id: 'modpack-scan-modal.success',
-		defaultMessage: 'Success',
-	},
 	failed: {
 		id: 'modpack-scan-modal.failed',
 		defaultMessage: 'Failed',
@@ -101,10 +98,6 @@ const messages = defineMessages({
 		id: 'modpack-scan-modal.delete-all-groups-confirmation.description',
 		defaultMessage:
 			'This will permanently delete all attribution groups for this project and all files inside them. This action cannot be undone.',
-	},
-	deleteAllGroupsConfirmationProceed: {
-		id: 'modpack-scan-modal.delete-all-groups.proceed',
-		defaultMessage: 'Clear',
 	},
 	deleteAllGroupsSuccess: {
 		id: 'modpack-scan-modal.delete-all-groups.success',
@@ -344,7 +337,7 @@ async function clearAllGroups() {
 	if (!failed) {
 		addNotification({
 			type: 'success',
-			title: formatMessage(messages.success),
+			title: formatMessage(commonMessages.successLabel),
 			text: formatMessage(messages.deleteAllGroupsSuccess),
 		})
 	}
@@ -369,7 +362,7 @@ defineExpose({ show, hide })
 		ref="clearModalRef"
 		:title="formatMessage(messages.deleteAllGroupsConfirmationTitle)"
 		:description="formatMessage(messages.deleteAllGroupsConfirmationDescription)"
-		:proceed-label="formatMessage(messages.deleteAllGroupsConfirmationProceed)"
+		:proceed-label="formatMessage(commonMessages.clearButton)"
 		@proceed="clearAllGroups"
 	/>
 

--- a/apps/frontend/src/locales/de-CH/index.json
+++ b/apps/frontend/src/locales/de-CH/index.json
@@ -1481,9 +1481,6 @@
   "dashboard.collections.sort.recently-updated": {
     "message": "Kürzlich aktualisiert"
   },
-  "dashboard.creator-tax-form-modal.close-button": {
-    "message": "Schließen"
-  },
   "dashboard.creator-tax-form-modal.confirmation.download-button": {
     "message": "{formType} herunterladen"
   },
@@ -2984,9 +2981,6 @@
   "modpack-scan-modal.delete-all-groups.error": {
     "message": "Fehler beim Löschen aller Gruppen: {error}"
   },
-  "modpack-scan-modal.delete-all-groups.proceed": {
-    "message": "Löschen"
-  },
   "modpack-scan-modal.delete-all-groups.success": {
     "message": "Alle Gruppen wurden gelöscht."
   },
@@ -3025,9 +3019,6 @@
   },
   "modpack-scan-modal.scanning": {
     "message": "Wird gescannt..."
-  },
-  "modpack-scan-modal.success": {
-    "message": "Erfolg"
   },
   "modpack-scan-modal.title": {
     "message": "Modpack-Scan ({scanned}/{total} Dateien)"

--- a/apps/frontend/src/locales/de-DE/index.json
+++ b/apps/frontend/src/locales/de-DE/index.json
@@ -1481,9 +1481,6 @@
   "dashboard.collections.sort.recently-updated": {
     "message": "Kürzlich aktualisiert"
   },
-  "dashboard.creator-tax-form-modal.close-button": {
-    "message": "Schließen"
-  },
   "dashboard.creator-tax-form-modal.confirmation.download-button": {
     "message": "Lade {formType} herunter"
   },
@@ -2984,9 +2981,6 @@
   "modpack-scan-modal.delete-all-groups.error": {
     "message": "Fehler beim Löschen aller Gruppen: {error}"
   },
-  "modpack-scan-modal.delete-all-groups.proceed": {
-    "message": "Löschen"
-  },
   "modpack-scan-modal.delete-all-groups.success": {
     "message": "Alle Gruppen wurden gelöscht."
   },
@@ -3025,9 +3019,6 @@
   },
   "modpack-scan-modal.scanning": {
     "message": "Wird gescannt..."
-  },
-  "modpack-scan-modal.success": {
-    "message": "Erfolg"
   },
   "modpack-scan-modal.title": {
     "message": "Modpack-Scan ({scanned}/{total} Dateien)"

--- a/apps/frontend/src/locales/en-US/index.json
+++ b/apps/frontend/src/locales/en-US/index.json
@@ -1481,9 +1481,6 @@
   "dashboard.collections.sort.recently-updated": {
     "message": "Recently Updated"
   },
-  "dashboard.creator-tax-form-modal.close-button": {
-    "message": "Close"
-  },
   "dashboard.creator-tax-form-modal.confirmation.download-button": {
     "message": "Download {formType}"
   },
@@ -2984,9 +2981,6 @@
   "modpack-scan-modal.delete-all-groups.error": {
     "message": "Failed to clear all groups: {error}"
   },
-  "modpack-scan-modal.delete-all-groups.proceed": {
-    "message": "Clear"
-  },
   "modpack-scan-modal.delete-all-groups.success": {
     "message": "All groups cleared successfully."
   },
@@ -3025,9 +3019,6 @@
   },
   "modpack-scan-modal.scanning": {
     "message": "Scanning..."
-  },
-  "modpack-scan-modal.success": {
-    "message": "Success"
   },
   "modpack-scan-modal.title": {
     "message": "Modpack Scan ({scanned}/{total} Files)"

--- a/apps/frontend/src/locales/es-419/index.json
+++ b/apps/frontend/src/locales/es-419/index.json
@@ -1481,9 +1481,6 @@
   "dashboard.collections.sort.recently-updated": {
     "message": "Actualizado recientemente"
   },
-  "dashboard.creator-tax-form-modal.close-button": {
-    "message": "Cerrar"
-  },
   "dashboard.creator-tax-form-modal.confirmation.download-button": {
     "message": "Descargar {formType}"
   },
@@ -2984,9 +2981,6 @@
   "modpack-scan-modal.delete-all-groups.error": {
     "message": "Error al borrar todos los grupos: {error}"
   },
-  "modpack-scan-modal.delete-all-groups.proceed": {
-    "message": "Borrar"
-  },
   "modpack-scan-modal.delete-all-groups.success": {
     "message": "Todos los grupos fueron borrados exitosamente."
   },
@@ -3025,9 +3019,6 @@
   },
   "modpack-scan-modal.scanning": {
     "message": "Escaneando..."
-  },
-  "modpack-scan-modal.success": {
-    "message": "Éxito"
   },
   "modpack-scan-modal.title": {
     "message": "Análisis del modpack ({scanned}/{total} archivos)"

--- a/apps/frontend/src/locales/fr-FR/index.json
+++ b/apps/frontend/src/locales/fr-FR/index.json
@@ -1481,9 +1481,6 @@
   "dashboard.collections.sort.recently-updated": {
     "message": "Mis à jour récemment"
   },
-  "dashboard.creator-tax-form-modal.close-button": {
-    "message": "Fermer"
-  },
   "dashboard.creator-tax-form-modal.confirmation.download-button": {
     "message": "Télécharger {formType}"
   },
@@ -2984,9 +2981,6 @@
   "modpack-scan-modal.delete-all-groups.error": {
     "message": "Le nettoyage des groupes a échoué : {error}"
   },
-  "modpack-scan-modal.delete-all-groups.proceed": {
-    "message": "Effacer"
-  },
   "modpack-scan-modal.delete-all-groups.success": {
     "message": "Tous les groupes ont été nettoyés avec succès."
   },
@@ -3025,9 +3019,6 @@
   },
   "modpack-scan-modal.scanning": {
     "message": "Scan en cours..."
-  },
-  "modpack-scan-modal.success": {
-    "message": "Succès"
   },
   "modpack-scan-modal.title": {
     "message": "Scan du modpack ({scanned}/{total} fichiers)"

--- a/apps/frontend/src/locales/hu-HU/index.json
+++ b/apps/frontend/src/locales/hu-HU/index.json
@@ -1415,9 +1415,6 @@
   "dashboard.collections.sort.recently-updated": {
     "message": "Nemrég frissített"
   },
-  "dashboard.creator-tax-form-modal.close-button": {
-    "message": "Bezárás"
-  },
   "dashboard.creator-tax-form-modal.confirmation.download-button": {
     "message": "Letöltés {formType}"
   },

--- a/apps/frontend/src/locales/it-IT/index.json
+++ b/apps/frontend/src/locales/it-IT/index.json
@@ -1475,9 +1475,6 @@
   "dashboard.collections.sort.recently-updated": {
     "message": "Ultima modifica"
   },
-  "dashboard.creator-tax-form-modal.close-button": {
-    "message": "Chiudi"
-  },
   "dashboard.creator-tax-form-modal.confirmation.download-button": {
     "message": "Scarica {formType}"
   },
@@ -2975,9 +2972,6 @@
   "modpack-scan-modal.delete-all-groups.error": {
     "message": "Errore nell'eliminazione dei gruppi: {error}"
   },
-  "modpack-scan-modal.delete-all-groups.proceed": {
-    "message": "Procedi"
-  },
   "modpack-scan-modal.delete-all-groups.success": {
     "message": "Tutti i gruppi eliminati con successo."
   },
@@ -3016,9 +3010,6 @@
   },
   "modpack-scan-modal.scanning": {
     "message": "Scansione..."
-  },
-  "modpack-scan-modal.success": {
-    "message": "Successo"
   },
   "modpack-scan-modal.title": {
     "message": "Scansione del pacchetto ({scanned}/{total} file)"

--- a/apps/frontend/src/locales/ja-JP/index.json
+++ b/apps/frontend/src/locales/ja-JP/index.json
@@ -1109,9 +1109,6 @@
   "dashboard.collections.sort.recently-updated": {
     "message": "更新順(新しい順)"
   },
-  "dashboard.creator-tax-form-modal.close-button": {
-    "message": "閉じる"
-  },
   "dashboard.creator-tax-form-modal.confirmation.download-button": {
     "message": "{formType} をダウンロード"
   },

--- a/apps/frontend/src/locales/ko-KR/index.json
+++ b/apps/frontend/src/locales/ko-KR/index.json
@@ -1481,9 +1481,6 @@
   "dashboard.collections.sort.recently-updated": {
     "message": "최근 업데이트"
   },
-  "dashboard.creator-tax-form-modal.close-button": {
-    "message": "닫기"
-  },
   "dashboard.creator-tax-form-modal.confirmation.download-button": {
     "message": "{formType} 다운로드"
   },
@@ -2984,9 +2981,6 @@
   "modpack-scan-modal.delete-all-groups.error": {
     "message": "모든 그룹 삭제 실패: {error}"
   },
-  "modpack-scan-modal.delete-all-groups.proceed": {
-    "message": "삭제"
-  },
   "modpack-scan-modal.delete-all-groups.success": {
     "message": "모든 그룹 삭제 완료."
   },
@@ -3025,9 +3019,6 @@
   },
   "modpack-scan-modal.scanning": {
     "message": "스캔중..."
-  },
-  "modpack-scan-modal.success": {
-    "message": "성공"
   },
   "modpack-scan-modal.title": {
     "message": "모드팩 스캔 ({scanned}/{total} 파일)"

--- a/apps/frontend/src/locales/ms-MY/index.json
+++ b/apps/frontend/src/locales/ms-MY/index.json
@@ -1112,9 +1112,6 @@
   "dashboard.collections.sort.recently-updated": {
     "message": "Dikemas Kini Baru-baru Ini"
   },
-  "dashboard.creator-tax-form-modal.close-button": {
-    "message": "Tutup"
-  },
   "dashboard.creator-tax-form-modal.confirmation.download-button": {
     "message": "Muat turun {formType}"
   },
@@ -2422,9 +2419,6 @@
   },
   "moderation.page.technicalReview": {
     "message": "Semakan teknikal"
-  },
-  "modpack-scan-modal.delete-all-groups.proceed": {
-    "message": "Kosongkan"
   },
   "modpack-scan-modal.failed": {
     "message": "Gagal"

--- a/apps/frontend/src/locales/nl-NL/index.json
+++ b/apps/frontend/src/locales/nl-NL/index.json
@@ -1478,9 +1478,6 @@
   "dashboard.collections.sort.recently-updated": {
     "message": "Recentelijk geüpdate"
   },
-  "dashboard.creator-tax-form-modal.close-button": {
-    "message": "Sluiten"
-  },
   "dashboard.creator-tax-form-modal.confirmation.download-button": {
     "message": "Download {formType}"
   },
@@ -2981,9 +2978,6 @@
   "modpack-scan-modal.delete-all-groups.error": {
     "message": "Niet gelukt om alle groepen te wissen: {error}"
   },
-  "modpack-scan-modal.delete-all-groups.proceed": {
-    "message": "Wissen"
-  },
   "modpack-scan-modal.delete-all-groups.success": {
     "message": "Alle groepen zijn succesvol gewist."
   },
@@ -3022,9 +3016,6 @@
   },
   "modpack-scan-modal.scanning": {
     "message": "Scannen..."
-  },
-  "modpack-scan-modal.success": {
-    "message": "Gelukt"
   },
   "modpack-scan-modal.title": {
     "message": "Modpack-scan ({scanned}/{total} bestanden)"

--- a/apps/frontend/src/locales/pl-PL/index.json
+++ b/apps/frontend/src/locales/pl-PL/index.json
@@ -1478,9 +1478,6 @@
   "dashboard.collections.sort.recently-updated": {
     "message": "Ostatnio zaktualizowane"
   },
-  "dashboard.creator-tax-form-modal.close-button": {
-    "message": "Zamknij"
-  },
   "dashboard.creator-tax-form-modal.confirmation.download-button": {
     "message": "Pobierz {formType}"
   },
@@ -2975,9 +2972,6 @@
   "modpack-scan-modal.delete-all-groups-confirmation.description": {
     "message": "Trwale usunie to wszystkie grupy atrybucji i wszystkie zawarte w nich pliki. Tej akcji nie można cofnąć."
   },
-  "modpack-scan-modal.delete-all-groups.proceed": {
-    "message": "Wyczyść"
-  },
   "modpack-scan-modal.failed": {
     "message": "Błąd"
   },
@@ -3013,9 +3007,6 @@
   },
   "modpack-scan-modal.scanning": {
     "message": "Skanowanie..."
-  },
-  "modpack-scan-modal.success": {
-    "message": "Sukces"
   },
   "modpack-scan-modal.title": {
     "message": "Skanowanie paczki modów ({scanned}/{total} plików)"

--- a/apps/frontend/src/locales/pt-BR/index.json
+++ b/apps/frontend/src/locales/pt-BR/index.json
@@ -1481,9 +1481,6 @@
   "dashboard.collections.sort.recently-updated": {
     "message": "Atualizado recentemente"
   },
-  "dashboard.creator-tax-form-modal.close-button": {
-    "message": "Fechar"
-  },
   "dashboard.creator-tax-form-modal.confirmation.download-button": {
     "message": "Baixar {formType}"
   },
@@ -2984,9 +2981,6 @@
   "modpack-scan-modal.delete-all-groups.error": {
     "message": "Falhou ao excluir todos os grupos: {error}"
   },
-  "modpack-scan-modal.delete-all-groups.proceed": {
-    "message": "Excluir"
-  },
   "modpack-scan-modal.delete-all-groups.success": {
     "message": "Todos os grupos excluídos com sucesso."
   },
@@ -3025,9 +3019,6 @@
   },
   "modpack-scan-modal.scanning": {
     "message": "Verificando..."
-  },
-  "modpack-scan-modal.success": {
-    "message": "Sucesso"
   },
   "modpack-scan-modal.title": {
     "message": "Verificação do pacote de mods ({scanned}/{total} Arquivos)"

--- a/apps/frontend/src/locales/ru-RU/index.json
+++ b/apps/frontend/src/locales/ru-RU/index.json
@@ -1475,9 +1475,6 @@
   "dashboard.collections.sort.recently-updated": {
     "message": "Дата обновления"
   },
-  "dashboard.creator-tax-form-modal.close-button": {
-    "message": "Закрыть"
-  },
   "dashboard.creator-tax-form-modal.confirmation.download-button": {
     "message": "Скачать {formType}"
   },
@@ -2978,9 +2975,6 @@
   "modpack-scan-modal.delete-all-groups.error": {
     "message": "Не удалось удалить все группы: {error}"
   },
-  "modpack-scan-modal.delete-all-groups.proceed": {
-    "message": "Удалить"
-  },
   "modpack-scan-modal.delete-all-groups.success": {
     "message": "Все группы успешно удалены."
   },
@@ -3019,9 +3013,6 @@
   },
   "modpack-scan-modal.scanning": {
     "message": "Сканирование..."
-  },
-  "modpack-scan-modal.success": {
-    "message": "Готово"
   },
   "muralpay.account-type.checking": {
     "message": "Расчётный"

--- a/apps/frontend/src/locales/sv-SE/index.json
+++ b/apps/frontend/src/locales/sv-SE/index.json
@@ -1313,9 +1313,6 @@
   "dashboard.collections.sort.recently-updated": {
     "message": "Nyligen uppdaterade"
   },
-  "dashboard.creator-tax-form-modal.close-button": {
-    "message": "Stäng"
-  },
   "dashboard.creator-tax-form-modal.confirmation.download-button": {
     "message": "Ladda ner {formType}"
   },
@@ -2644,9 +2641,6 @@
   },
   "modpack-scan-modal.delete-all-groups.error": {
     "message": "Misslyckades att tömma alla grupper: {error}"
-  },
-  "modpack-scan-modal.delete-all-groups.proceed": {
-    "message": "Töm"
   },
   "modpack-scan-modal.failed": {
     "message": "Misslyckades"

--- a/apps/frontend/src/locales/tr-TR/index.json
+++ b/apps/frontend/src/locales/tr-TR/index.json
@@ -1358,9 +1358,6 @@
   "dashboard.collections.sort.recently-updated": {
     "message": "Son Güncellenen"
   },
-  "dashboard.creator-tax-form-modal.close-button": {
-    "message": "Kapat"
-  },
   "dashboard.creator-tax-form-modal.confirmation.download-button": {
     "message": "{formType} İndirin"
   },
@@ -2773,9 +2770,6 @@
   },
   "modpack-scan-modal.scanning": {
     "message": "Taranıyor..."
-  },
-  "modpack-scan-modal.success": {
-    "message": "Başarılı"
   },
   "modpack-scan-modal.title": {
     "message": "Mod paketi taraması ({scanned}/{total} Dosyalar)"

--- a/apps/frontend/src/locales/uk-UA/index.json
+++ b/apps/frontend/src/locales/uk-UA/index.json
@@ -1478,9 +1478,6 @@
   "dashboard.collections.sort.recently-updated": {
     "message": "Нещодавно оновлені"
   },
-  "dashboard.creator-tax-form-modal.close-button": {
-    "message": "Закрити"
-  },
   "dashboard.creator-tax-form-modal.confirmation.download-button": {
     "message": "Завантажити {formType}"
   },
@@ -2981,9 +2978,6 @@
   "modpack-scan-modal.delete-all-groups.error": {
     "message": "Не вдалося очистити всі групи: {error}"
   },
-  "modpack-scan-modal.delete-all-groups.proceed": {
-    "message": "Очистити"
-  },
   "modpack-scan-modal.delete-all-groups.success": {
     "message": "Усі групи успішно очищено."
   },
@@ -3022,9 +3016,6 @@
   },
   "modpack-scan-modal.scanning": {
     "message": "Скануємо…"
-  },
-  "modpack-scan-modal.success": {
-    "message": "Успіх"
   },
   "modpack-scan-modal.title": {
     "message": "Сканування збірки ({scanned}/{total} файлів)"

--- a/apps/frontend/src/locales/zh-CN/index.json
+++ b/apps/frontend/src/locales/zh-CN/index.json
@@ -1481,9 +1481,6 @@
   "dashboard.collections.sort.recently-updated": {
     "message": "最近更新"
   },
-  "dashboard.creator-tax-form-modal.close-button": {
-    "message": "关闭"
-  },
   "dashboard.creator-tax-form-modal.confirmation.download-button": {
     "message": "下载{formType}"
   },
@@ -2984,9 +2981,6 @@
   "modpack-scan-modal.delete-all-groups.error": {
     "message": "未能清除所有组:{error}"
   },
-  "modpack-scan-modal.delete-all-groups.proceed": {
-    "message": "清除"
-  },
   "modpack-scan-modal.delete-all-groups.success": {
     "message": "所有组均已成功清除。"
   },
@@ -3025,9 +3019,6 @@
   },
   "modpack-scan-modal.scanning": {
     "message": "扫描中……"
-  },
-  "modpack-scan-modal.success": {
-    "message": "成功"
   },
   "modpack-scan-modal.title": {
     "message": "模组包扫描 ({scanned}/{total} 个文件)"

--- a/apps/frontend/src/locales/zh-TW/index.json
+++ b/apps/frontend/src/locales/zh-TW/index.json
@@ -1481,9 +1481,6 @@
   "dashboard.collections.sort.recently-updated": {
     "message": "最近更新"
   },
-  "dashboard.creator-tax-form-modal.close-button": {
-    "message": "關閉"
-  },
   "dashboard.creator-tax-form-modal.confirmation.download-button": {
     "message": "下載 {formType}"
   },
@@ -2984,9 +2981,6 @@
   "modpack-scan-modal.delete-all-groups.error": {
     "message": "無法清除所有群組：{error}"
   },
-  "modpack-scan-modal.delete-all-groups.proceed": {
-    "message": "清除"
-  },
   "modpack-scan-modal.delete-all-groups.success": {
     "message": "已成功清除所有群組。"
   },
@@ -3025,9 +3019,6 @@
   },
   "modpack-scan-modal.scanning": {
     "message": "正在掃描..."
-  },
-  "modpack-scan-modal.success": {
-    "message": "成功"
   },
   "modpack-scan-modal.title": {
     "message": "模組包掃描（{scanned}/{total} 個檔案）"

--- a/packages/ui/src/components/sharing/invite-players-modal/index.vue
+++ b/packages/ui/src/components/sharing/invite-players-modal/index.vue
@@ -147,6 +147,7 @@ import { Button } from '#ui/components/base/buttons'
 
 import { defineMessages, useVIntl } from '../../../composables/i18n'
 import { injectNotificationManager } from '../../../providers'
+import { commonMessages } from '../../../utils/common-messages'
 import Avatar from '../../base/Avatar.vue'
 import Combobox from '../../base/Combobox.vue'
 import NewModal from '../../modal/NewModal.vue'
@@ -226,10 +227,6 @@ const messages = defineMessages({
 		id: 'sharing.invite-players-modal.added',
 		defaultMessage: 'Added',
 	},
-	cancelButton: {
-		id: 'sharing.invite-players-modal.cancel',
-		defaultMessage: 'Cancel',
-	},
 	requestedButton: {
 		id: 'sharing.invite-players-modal.requested',
 		defaultMessage: 'Request sent',
@@ -297,7 +294,9 @@ const searchPlaceholderLabel = computed(
 const addButtonLabel = computed(() => props.addLabel ?? formatMessage(messages.addButton))
 const inviteButtonLabel = computed(() => props.inviteLabel ?? formatMessage(messages.inviteButton))
 const addedButtonLabel = computed(() => props.addedLabel ?? formatMessage(messages.addedButton))
-const cancelButtonLabel = computed(() => props.cancelLabel ?? formatMessage(messages.cancelButton))
+const cancelButtonLabel = computed(
+	() => props.cancelLabel ?? formatMessage(commonMessages.cancelButton),
+)
 const requestedButtonLabel = computed(
 	() => props.requestedLabel ?? formatMessage(messages.requestedButton),
 )

--- a/packages/ui/src/components/sharing/invite-players-modal/invite-players-modal-invite-link-editor.vue
+++ b/packages/ui/src/components/sharing/invite-players-modal/invite-players-modal-invite-link-editor.vue
@@ -32,7 +32,7 @@
 							/>
 							<div class="flex justify-end gap-2 p-3 pt-1">
 								<Button type="outlined" native-type="button" @click="cancelCustomExpiry">
-									{{ formatMessage(messages.cancel) }}
+									{{ formatMessage(commonMessages.cancelButton) }}
 								</Button>
 								<Button
 									type="colored"
@@ -73,7 +73,7 @@
 			<div class="flex justify-end gap-2">
 				<Button :disabled="saving" @click="modal?.hide()">
 					<XIcon aria-hidden="true" />
-					{{ formatMessage(messages.cancel) }}
+					{{ formatMessage(commonMessages.cancelButton) }}
 				</Button>
 				<Button type="colored" color="brand" :disabled="!canSave" @click="save">
 					<SpinnerIcon v-if="saving" class="animate-spin" aria-hidden="true" />
@@ -94,6 +94,7 @@ import { Button } from '#ui/components/base/buttons'
 import { useFormatDateTime } from '../../../composables'
 import { defineMessages, useVIntl } from '../../../composables/i18n'
 import { injectNotificationManager } from '../../../providers'
+import { commonMessages } from '../../../utils/common-messages'
 import Combobox, { type ComboboxOption } from '../../base/Combobox.vue'
 import DatePicker from '../../base/DatePicker.vue'
 import StyledInput from '../../base/StyledInput.vue'
@@ -185,10 +186,6 @@ const messages = defineMessages({
 	customExpiryValue: {
 		id: 'sharing.invite-players-modal.custom-expiry-value',
 		defaultMessage: 'Custom: {date}',
-	},
-	cancel: {
-		id: 'sharing.invite-players-modal.cancel-button',
-		defaultMessage: 'Cancel',
 	},
 	apply: {
 		id: 'sharing.invite-players-modal.apply-button',

--- a/packages/ui/src/layouts/shared/files-tab/components/editor/EditorFindReplace.vue
+++ b/packages/ui/src/layouts/shared/files-tab/components/editor/EditorFindReplace.vue
@@ -66,9 +66,9 @@
 				</IconButton>
 				<div class="mx-0.5 h-4 w-px bg-surface-5" />
 				<IconButton
-					v-tooltip="formatMessage(messages.closeFind)"
+					v-tooltip="formatMessage(commonMessages.closeButton)"
 					type="quiet"
-					:label="formatMessage(messages.closeFind)"
+					:label="formatMessage(commonMessages.closeButton)"
 					@click="close"
 				>
 					<XIcon />
@@ -118,6 +118,7 @@ import { nextTick, ref, watch } from 'vue'
 import { Button, IconButton } from '#ui/components/base/buttons'
 import StyledInput from '#ui/components/base/StyledInput.vue'
 import { defineMessages, useVIntl } from '#ui/composables/i18n'
+import { commonMessages } from '#ui/utils/common-messages'
 
 const props = defineProps<{
 	isFindOpen: boolean
@@ -160,10 +161,6 @@ const messages = defineMessages({
 	nextMatch: {
 		id: 'files.editor.find-next-match',
 		defaultMessage: 'Next match',
-	},
-	closeFind: {
-		id: 'files.editor.find-close',
-		defaultMessage: 'Close',
 	},
 	toggleReplace: {
 		id: 'files.editor.find-toggle-replace',

--- a/packages/ui/src/locales/cs-CZ/index.json
+++ b/packages/ui/src/locales/cs-CZ/index.json
@@ -1130,9 +1130,6 @@
   "files.editor.file-saved-title": {
     "defaultMessage": "Soubor uložen"
   },
-  "files.editor.find-close": {
-    "defaultMessage": "Zavřít"
-  },
   "files.editor.find-in-file": {
     "defaultMessage": "Najít"
   },
@@ -4557,4 +4554,3 @@
     "defaultMessage": "Typ"
   }
 }
-

--- a/packages/ui/src/locales/da-DK/index.json
+++ b/packages/ui/src/locales/da-DK/index.json
@@ -557,9 +557,6 @@
   "files.editor.file-saved-title": {
     "defaultMessage": "Fil gemt"
   },
-  "files.editor.find-close": {
-    "defaultMessage": "Luk"
-  },
   "files.editor.find-in-file": {
     "defaultMessage": "Find"
   },
@@ -2253,4 +2250,3 @@
     "defaultMessage": "Vanilla Shader"
   }
 }
-

--- a/packages/ui/src/locales/de-CH/index.json
+++ b/packages/ui/src/locales/de-CH/index.json
@@ -1304,9 +1304,6 @@
   "files.editor.file-saved-title": {
     "defaultMessage": "Datei gespeichert"
   },
-  "files.editor.find-close": {
-    "defaultMessage": "Schliessen"
-  },
   "files.editor.find-in-file": {
     "defaultMessage": "Finden"
   },
@@ -5399,12 +5396,6 @@
   "sharing.invite-players-modal.avatar-alt": {
     "defaultMessage": "Avatar von {username}"
   },
-  "sharing.invite-players-modal.cancel": {
-    "defaultMessage": "Abbrechen"
-  },
-  "sharing.invite-players-modal.cancel-button": {
-    "defaultMessage": "Abbrechen"
-  },
   "sharing.invite-players-modal.custom-expiry": {
     "defaultMessage": "Benutzerdefiniert..."
   },
@@ -6240,4 +6231,3 @@
     "defaultMessage": "Typ"
   }
 }
-

--- a/packages/ui/src/locales/de-DE/index.json
+++ b/packages/ui/src/locales/de-DE/index.json
@@ -1304,9 +1304,6 @@
   "files.editor.file-saved-title": {
     "defaultMessage": "Datei gespeichert"
   },
-  "files.editor.find-close": {
-    "defaultMessage": "Schließen"
-  },
   "files.editor.find-in-file": {
     "defaultMessage": "Finden"
   },
@@ -5399,12 +5396,6 @@
   "sharing.invite-players-modal.avatar-alt": {
     "defaultMessage": "Avatar von {username}"
   },
-  "sharing.invite-players-modal.cancel": {
-    "defaultMessage": "Abbrechen"
-  },
-  "sharing.invite-players-modal.cancel-button": {
-    "defaultMessage": "Abbrechen"
-  },
   "sharing.invite-players-modal.custom-expiry": {
     "defaultMessage": "Benutzerdefiniert..."
   },
@@ -6240,4 +6231,3 @@
     "defaultMessage": "Typ"
   }
 }
-

--- a/packages/ui/src/locales/en-US/index.json
+++ b/packages/ui/src/locales/en-US/index.json
@@ -1304,9 +1304,6 @@
   "files.editor.file-saved-title": {
     "defaultMessage": "File saved"
   },
-  "files.editor.find-close": {
-    "defaultMessage": "Close"
-  },
   "files.editor.find-in-file": {
     "defaultMessage": "Find"
   },
@@ -5413,12 +5410,6 @@
   },
   "sharing.invite-players-modal.avatar-alt": {
     "defaultMessage": "{username}'s avatar"
-  },
-  "sharing.invite-players-modal.cancel": {
-    "defaultMessage": "Cancel"
-  },
-  "sharing.invite-players-modal.cancel-button": {
-    "defaultMessage": "Cancel"
   },
   "sharing.invite-players-modal.custom-expiry": {
     "defaultMessage": "Custom..."

--- a/packages/ui/src/locales/es-419/index.json
+++ b/packages/ui/src/locales/es-419/index.json
@@ -1304,9 +1304,6 @@
   "files.editor.file-saved-title": {
     "defaultMessage": "Archivo guardado"
   },
-  "files.editor.find-close": {
-    "defaultMessage": "Cerrar"
-  },
   "files.editor.find-in-file": {
     "defaultMessage": "Buscar"
   },
@@ -5414,12 +5411,6 @@
   "sharing.invite-players-modal.avatar-alt": {
     "defaultMessage": "Avatar de {username}"
   },
-  "sharing.invite-players-modal.cancel": {
-    "defaultMessage": "Cancelar"
-  },
-  "sharing.invite-players-modal.cancel-button": {
-    "defaultMessage": "Cancelar"
-  },
   "sharing.invite-players-modal.custom-expiry": {
     "defaultMessage": "Otro..."
   },
@@ -6255,4 +6246,3 @@
     "defaultMessage": "Tipo"
   }
 }
-

--- a/packages/ui/src/locales/es-ES/index.json
+++ b/packages/ui/src/locales/es-ES/index.json
@@ -1187,9 +1187,6 @@
   "files.editor.file-saved-title": {
     "defaultMessage": "Archivo guardado"
   },
-  "files.editor.find-close": {
-    "defaultMessage": "Cerrar"
-  },
   "files.editor.find-in-file": {
     "defaultMessage": "Encontrar"
   },

--- a/packages/ui/src/locales/fil-PH/index.json
+++ b/packages/ui/src/locales/fil-PH/index.json
@@ -341,9 +341,6 @@
   "external-project-license-status.yes": {
     "defaultMessage": "Oo"
   },
-  "files.editor.find-close": {
-    "defaultMessage": "Isara"
-  },
   "files.editor.find-in-file": {
     "defaultMessage": "Hahanapin"
   },
@@ -2766,4 +2763,3 @@
     "defaultMessage": "Uri"
   }
 }
-

--- a/packages/ui/src/locales/fr-FR/index.json
+++ b/packages/ui/src/locales/fr-FR/index.json
@@ -1301,9 +1301,6 @@
   "files.editor.file-saved-title": {
     "defaultMessage": "Fichier sauvegardé"
   },
-  "files.editor.find-close": {
-    "defaultMessage": "Fermer"
-  },
   "files.editor.find-in-file": {
     "defaultMessage": "Trouver"
   },
@@ -5389,12 +5386,6 @@
   },
   "sharing.invite-players-modal.avatar-alt": {
     "defaultMessage": "Avatar de {username}"
-  },
-  "sharing.invite-players-modal.cancel": {
-    "defaultMessage": "Annuler"
-  },
-  "sharing.invite-players-modal.cancel-button": {
-    "defaultMessage": "Annuler"
   },
   "sharing.invite-players-modal.custom-expiry": {
     "defaultMessage": "Personnaliser..."

--- a/packages/ui/src/locales/hu-HU/index.json
+++ b/packages/ui/src/locales/hu-HU/index.json
@@ -1028,9 +1028,6 @@
   "files.editor.file-saved-title": {
     "defaultMessage": "A fájl mentve"
   },
-  "files.editor.find-close": {
-    "defaultMessage": "Bezárás"
-  },
   "files.editor.find-in-file": {
     "defaultMessage": "Keresés"
   },
@@ -4543,12 +4540,6 @@
   },
   "sharing.invite-players-modal.avatar-alt": {
     "defaultMessage": "{username} avatárja"
-  },
-  "sharing.invite-players-modal.cancel": {
-    "defaultMessage": "Mégse"
-  },
-  "sharing.invite-players-modal.cancel-button": {
-    "defaultMessage": "Mégse"
   },
   "sharing.invite-players-modal.edit-invite-link": {
     "defaultMessage": "Meghívólink szerkesztése."

--- a/packages/ui/src/locales/id-ID/index.json
+++ b/packages/ui/src/locales/id-ID/index.json
@@ -824,9 +824,6 @@
   "files.editor.file-saved-title": {
     "defaultMessage": "Berkas disimpan"
   },
-  "files.editor.find-close": {
-    "defaultMessage": "Tutup"
-  },
   "files.editor.find-in-file": {
     "defaultMessage": "Cari"
   },
@@ -2985,4 +2982,3 @@
     "defaultMessage": "Anda memiliki perubahan yang belum tersimpan."
   }
 }
-

--- a/packages/ui/src/locales/it-IT/index.json
+++ b/packages/ui/src/locales/it-IT/index.json
@@ -1274,9 +1274,6 @@
   "files.editor.file-saved-title": {
     "defaultMessage": "File salvato"
   },
-  "files.editor.find-close": {
-    "defaultMessage": "Chiudi"
-  },
   "files.editor.find-in-file": {
     "defaultMessage": "Trova"
   },
@@ -5371,12 +5368,6 @@
   },
   "sharing.invite-players-modal.avatar-alt": {
     "defaultMessage": "Foto profilo di {username}"
-  },
-  "sharing.invite-players-modal.cancel": {
-    "defaultMessage": "Annulla"
-  },
-  "sharing.invite-players-modal.cancel-button": {
-    "defaultMessage": "Annulla"
   },
   "sharing.invite-players-modal.custom-expiry": {
     "defaultMessage": "Personalizzata..."

--- a/packages/ui/src/locales/ja-JP/index.json
+++ b/packages/ui/src/locales/ja-JP/index.json
@@ -1220,9 +1220,6 @@
   "files.editor.file-saved-title": {
     "defaultMessage": "保存済み"
   },
-  "files.editor.find-close": {
-    "defaultMessage": "閉じる"
-  },
   "files.editor.find-in-file": {
     "defaultMessage": "検索"
   },

--- a/packages/ui/src/locales/ko-KR/index.json
+++ b/packages/ui/src/locales/ko-KR/index.json
@@ -1304,9 +1304,6 @@
   "files.editor.file-saved-title": {
     "defaultMessage": "파일 저장됨"
   },
-  "files.editor.find-close": {
-    "defaultMessage": "닫다"
-  },
   "files.editor.find-in-file": {
     "defaultMessage": "찾다"
   },
@@ -5395,12 +5392,6 @@
   },
   "sharing.invite-players-modal.avatar-alt": {
     "defaultMessage": "{username} 님의 아바타"
-  },
-  "sharing.invite-players-modal.cancel": {
-    "defaultMessage": "취소"
-  },
-  "sharing.invite-players-modal.cancel-button": {
-    "defaultMessage": "취소"
   },
   "sharing.invite-players-modal.custom-expiry": {
     "defaultMessage": "커스텀..."

--- a/packages/ui/src/locales/ms-MY/index.json
+++ b/packages/ui/src/locales/ms-MY/index.json
@@ -914,9 +914,6 @@
   "files.editor.file-saved-title": {
     "defaultMessage": "Fail disimpan"
   },
-  "files.editor.find-close": {
-    "defaultMessage": "Tutup"
-  },
   "files.editor.find-in-file": {
     "defaultMessage": "Cari"
   },
@@ -5058,4 +5055,3 @@
     "defaultMessage": "Jenis"
   }
 }
-

--- a/packages/ui/src/locales/nl-NL/index.json
+++ b/packages/ui/src/locales/nl-NL/index.json
@@ -1301,9 +1301,6 @@
   "files.editor.file-saved-title": {
     "defaultMessage": "Bestand opgeslagen"
   },
-  "files.editor.find-close": {
-    "defaultMessage": "Sluiten"
-  },
   "files.editor.find-in-file": {
     "defaultMessage": "Vind"
   },
@@ -5218,12 +5215,6 @@
   },
   "sharing.invite-players-modal.avatar-alt": {
     "defaultMessage": "Avatar van {username}"
-  },
-  "sharing.invite-players-modal.cancel": {
-    "defaultMessage": "Annuleren"
-  },
-  "sharing.invite-players-modal.cancel-button": {
-    "defaultMessage": "Annuleren"
   },
   "sharing.invite-players-modal.edit-invite-link": {
     "defaultMessage": "Uitnodigingslink bewerken."

--- a/packages/ui/src/locales/pl-PL/index.json
+++ b/packages/ui/src/locales/pl-PL/index.json
@@ -1298,9 +1298,6 @@
   "files.editor.file-saved-title": {
     "defaultMessage": "Plik zapisany"
   },
-  "files.editor.find-close": {
-    "defaultMessage": "Zamknij"
-  },
   "files.editor.find-in-file": {
     "defaultMessage": "Znajdź"
   },
@@ -5368,12 +5365,6 @@
   },
   "sharing.invite-players-modal.avatar-alt": {
     "defaultMessage": "Awatar użytkownika {username}"
-  },
-  "sharing.invite-players-modal.cancel": {
-    "defaultMessage": "Anuluj"
-  },
-  "sharing.invite-players-modal.cancel-button": {
-    "defaultMessage": "Anuluj"
   },
   "sharing.invite-players-modal.expiry-label": {
     "defaultMessage": "Data wygaśnięcia"

--- a/packages/ui/src/locales/pt-BR/index.json
+++ b/packages/ui/src/locales/pt-BR/index.json
@@ -1304,9 +1304,6 @@
   "files.editor.file-saved-title": {
     "defaultMessage": "Arquivo salvo"
   },
-  "files.editor.find-close": {
-    "defaultMessage": "Fechar"
-  },
   "files.editor.find-in-file": {
     "defaultMessage": "Localizar"
   },
@@ -5414,12 +5411,6 @@
   "sharing.invite-players-modal.avatar-alt": {
     "defaultMessage": "Avatar de {username}"
   },
-  "sharing.invite-players-modal.cancel": {
-    "defaultMessage": "Cancelar"
-  },
-  "sharing.invite-players-modal.cancel-button": {
-    "defaultMessage": "Cancelar"
-  },
   "sharing.invite-players-modal.custom-expiry": {
     "defaultMessage": "Personalizado..."
   },
@@ -6255,4 +6246,3 @@
     "defaultMessage": "Tipo"
   }
 }
-

--- a/packages/ui/src/locales/pt-PT/index.json
+++ b/packages/ui/src/locales/pt-PT/index.json
@@ -497,9 +497,6 @@
   "files.editor.file-saved-title": {
     "defaultMessage": "Ficheiro salvo"
   },
-  "files.editor.find-close": {
-    "defaultMessage": "Fechar"
-  },
   "files.editor.find-in-file": {
     "defaultMessage": "Encontrar"
   },
@@ -2526,4 +2523,3 @@
     "defaultMessage": "Tens alterações por guardar."
   }
 }
-

--- a/packages/ui/src/locales/ro-RO/index.json
+++ b/packages/ui/src/locales/ro-RO/index.json
@@ -551,9 +551,6 @@
   "files.editor.file-saved-title": {
     "defaultMessage": "Fișier salvat"
   },
-  "files.editor.find-close": {
-    "defaultMessage": "Închide"
-  },
   "files.editor.find-in-file": {
     "defaultMessage": "Caută"
   },

--- a/packages/ui/src/locales/ru-RU/index.json
+++ b/packages/ui/src/locales/ru-RU/index.json
@@ -1232,9 +1232,6 @@
   "files.editor.file-saved-title": {
     "defaultMessage": "Файл сохранён"
   },
-  "files.editor.find-close": {
-    "defaultMessage": "Закрыть"
-  },
   "files.editor.find-in-file": {
     "defaultMessage": "Найти"
   },
@@ -5326,12 +5323,6 @@
   },
   "sharing.invite-players-modal.avatar-alt": {
     "defaultMessage": "Аватар {username}"
-  },
-  "sharing.invite-players-modal.cancel": {
-    "defaultMessage": "Отозвать"
-  },
-  "sharing.invite-players-modal.cancel-button": {
-    "defaultMessage": "Отмена"
   },
   "sharing.invite-players-modal.custom-expiry": {
     "defaultMessage": "Другое..."

--- a/packages/ui/src/locales/sr-CS/index.json
+++ b/packages/ui/src/locales/sr-CS/index.json
@@ -1253,9 +1253,6 @@
   "files.editor.file-saved-title": {
     "defaultMessage": "Datoteka sačuvana"
   },
-  "files.editor.find-close": {
-    "defaultMessage": "Zatvori"
-  },
   "files.editor.find-in-file": {
     "defaultMessage": "Pronađi"
   },
@@ -5784,4 +5781,3 @@
     "defaultMessage": "Tip"
   }
 }
-

--- a/packages/ui/src/locales/sv-SE/index.json
+++ b/packages/ui/src/locales/sv-SE/index.json
@@ -1142,9 +1142,6 @@
   "files.editor.file-saved-title": {
     "defaultMessage": "Filen sparades"
   },
-  "files.editor.find-close": {
-    "defaultMessage": "Stäng"
-  },
   "files.editor.find-in-file": {
     "defaultMessage": "Hitta"
   },
@@ -4760,12 +4757,6 @@
   "sharing.invite-players-modal.avatar-alt": {
     "defaultMessage": "{username}s avatar"
   },
-  "sharing.invite-players-modal.cancel": {
-    "defaultMessage": "Avbryt"
-  },
-  "sharing.invite-players-modal.cancel-button": {
-    "defaultMessage": "Avbryt"
-  },
   "sharing.invite-players-modal.custom-expiry": {
     "defaultMessage": "Anpassat..."
   },
@@ -5442,4 +5433,3 @@
     "defaultMessage": "Typ"
   }
 }
-

--- a/packages/ui/src/locales/tr-TR/index.json
+++ b/packages/ui/src/locales/tr-TR/index.json
@@ -1274,9 +1274,6 @@
   "files.editor.file-saved-title": {
     "defaultMessage": "Dosya kaydedildi"
   },
-  "files.editor.find-close": {
-    "defaultMessage": "Kapat"
-  },
   "files.editor.find-in-file": {
     "defaultMessage": "Bul"
   },

--- a/packages/ui/src/locales/uk-UA/index.json
+++ b/packages/ui/src/locales/uk-UA/index.json
@@ -1259,9 +1259,6 @@
   "files.editor.file-saved-title": {
     "defaultMessage": "Файл збережено"
   },
-  "files.editor.find-close": {
-    "defaultMessage": "Закрити"
-  },
   "files.editor.find-in-file": {
     "defaultMessage": "Знайти"
   },
@@ -5362,12 +5359,6 @@
   },
   "sharing.invite-players-modal.avatar-alt": {
     "defaultMessage": "Аватар користувача {username}"
-  },
-  "sharing.invite-players-modal.cancel": {
-    "defaultMessage": "Скасувати"
-  },
-  "sharing.invite-players-modal.cancel-button": {
-    "defaultMessage": "Скасувати"
   },
   "sharing.invite-players-modal.custom-expiry": {
     "defaultMessage": "Власна…"

--- a/packages/ui/src/locales/vi-VN/index.json
+++ b/packages/ui/src/locales/vi-VN/index.json
@@ -935,9 +935,6 @@
   "files.editor.file-saved-title": {
     "defaultMessage": "Tệp đã được lưu"
   },
-  "files.editor.find-close": {
-    "defaultMessage": "Đóng"
-  },
   "files.editor.find-in-file": {
     "defaultMessage": "Tìm"
   },
@@ -5082,4 +5079,3 @@
     "defaultMessage": "Đội ngũ Modrinth"
   }
 }
-

--- a/packages/ui/src/locales/zh-CN/index.json
+++ b/packages/ui/src/locales/zh-CN/index.json
@@ -1304,9 +1304,6 @@
   "files.editor.file-saved-title": {
     "defaultMessage": "文件已保存"
   },
-  "files.editor.find-close": {
-    "defaultMessage": "关闭"
-  },
   "files.editor.find-in-file": {
     "defaultMessage": "查找"
   },
@@ -5414,12 +5411,6 @@
   "sharing.invite-players-modal.avatar-alt": {
     "defaultMessage": "{username} 的头像"
   },
-  "sharing.invite-players-modal.cancel": {
-    "defaultMessage": "取消"
-  },
-  "sharing.invite-players-modal.cancel-button": {
-    "defaultMessage": "取消"
-  },
   "sharing.invite-players-modal.custom-expiry": {
     "defaultMessage": "自定义……"
   },
@@ -6255,4 +6246,3 @@
     "defaultMessage": "类型"
   }
 }
-

--- a/packages/ui/src/locales/zh-TW/index.json
+++ b/packages/ui/src/locales/zh-TW/index.json
@@ -1304,9 +1304,6 @@
   "files.editor.file-saved-title": {
     "defaultMessage": "已儲存檔案"
   },
-  "files.editor.find-close": {
-    "defaultMessage": "關閉"
-  },
   "files.editor.find-in-file": {
     "defaultMessage": "尋找"
   },
@@ -5414,12 +5411,6 @@
   "sharing.invite-players-modal.avatar-alt": {
     "defaultMessage": "{username} 的顯示圖片"
   },
-  "sharing.invite-players-modal.cancel": {
-    "defaultMessage": "取消"
-  },
-  "sharing.invite-players-modal.cancel-button": {
-    "defaultMessage": "取消"
-  },
   "sharing.invite-players-modal.custom-expiry": {
     "defaultMessage": "自訂..."
   },
@@ -6255,4 +6246,3 @@
     "defaultMessage": "類型"
   }
 }
-


### PR DESCRIPTION
`commonMessages` already has "Cancel", "Close", "Clear" and "Success",
but a few components were defining their own. Swapped them over and
removed the old ones.

Nothing changes — the defaultMessages were identical.

The locale diff is just `pnpm prepr` pruning the orphaned strings out of
every language.
