### PR TITLE
Moderation: Rule placeholders with subsections & anchors, update messages.

### DIFF
--- a/packages/moderation/src/data/messages/checklist/messages/description/clarity.md
+++ b/packages/moderation/src/data/messages/checklist/messages/description/clarity.md
@@ -1,7 +1,7 @@
 ## Description Clarity
 
-Per section 2 of %RULES% It's important that your Description accurately and honestly represents the content of your project.  
-Currently, some elements in your Description may be confusing or misleading.  
-Please edit your description to ensure it accurately represents the current functionality of your project.  
-Avoid making hyperbolic claims that could misrepresent the facts of your project.  
+%R2%, It's important that your Description accurately and honestly represents the content of your project. \
+Currently, some elements in your Description may be confusing or misleading. \
+Please edit your description to ensure it accurately represents the current functionality of your project. \
+Avoid making hyperbolic claims that could misrepresent the facts of your project. \
 Ensure that your Description is accurate and not likely to confuse users.

--- a/packages/moderation/src/data/messages/checklist/messages/description/headers-as-body.md
+++ b/packages/moderation/src/data/messages/checklist/messages/description/headers-as-body.md
@@ -1,6 +1,6 @@
 ## Description Accessibility
 
-In accordance with section 2.2 of %RULES%, we request that `# header`s not be used as body text.
+%R2.2%, we ask that `# header`s not be used as body text.
 
 Headers are interpreted differently by screen-readers and thus should generally only be used for things like separating sections of your Description.
 

--- a/packages/moderation/src/data/messages/checklist/messages/description/image-only.md
+++ b/packages/moderation/src/data/messages/checklist/messages/description/image-only.md
@@ -1,6 +1,6 @@
 ## Image Descriptions
 
-In accordance with section 2.2 of %RULES%, we ask that you provide a text alternative to your current Description.
+%R2.2%, we ask that you provide a text alternative to your current Description.
 
 It is important that your Description contains enough detail about your project that a user can have a full understanding of it from text alone.
 

--- a/packages/moderation/src/data/messages/checklist/messages/description/insufficient/header.md
+++ b/packages/moderation/src/data/messages/checklist/messages/description/insufficient/header.md
@@ -1,4 +1,4 @@
 ## Insufficient Description
 
-Per section 2.1 of %RULES%, your %PROJECT_DESCRIPTION_FLINK% should clearly inform the reader of the content, purpose, and appeal of your %PROJECT_TYPE%.</br>
+%R2.1%, your %PROJECT_DESCRIPTION_FLINK% should clearly inform the reader of the content, purpose, and appeal of your %PROJECT_TYPE%.</br>
 Currently, it looks like there are some missing details.

--- a/packages/moderation/src/data/messages/checklist/messages/description/non-english-server.md
+++ b/packages/moderation/src/data/messages/checklist/messages/description/non-english-server.md
@@ -1,6 +1,6 @@
 ## No English Description
 
