### PR TITLE
fix: project page NavTabs shadow clipping

### DIFF
--- a/apps/frontend/src/pages/[type]/[project].vue
+++ b/apps/frontend/src/pages/[type]/[project].vue
@@ -478,7 +478,9 @@
 				</div>
 
 				<div class="normal-page__content">
-					<div class="mb-3 overflow-x-auto"><NavTabs :links="navLinks" replace class="mb-1" /></div>
+					<div class="mb-3 overflow-visible">
+						<NavTabs :links="navLinks" replace class="mb-1" />
+					</div>
 					<NuxtPage @on-download="triggerDownloadAnimation" @delete-version="deleteVersion" />
 				</div>
 			</div>

--- a/apps/frontend/src/pages/[type]/[project].vue
+++ b/apps/frontend/src/pages/[type]/[project].vue
@@ -478,7 +478,7 @@
 				</div>
 
 				<div class="normal-page__content">
-					<div class="mb-3 overflow-visible">
+					<div class="mb-3 overflow-x-auto lg:overflow-visible">
 						<NavTabs :links="navLinks" replace class="mb-1" />
 					</div>
 					<NuxtPage @on-download="triggerDownloadAnimation" @delete-version="deleteVersion" />


### PR DESCRIPTION
before
<img width="538" height="202" alt="image" src="https://github.com/user-attachments/assets/509381ea-d23a-474d-a0fc-0947afa70fb4" />
after
<img width="541" height="225" alt="image" src="https://github.com/user-attachments/assets/e891ff6e-2381-4884-8dde-01822f30aff5" />
