### PR TITLE
fix: search indexing and schema changes

### DIFF
--- a/apps/labrinth/src/background_task.rs
+++ b/apps/labrinth/src/background_task.rs
@@ -100,7 +100,7 @@ impl BackgroundTask {
             }
             IncrementalIndexSearch => {
                 crate::search::incremental::consume::run(
-                    ro_pool,
+                    pool,
                     redis_pool,
                     search_backend,
                     kafka_client,

--- a/apps/labrinth/src/search/backend/elasticsearch/mod.rs
+++ b/apps/labrinth/src/search/backend/elasticsearch/mod.rs
@@ -688,6 +688,10 @@ impl Elasticsearch {
                     "compatible_dependency_project_ids": {
                         "type": "keyword"
                     },
+                    "required_dependency_project_ids": {"type": "keyword"},
+                    "optional_dependency_project_ids": {"type": "keyword"},
+                    "embedded_dependency_project_ids": {"type": "keyword"},
+                    "incompatible_dependency_project_ids": {"type": "keyword"},
                     "project_loader_fields": {
                         "type": "object",
                         "enabled": false

--- a/apps/labrinth/src/search/backend/typesense/mod.rs
+++ b/apps/labrinth/src/search/backend/typesense/mod.rs
@@ -715,6 +715,40 @@ impl SearchField {
                 optional: true,
                 token_separators: &["-"],
             },
+            SearchField::RequiredDependencyProjectIds => TypesenseFieldSpec {
+                path: "required_dependency_project_ids",
+                ty: "string[]",
+                facet: true,
+                sort: false,
+                optional: true,
+                token_separators: &["-"],
+            },
+            SearchField::OptionalDependencyProjectIds => TypesenseFieldSpec {
+                path: "optional_dependency_project_ids",
+                ty: "string[]",
+                facet: true,
+                sort: false,
+                optional: true,
+                token_separators: &["-"],
+            },
+            SearchField::EmbeddedDependencyProjectIds => TypesenseFieldSpec {
+                path: "embedded_dependency_project_ids",
+                ty: "string[]",
+                facet: true,
+                sort: false,
+                optional: true,
+                token_separators: &["-"],
+            },
+            SearchField::IncompatibleDependencyProjectIds => {
+                TypesenseFieldSpec {
+                    path: "incompatible_dependency_project_ids",
+                    ty: "string[]",
+                    facet: true,
+                    sort: false,
+                    optional: true,
+                    token_separators: &["-"],
+                }
+            }
         }
     }
 }

--- a/apps/labrinth/src/search/indexing.rs
+++ b/apps/labrinth/src/search/indexing.rs
@@ -517,6 +517,34 @@ async fn build_search_documents(
             })
             .map(|dependency| dependency.project_id.clone())
             .collect::<Vec<_>>();
+        let required_dependency_project_ids = dependencies
+            .iter()
+            .filter(|dependency| {
+                dependency.dependency_type == DependencyType::Required
+            })
+            .map(|dependency| dependency.project_id.clone())
+            .collect::<Vec<_>>();
+        let optional_dependency_project_ids = dependencies
+            .iter()
+            .filter(|dependency| {
+                dependency.dependency_type == DependencyType::Optional
+            })
+            .map(|dependency| dependency.project_id.clone())
+            .collect::<Vec<_>>();
+        let embedded_dependency_project_ids = dependencies
+            .iter()
+            .filter(|dependency| {
+                dependency.dependency_type == DependencyType::Embedded
+            })
+            .map(|dependency| dependency.project_id.clone())
+            .collect::<Vec<_>>();
+        let incompatible_dependency_project_ids = dependencies
+            .iter()
+            .filter(|dependency| {
+                dependency.dependency_type == DependencyType::Incompatible
+            })
+            .map(|dependency| dependency.project_id.clone())
+            .collect::<Vec<_>>();
 
         if let Some(versions) = versions.remove(&project.id) {
             let Some(latest_version) = versions.iter().max_by(|a, b| {
@@ -731,6 +759,10 @@ async fn build_search_documents(
                 color: project.color.map(|x| x as u32),
                 dependency_project_ids,
                 compatible_dependency_project_ids,
+                required_dependency_project_ids,
+                optional_dependency_project_ids,
+                embedded_dependency_project_ids,
+                incompatible_dependency_project_ids,
                 dependencies,
                 project_loader_fields,
                 loader_fields,

--- a/apps/labrinth/src/search/mod.rs
+++ b/apps/labrinth/src/search/mod.rs
@@ -218,6 +218,10 @@ pub enum SearchField {
     MinecraftJavaServerPingData,
     DependencyProjectIds,
     CompatibleDependencyProjectIds,
+    RequiredDependencyProjectIds,
+    OptionalDependencyProjectIds,
+    EmbeddedDependencyProjectIds,
+    IncompatibleDependencyProjectIds,
 }
 
 #[derive(Debug, Error)]
@@ -288,6 +292,14 @@ pub struct UploadSearchProject {
     pub dependency_project_ids: Vec<String>,
     #[serde(default)]
     pub compatible_dependency_project_ids: Vec<String>,
+    #[serde(default)]
+    pub required_dependency_project_ids: Vec<String>,
+    #[serde(default)]
+    pub optional_dependency_project_ids: Vec<String>,
+    #[serde(default)]
+    pub embedded_dependency_project_ids: Vec<String>,
+    #[serde(default)]
+    pub incompatible_dependency_project_ids: Vec<String>,
     #[serde(default)]
     pub dependencies: Vec<SearchProjectDependency>,
 
@@ -387,6 +399,14 @@ pub struct ResultSearchProject {
     #[serde(default)]
     pub compatible_dependency_project_ids: Vec<String>,
     #[serde(default)]
+    pub required_dependency_project_ids: Vec<String>,
+    #[serde(default)]
+    pub optional_dependency_project_ids: Vec<String>,
+    #[serde(default)]
+    pub embedded_dependency_project_ids: Vec<String>,
+    #[serde(default)]
+    pub incompatible_dependency_project_ids: Vec<String>,
+    #[serde(default)]
     pub dependencies: Vec<SearchProjectDependency>,
 
     // Hidden fields to get the Project model out of the search results.
@@ -429,6 +449,14 @@ impl From<UploadSearchProject> for ResultSearchProject {
             dependency_project_ids: source.dependency_project_ids,
             compatible_dependency_project_ids: source
                 .compatible_dependency_project_ids,
+            required_dependency_project_ids: source
+                .required_dependency_project_ids,
+            optional_dependency_project_ids: source
+                .optional_dependency_project_ids,
+            embedded_dependency_project_ids: source
+                .embedded_dependency_project_ids,
+            incompatible_dependency_project_ids: source
+                .incompatible_dependency_project_ids,
             dependencies: source.dependencies,
             loaders: source.loaders,
             project_loader_fields: source.project_loader_fields,


### PR DESCRIPTION
- make incremental index task use the `pool`, not `ro_pool`, to ensure read replication can't cause stale data to be indexed
- split dependent search fields into required/optional/embedded fields