-Per section 2.2 of %RULES%, a server's [Summary](%PROJECT_SETTINGS_LINK%) and %PROJECT_DESCRIPTION_FLINK% must be in English, unless meant exclusively for a non-english audience.
+%R2.2%, a server's %PROJECT_SUMMARY_FLINK% and %PROJECT_DESCRIPTION_FLINK% must be in English, unless meant exclusively for a non-english audience.
 
 You may include your non-English Description if you would like but we ask that you also add an English translation of the Description to your project page, if you would like to use an online translator to do this, we recommend [DeepL](https://www.deepl.com/translator).
 

--- a/packages/moderation/src/data/messages/checklist/messages/description/non-english.md
+++ b/packages/moderation/src/data/messages/checklist/messages/description/non-english.md
@@ -1,5 +1,5 @@
 ## No English Description
 
-Per section 2.2 of %RULES%, a project's [Summary](%PROJECT_SETTINGS_LINK%) and %PROJECT_DESCRIPTION_FLINK% must be in English, unless meant exclusively for non-English use, such as translations.
+%R2.2%, a project's %PROJECT_SUMMARY_FLINK% and %PROJECT_DESCRIPTION_FLINK% must be in English, unless meant exclusively for non-English use, such as translations.
 
 You may include your non-English Description if you would like but we ask that you also add an English translation of the Description to your project page, if you would like to use an online translator to do this, we recommend [DeepL](https://www.deepl.com/translator).

--- a/packages/moderation/src/data/messages/checklist/messages/description/non-standard-text.md
+++ b/packages/moderation/src/data/messages/checklist/messages/description/non-standard-text.md
@@ -1,6 +1,6 @@
 ## Description Accessibility
 
-Per section 2 of %RULES%, your description must be plainly readable and accessible.
+%R2.2%, your description must be plainly readable and accessible.
 
 Using non-standard text characters like Zalgo or "fancy text" in place of text anywhere in your project, including the Description, Summary, or Title can make your project pages inaccessible.
 

--- a/packages/moderation/src/data/messages/checklist/messages/gallery/insufficient.md
+++ b/packages/moderation/src/data/messages/checklist/messages/gallery/insufficient.md
@@ -1,7 +1,7 @@
 ## Insufficient Gallery Images
 
-We ask that projects like yours show off their content using images in the %PROJECT_GALLERY_FLINK%, or optionally in the Description, in order to effectively and clearly inform users of its content per section 2.1 of %RULES%.
-Keep in mind that you should:
+%R2.1%, we ask that projects like yours show off their content using images in the %PROJECT_GALLERY_FLINK%, or optionally in the Description, in order to effectively and clearly inform users of its content. \
+Keep in mind that you should: \
 
 - Set a featured image that best represents your project.
 - Ensure all your images have titles that accurately label the image, and optionally, details on the contents of the image in the images Description.

--- a/packages/moderation/src/data/messages/checklist/messages/gallery/not-relevant.md
+++ b/packages/moderation/src/data/messages/checklist/messages/gallery/not-relevant.md
@@ -1,3 +1,3 @@
 ## Unrelated Gallery Images
 
-Per section 5.5 of %RULES%, any images in your project's %PROJECT_GALLERY_FLINK% must be relevant to the project and also include a Title.
+%R5.5%, any images in your project's %PROJECT_GALLERY_FLINK% must be relevant to the project and also include a Title.

--- a/packages/moderation/src/data/messages/checklist/messages/gallery/showcase-clarity.md
+++ b/packages/moderation/src/data/messages/checklist/messages/gallery/showcase-clarity.md
@@ -1,6 +1,6 @@
 ## Showcase Clarity
 
-Per section 2 of %RULES%, it's important that your project page accurately and honestly represent the content of your project.
+%R2%, it's important that your project page accurately and honestly represent the content of your project.
 
 Currently, it looks like some images do not accurately represent the content of your %PROJECT_TYPE_FORMATTED_LOWER%.
 Please make sure you use authentic images such as in-game screenshots when showcasing the content or functionality of your work.

--- a/packages/moderation/src/data/messages/checklist/messages/license/no-source-fork.md
+++ b/packages/moderation/src/data/messages/checklist/messages/license/no-source-fork.md
@@ -1,5 +1,5 @@
 ## No Source Code Provided
 
-Your project's %PROJECT_LICENSE_FLINK% of `%PROJECT_LICENSE_NAME%`, requires source disclosure.  
-Consider adding a Source link to your project's repository, or including a Sources file for each version as an Additional File.  
-Keep in mind this may be a requirement of the source work's licensing, which must be abided per section 4 of %RULES%.
+Your project's %PROJECT_LICENSE_FLINK% of `%PROJECT_LICENSE_NAME%`, requires source disclosure. \
+Consider adding a Source link to your project's repository, or including a Sources file for each version as an Additional File. \
+%R4%, you may be required to publish your source work by the terms of the source work's licensing.

--- a/packages/moderation/src/data/messages/checklist/messages/links/header.md
+++ b/packages/moderation/src/data/messages/checklist/messages/links/header.md
@@ -1,4 +1,4 @@
 ## Links
 
-It looks like some of your %PROJECT_TYPE_FORMATTED_LOWER%'s %PROJECT_LINKS_FLINK% are misused or inaccessible.</br>
-Per section 5.4 of %RULES%, all %PROJECT_LINKS_FLINK% must lead to correctly labeled publicly available resources that are directly related to your project.
+It looks like some of your %PROJECT_TYPE_FORMATTED_LOWER%'s %PROJECT_LINKS_FLINK% are misused or inaccessible. \
+%R5.4%, all %PROJECT_LINKS_FLINK% must lead to correctly labeled publicly available resources that are directly related to your project.

--- a/packages/moderation/src/data/messages/checklist/messages/metadata/dependencies.md
+++ b/packages/moderation/src/data/messages/checklist/messages/metadata/dependencies.md
@@ -1,4 +1,4 @@
 ## Missing Dependencies
 
-Per section 5.6 of %RULES%, it is important that relevant dependencies be listed in the dependencies section of your project.  
+%R5.6%, it is important that relevant dependencies be listed in the dependencies section of your project. \
 Please ensure that all relevant dependencies are included in the Dependencies section of each version of your project.

--- a/packages/moderation/src/data/messages/checklist/messages/metadata/environment/inaccurate.md
+++ b/packages/moderation/src/data/messages/checklist/messages/metadata/environment/inaccurate.md
@@ -1,8 +1,8 @@
 ## Environment Metadata
 
-Per section 5.1 of %RULES%, it is important that the metadata of your projects is accurate, including Environment Information.
+%R5.1%, it is important that the metadata of your projects is accurate, including Environment Information.
 
-We've recently overhauled how environment metadata works on Modrinth, you can now edit this in your project's [Version Settings](https://modrinth.com/project/%PROJECT_ID%/settings/versions).
+We've recently overhauled how environment metadata works on Modrinth, you can now edit this in your project's [Version Settings](https://modrinth.com/project/%PROJECT_ID%/settings/versions). \
 Please [read this blogpost](%NEW_ENVIRONMENTS_LINK%) for full details and information on how to ensure your project is labeled correctly.
 
 %CORRECT%

--- a/packages/moderation/src/data/messages/checklist/messages/metadata/game-version/inaccurate.md
+++ b/packages/moderation/src/data/messages/checklist/messages/metadata/game-version/inaccurate.md
@@ -1,5 +1,5 @@
 ## Game Version Metadata
 
-Per section 5.1 of %RULES%, it is important that the metadata of your project is accurate, including which Minecraft versions are selected.
+%R5.1%, it is important that the metadata of your project is accurate, including which Minecraft versions are selected.
 
 %CORRECT%

--- a/packages/moderation/src/data/messages/checklist/messages/metadata/loader/inaccurate.md
+++ b/packages/moderation/src/data/messages/checklist/messages/metadata/loader/inaccurate.md
@@ -1,5 +1,5 @@
 ## Loader Metadata
 
-Per section 5.1 of %RULES%, it is important that the metadata of your project is accurate, including which loaders are selected.
+%R5.1%, it is important that the metadata of your project is accurate, including which loaders are selected.
 
 %CORRECT%

--- a/packages/moderation/src/data/messages/checklist/messages/permissions/missing-permissions.md
+++ b/packages/moderation/src/data/messages/checklist/messages/permissions/missing-permissions.md
@@ -1,3 +1,3 @@
 ## Permissions Incomplete
 
-Per section 4 of %RULES%, we ask that you complete all steps requested in your project's %PROJECT_PERMISSIONS_FLINK%.
+%R4%, we ask that you complete all steps requested in your project's %PROJECT_PERMISSIONS_FLINK%.

--- a/packages/moderation/src/data/messages/checklist/messages/post-approval/metadata-issue.md
+++ b/packages/moderation/src/data/messages/checklist/messages/post-approval/metadata-issue.md
@@ -2,4 +2,5 @@
 
 Unfortunately, it has come to our attention that there may be issues with your project that require attention.
 
-Some information may be incorrect, per section 5.1 of %RULES% it's important that all project metadata be accurate to ensure the best experience for all modrinth users.
+%R5.1%, it's important that all project metadata be accurate to ensure the best experience for all modrinth users. \
+Currently, some information may be incorrect.

--- a/packages/moderation/src/data/messages/checklist/messages/reupload/custom-pack-verification.md
+++ b/packages/moderation/src/data/messages/checklist/messages/reupload/custom-pack-verification.md
@@ -2,8 +2,8 @@
 
 It looks like the custom modpack for your server may be distributing content from outside of the Modrinth ecosystem.
 
-Per section 4 of [Modrinth's Content Rules](https://modrinth.com/legal/rules), we ask that you verify you are abiding by all licensing requirements and have permission to distribute the content included in your modpack.
+%R4%, we ask that you verify you are abiding by all licensing requirements and have permission to distribute the content included in your modpack.
 
 By resubmitting your server while including this content, you acknowledge that you have seen this notice and have all necessary rights and permissions to upload your custom server pack to Modrinth.
 
-Keep in mind, if your server's custom modpack is found to be in violation of [Modrinth's Content Rules](https://modrinth.com/legal/rules), your listing may be temporarily or permanently removed from Modrinth with or without warning.
+Keep in mind, if your server's custom modpack is found to be in violation of %RULES%, your listing may be temporarily or permanently removed from Modrinth with or without warning.

--- a/packages/moderation/src/data/messages/checklist/messages/reupload/insufficient-fork.md
+++ b/packages/moderation/src/data/messages/checklist/messages/reupload/insufficient-fork.md
@@ -1,4 +1,6 @@
 ## Insufficient Fork
 
-This project does not appear to significantly diverge from the source work, or does not abide by the license of the source work as required by section 4 of %RULES%.  
-Please provide proof of your explicit permission to distribute this project from the creator(s) of the source work.
+%R4%, it is important that your project your project abides by the license of and is significantly divergent from the source work.
+
+Unfortunately, this project does not appear to meet these requirements. \
+For your project to be published, you can instead provide proof of your explicit permission to distribute this project from the creator(s) of the source work.

--- a/packages/moderation/src/data/messages/checklist/messages/reupload/request-proof-server.md
+++ b/packages/moderation/src/data/messages/checklist/messages/reupload/request-proof-server.md
@@ -1,5 +1,5 @@
 ## Reuploads are forbidden
 
-This server appears to have uploaded a Modpack by another creator.  
-Per section 4 of %RULES%, we ask that you provide proof of your permission to distribute this pack on Modrinth.  
+This server appears to have uploaded a Modpack by another creator. \
+%R4%, we ask that you provide proof of your permission to distribute this pack on Modrinth. \
 Either implicit permission abiding by the terms of the content's license(s) or explicit permission from the original creator of the pack.

--- a/packages/moderation/src/data/messages/checklist/messages/reupload/request-proof.md
+++ b/packages/moderation/src/data/messages/checklist/messages/reupload/request-proof.md
@@ -1,5 +1,5 @@
 ## Proof of permissions
 
-This project appears to contain content from other creators.  
-Per section 4 of %RULES%, we ask that you provide proof of your permission to distribute this content, or derivatives of this content in your project on Modrinth.  
+This project appears to contain content from other creators. \
+%R4%, we ask that you provide proof of your permission to distribute this content, or derivatives of this content in your project on Modrinth. \
 Either implicit permission abiding by the terms of the content's license(s) or explicit permission from the original creator of the content.

--- a/packages/moderation/src/data/messages/checklist/messages/reupload/reupload.md
+++ b/packages/moderation/src/data/messages/checklist/messages/reupload/reupload.md
@@ -1,5 +1,6 @@
 ## Reuploads are forbidden
 
-This project appears to contain content from %ORIGINAL_PROJECT% by %ORIGINAL_AUTHOR%.  
-Per section 4 of %RULES%, this is strictly forbidden.  
+This project appears to contain content from %ORIGINAL_PROJECT% by %ORIGINAL_AUTHOR%.
+
+%R4%, this is strictly forbidden. \
 If you believe this is an error, or you can verify you are the creator and rightful owner of this content please let us know. Otherwise, we ask that you **do not resubmit this project**.

--- a/packages/moderation/src/data/messages/checklist/messages/reupload/unclear-fork.md
+++ b/packages/moderation/src/data/messages/checklist/messages/reupload/unclear-fork.md
@@ -1,4 +1,4 @@
 ## Forks and Reuploads
 
-Per section 4 of %RULES%, please provide proof that this project is both license-abiding and significantly divergent from the source work.  
+%R4%, please provide proof that this project is both license-abiding and significantly divergent from the source work. \
 Alternatively, please provide proof of your explicit permission from the author of the source work to distribute this content on Modrinth.

--- a/packages/moderation/src/data/messages/checklist/messages/rules/cheat-or-hack-advertising.md
+++ b/packages/moderation/src/data/messages/checklist/messages/rules/cheat-or-hack-advertising.md
@@ -1,5 +1,5 @@
 ## Prohibited Content
 
-This project may violate section 3.1 of [Modrinth's Content Rules](https://modrinth.com/legal/rules).
+This project may violate section 3.1 of [Modrinth's Content Rules](https://modrinth.com/legal/rules#cheats-and-hacks).
 
 We ask that you ensure your project does not endorse, promote, or enable hacks or the use of hacks. Additionally, your project page should not contain language that endorses or promotes hacks or the use of hacks.

--- a/packages/moderation/src/data/messages/checklist/messages/rules/excessive-languages.md
+++ b/packages/moderation/src/data/messages/checklist/messages/rules/excessive-languages.md
@@ -1,5 +1,6 @@
 ## Supported Languages
 
-Currently, you've selected %PROJECT_LANGUAGE_COUNT% [Languages](%PROJECT_LANGUAGE_SETTINGS%), per section 5.1 of %RULES% we ask that you confirm all selected languages are accurate.
+%R5.1% we ask that you confirm all selected languages are accurate. \
+Currently, you've selected %PROJECT_LANGUAGE_COUNT% [Languages](%PROJECT_LANGUAGE_SETTINGS%).
 
 Selected languages should represent what players can expect to see on your server, and all players should be able to get the full experience out of your server even if they only understand one of the selected languages.

--- a/packages/moderation/src/data/messages/checklist/messages/rules/prohibited-content-header.md
+++ b/packages/moderation/src/data/messages/checklist/messages/rules/prohibited-content-header.md
@@ -1,3 +1,3 @@
 ## Prohibited Content
 
-This project contains content which may violate section 1 of [Modrinth's Content Rules](https://modrinth.com/legal/rules):
+This project contains content which may violate section 1 of [Modrinth's Content Rules](https://modrinth.com/legal/rules#prohibited-content):

--- a/packages/moderation/src/data/messages/checklist/messages/rules/server-side-opt-in-header.md
+++ b/packages/moderation/src/data/messages/checklist/messages/rules/server-side-opt-in-header.md
@@ -1,3 +1,3 @@
 ## Server-side opt-in required
 
-Per section 3.3 of [Modrinth's Content Rules](https://modrinth.com/legal/rules), we ask that any features in this project that violate the following rules require a server-side opt-in:
+%R3.3%, we ask that any features in this project that violate the following rules require a server-side opt-in:

--- a/packages/moderation/src/data/messages/checklist/messages/rules/server-side-opt-out.md
+++ b/packages/moderation/src/data/messages/checklist/messages/rules/server-side-opt-out.md
@@ -1,3 +1,3 @@
 ## Server-side opt-out required
 
-Per section 3.2 of [Modrinth's Content Rules](https://modrinth.com/legal/rules), we ask that your project implements a server-side opt-out.
+%R3.3%, we ask that your project implements a server-side opt-out.

--- a/packages/moderation/src/data/messages/checklist/messages/status-alerts/corrections-applied-approved.md
+++ b/packages/moderation/src/data/messages/checklist/messages/status-alerts/corrections-applied-approved.md
@@ -1,4 +1,4 @@
 ## Corrections Applied
 
-These have been corrected by our Moderation Team so your project can remain Approved, be sure to read and understand each issue listed below to ensure a smooth review for your next submission.
+These have been corrected by our Moderation Team so your project can remain Approved, be sure to read and understand each issue listed below to ensure a smooth review for your next submission. \
 If you have further questions, %SUPPORT%

--- a/packages/moderation/src/data/messages/checklist/messages/status-alerts/corrections-applied.md
+++ b/packages/moderation/src/data/messages/checklist/messages/status-alerts/corrections-applied.md
@@ -1,4 +1,4 @@
 ## Corrections Applied
 
-Your submission contained some issues that may have prevented your project from being published.
+Your submission contained some issues that may have prevented your project from being published. \
 These have been corrected by our Moderation Team so your project can be Approved, be sure to read and understand each issue listed below to ensure a smooth review for your next submission.

--- a/packages/moderation/src/data/messages/checklist/messages/summary/formatting.md
+++ b/packages/moderation/src/data/messages/checklist/messages/summary/formatting.md
@@ -1,6 +1,6 @@
 ## Invalid Summary Formatting
 
-Per section 5.3 of %RULES%, your %PROJECT_SUMMARY_FLINK% can not include any extra formatting such as lists, or links.
+%R5.3%, your %PROJECT_SUMMARY_FLINK% can not include any extra formatting such as lists, or links.
 
 Your project summary should provide a brief overview of your project that informs and entices users.
 

--- a/packages/moderation/src/data/messages/checklist/messages/summary/insufficient.md
+++ b/packages/moderation/src/data/messages/checklist/messages/summary/insufficient.md
@@ -1,5 +1,5 @@
 ## Insufficient Summary
 
-Per section 5.3 of %RULES%, your project %PROJECT_SUMMARY_FLINK% should provide a brief overview of your project that informs and entices users.
+%R5.3%, your project %PROJECT_SUMMARY_FLINK% should provide a brief overview of your project that informs and entices users.
 
 This is the first thing most people will see about your %PROJECT_TYPE% other than the Logo, so it's important it be accurate, reasonably detailed, and exciting.

--- a/packages/moderation/src/data/messages/checklist/messages/summary/non-english.md
+++ b/packages/moderation/src/data/messages/checklist/messages/summary/non-english.md
@@ -1,5 +1,5 @@
 ## No English Summary
 
-Per section 2.2 of %RULES%, a project's %PROJECT_SUMMARY_FLINK% and %PROJECT_DESCRIPTION_FLINK% must be in English, unless meant exclusively for non-English use, such as translations.
+%R2.2%, a project's %PROJECT_SUMMARY_FLINK% and %PROJECT_DESCRIPTION_FLINK% must be in English, unless meant exclusively for non-English use, such as translations.
 
 You may include your non-English Summary but we ask that you also add an English translation.

--- a/packages/moderation/src/data/messages/checklist/messages/summary/repeat-title.md
+++ b/packages/moderation/src/data/messages/checklist/messages/summary/repeat-title.md
@@ -1,6 +1,6 @@
 ## Insufficient Summary
 
-Per section 5.3 of %RULES%, your %PROJECT_SUMMARY_FLINK% can not be the same as your project's Title.
+%R5.3%, your %PROJECT_SUMMARY_FLINK% can not be the same as your project's Title.
 
 Your project summary should provide a brief overview of your project that informs and entices users.
 

--- a/packages/moderation/src/data/messages/checklist/messages/tags/inaccurate.md
+++ b/packages/moderation/src/data/messages/checklist/messages/tags/inaccurate.md
@@ -1,3 +1,3 @@
 ## Misuse of Tags
 
-Per section 5.1 of %RULES%, it is important that the metadata of your projects is accurate. Including that selected tags honestly represent your project.
+%R5.1%, it is important that the metadata of your projects is accurate. Including that selected tags honestly represent your project.

--- a/packages/moderation/src/data/messages/checklist/messages/title-slug/title/minecraft-branding.md
+++ b/packages/moderation/src/data/messages/checklist/messages/title-slug/title/minecraft-branding.md
@@ -1,6 +1,6 @@
 ## Minecraft Project Names
 
-Projects must not use Minecraft's branding or include "Minecraft" as a significant part of the title.  
-Your project's current Name of `%PROJECT_TITLE%` may be confusingly similar to, or imply association with, the game Minecraft. We encourage you to change your project's [Name](%PROJECT_SETTINGS_LINK%) to avoid a potential violation of Minecraft's Usage Guidelines.  
-Abbreviations like "MC" or elaborate titles that do not make the name Minecraft a significant portion of the name are okay.  
+Projects must not use Minecraft's branding or include "Minecraft" as a significant part of the title. \
+Your project's current Name of `%PROJECT_TITLE%` may be confusingly similar to, or imply association with, the game Minecraft. We encourage you to change your project's [Name](%PROJECT_SETTINGS_LINK%) to avoid a potential violation of Minecraft's Usage Guidelines. \
+Abbreviations like "MC" or elaborate titles that do not make the name Minecraft a significant portion of the name are okay. \
 When editing your project's Name, remember to update its [URL](%PROJECT_SETTINGS_LINK%) to match.

--- a/packages/moderation/src/data/messages/checklist/messages/title-slug/title/similarities.md
+++ b/packages/moderation/src/data/messages/checklist/messages/title-slug/title/similarities.md
@@ -1,5 +1,5 @@
 ## Project Branding
 
-Per section 1.8 of %RULES%, your project or its branding must not imply association or be easily confused with any other person or organization.  
-We ask that you change your project's [Name](%PROJECT_SETTINGS_LINK%) and other relevant branding to avoid causing confusion or implying association with existing projects or individuals.  
+%R1.8%, your project or its branding must not imply association or be easily confused with any other person or organization. \
+We ask that you change your project's [Name](%PROJECT_SETTINGS_LINK%) and other relevant branding to avoid causing confusion or implying association with existing projects or individuals. \
 When editing your project's Name, remember to update its [URL](%PROJECT_SETTINGS_LINK%) to match.

--- a/packages/moderation/src/data/messages/checklist/messages/title-slug/title/similarities/fork.md
+++ b/packages/moderation/src/data/messages/checklist/messages/title-slug/title/similarities/fork.md
@@ -1,2 +1,2 @@
-You may reference the source work in the Description of your fork, however, you must do so in a way that is unlikely to cause confusion or imply association with or endorsement from the author of the source work.  
-Additionally, per section 4 of %RULES%, we ask that you ensure your project's Name and Branding abide by the license of the source work.
+You may reference the source work in the Description of your fork, however, you must do so in a way that is unlikely to cause confusion or imply association with or endorsement from the author of the source work. \
+%R4%, we also ask that you ensure your project's Name and Branding abide by the license of the source work.

--- a/packages/moderation/src/data/messages/checklist/messages/title-slug/title/useless-info.md
+++ b/packages/moderation/src/data/messages/checklist/messages/title-slug/title/useless-info.md
@@ -1,6 +1,6 @@
 ## Misuse of Project Name
 
-Per section 5.2 of %RULES%, your project's [Name](%PROJECT_SETTINGS_LINK%) should not include unnecessary information such as loaders, themes, tags, or versions.
-Your project's current Name of `%PROJECT_TITLE%` appears to contain extra information.  
-We ask that you remove all additional information from the [Name](%PROJECT_SETTINGS_LINK%). Instead, consider including this in your project's Summary or Description, or as a part of its relevant metadata.  
+%R5.2%, your project's [Name](%PROJECT_SETTINGS_LINK%) should not include unnecessary information such as loaders, themes, tags, or versions. \
+Your project's current Name of `%PROJECT_TITLE%` appears to contain extra information. \
+We ask that you remove all additional information from the [Name](%PROJECT_SETTINGS_LINK%). Instead, consider including this in your project's Summary or Description, or as a part of its relevant metadata. \
 When editing your project's Name, remember to update its [URL](%PROJECT_SETTINGS_LINK%) to match.

--- a/packages/moderation/src/data/messages/checklist/messages/versions/alternate-versions/additional.md
+++ b/packages/moderation/src/data/messages/checklist/messages/versions/alternate-versions/additional.md
@@ -1,5 +1,5 @@
 ## Unsupported Project
 
-Per section 5.7 of %RULES%, Modrinth does not support uploading multiple variations of your project as Additional files.  
-Having alternate versions of your content on the same project will hurt the functionality of the Modrinth App and other supported launchers as it would prevent users from updating your content, and may make it harder for your users to find the content they want.  
+%R5.7%, Modrinth does not support uploading multiple variations of your project as Additional files. \
+Having alternate versions of your content on the same project will hurt the functionality of the Modrinth App and other supported launchers as it would prevent users from updating your content, and may make it harder for your users to find the content they want. \
 We ask that you upload each alternate version of your project as a new project, ensuring that all users will be able to access and easily find your content.

--- a/packages/moderation/src/data/messages/checklist/messages/versions/alternate-versions/server-additional.md
+++ b/packages/moderation/src/data/messages/checklist/messages/versions/alternate-versions/server-additional.md
@@ -1,4 +1,4 @@
 ## Incorrect Additional Files
 
-Per section 5.7 of %RULES%, the additional files section should only be used for specific designated purposes such as a `Sources.jar`.
+%R5.7%, the additional files section should only be used for specific designated purposes such as a `Sources.jar`. \
 To ensure a smooth experience for you and your users, please upload each alternate version of your modpack as its own Modpack project, thank you.

--- a/packages/moderation/src/data/messages/checklist/messages/versions/alternate-versions/zip.md
+++ b/packages/moderation/src/data/messages/checklist/messages/versions/alternate-versions/zip.md
@@ -1,5 +1,5 @@
 ## Incorrect Additional Files
 
-Per section 5.7 of %RULES%, the additional files section should only be used for specific designated purposes such as a `Sources.jar`.
-Modrinth does not support the upload of modpacks in the `.zip` format, as this may cause issues for Modrinth users or distribute copyrighted content without the proper permissions.  
+%R5.7%, the additional files section should only be used for specific designated purposes such as a `Sources.jar`. \
+Modrinth does not support the upload of modpacks in the `.zip` format, as this may cause issues for Modrinth users or distribute copyrighted content without the proper permissions. \
 If you would like to upload a server-specific version of your modpack, consider creating a separate Modpack project.

--- a/packages/moderation/src/data/messages/checklist/messages/versions/incorrect-additional-files.md
+++ b/packages/moderation/src/data/messages/checklist/messages/versions/incorrect-additional-files.md
@@ -1,5 +1,7 @@
 ## Incorrect Use of Additional Files
 
-It looks like you've uploaded multiple primary files to one Version as Additional Files. Per section 5.7 of %RULES%, each Version of your project must include only one primary file that corresponds to its respective Minecraft and loader versions.  
-This allows users to easily find and download the content they need for their game profile with ease. The Additional Files feature can be used for things like a `Sources.jar`.  
+%R5.7%, each Version of your project must include only one primary file that corresponds to its respective Minecraft and loader versions.
+
+It looks like you've uploaded multiple primary files to one Version as Additional Files. \
+Ensuring your project's upload scheme is correct allows users to easily find and download the content they need for their game profile with ease. The Additional Files feature can be used for things like a `Sources.jar`. \
 Please upload each version of your project separately, thank you.

--- a/packages/moderation/src/data/messages/checklist/messages/versions/incorrect-loader.md
+++ b/packages/moderation/src/data/messages/checklist/messages/versions/incorrect-loader.md
@@ -1,4 +1,4 @@
-## Incorrect Loader Labels
+## Incorrect Loaders
 
-Per section 5.7 of %RULES%, the loader labels on each of your %PROJECT_VERSIONS_FLINK% must accurately reflect what the uploaded files support.
+%R5.7%, the loader labels on each of your %PROJECT_VERSIONS_FLINK% must accurately reflect what the uploaded files support. \
 Currently, some of your versions appear to use the following incorrect loader label(s). Please remove these loaders from any affected versions before resubmitting your project:

--- a/packages/moderation/src/utils.ts
+++ b/packages/moderation/src/utils.ts
@@ -115,6 +115,47 @@ export function flattenStaticVariables(): Record<string, string> {
 	const vars: Record<string, string> = {}
 
 	vars[`RULES`] = `[Modrinth's Content Rules](https://modrinth.com/legal/rules)`
+	vars[`R1`] =
+		`Per section 1 of [Modrinth's Content Rules](https://modrinth.com/legal/rules#prohibited-content)`
+	const rule1subs = 12
+	for (let n = 1; n <= rule1subs; n++) {
+		vars[`R1.${n}`] =
+			`Per section 1.${n} of [Modrinth's Content Rules](https://modrinth.com/legal/rules#prohibited-content)`
+	}
+	vars[`R2`] =
+		`Per section 2 of [Modrinth's Content Rules](https://modrinth.com/legal/rules#clear-and-honest-function)`
+	vars[`R2.1`] =
+		`Per section 2.1 of [Modrinth's Content Rules](https://modrinth.com/legal/rules#general-expectations)`
+	const rule2sub1subs = 3
+	for (let n = 1; n <= rule2sub1subs; n++) {
+		const l = String.fromCharCode(96 + n)
+		vars[`R2.1${l}`] =
+			`Per section 2.1${l} of [Modrinth's Content Rules](https://modrinth.com/legal/rules#general-expectations)`
+	}
+	vars[`R2.2`] =
+		`Per section 2.2 of [Modrinth's Content Rules](https://modrinth.com/legal/rules#accessibility)`
+	vars[`R3`] =
+		`Per section 3 of [Modrinth's Content Rules](https://modrinth.com/legal/rules#cheats-and-hacks)`
+	const rule3subs = 3
+	for (let n = 1; n <= rule3subs; n++) {
+		vars[`R3.${n}`] =
+			`Per section 3.${n} of [Modrinth's Content Rules](https://modrinth.com/legal/rules#cheats-and-hacks)`
+	}
+	const rule3sub3subs = 6
+	for (let n = 1; n <= rule3sub3subs; n++) {
+		const l = String.fromCharCode(96 + n)
+		vars[`R3.3${l}`] =
+			`Per section 3.3${l} of [Modrinth's Content Rules](https://modrinth.com/legal/rules#cheats-and-hacks)`
+	}
+	vars[`R4`] =
+		`Per section 4 of [Modrinth's Content Rules](https://modrinth.com/legal/rules#copyright-and-legality-of-content)`
+	vars[`R5`] =
+		`Per section 5 of [Modrinth's Content Rules](https://modrinth.com/legal/rules#miscellaneous)`
+	const rule5subs = 8
+	for (let n = 1; n <= rule5subs; n++) {
+		vars[`R5.${n}`] =
+			`Per section 5.${n} of [Modrinth's Content Rules](https://modrinth.com/legal/rules#miscellaneous)`
+	}
 	vars[`TOS`] = `[Terms of Use](https://modrinth.com/legal/terms)`
 	vars[`COPYRIGHT_POLICY`] = `[Copyright Policy](https://modrinth.com/legal/copyright)`
 	vars[`SUPPORT`] =


### PR DESCRIPTION
Linking creators to the rules should now universally be more specific and provide anchors in each link.  
The layout of most messages has been updated to be more uniform.  
Fixed some newline formatting.
Added placeholders to reference any specific rule section and subsection in the format of %R1.1a% ect.