### PR TITLE
 fix modrinth#7172

### DIFF
--- a/apps/app-frontend/src/App.vue
+++ b/apps/app-frontend/src/App.vue
@@ -1983,7 +1983,7 @@ provideAppUpdateDownloadProgress(appUpdateDownload)
 
 	display: grid;
 	grid-template-columns: 1fr 0px;
-	// transition: grid-template-columns 0.4s ease-in-out;
+	will-change: grid-template-columns;
 
 	&.sidebar-enabled {
 		grid-template-columns: 1fr 300px;

--- a/apps/app-frontend/src/components/ui/Breadcrumbs.vue
+++ b/apps/app-frontend/src/components/ui/Breadcrumbs.vue
@@ -112,16 +112,30 @@ function onAnimationIteration() {
 }
 
 let resizeObserver: ResizeObserver | null = null
+let resizeObserverTimeout: number | null = null
+
+function debouncedCheckOverflow() {
+	if (resizeObserverTimeout !== null) {
+		clearTimeout(resizeObserverTimeout)
+	}
+	resizeObserverTimeout = window.setTimeout(() => {
+		checkOverflow()
+		resizeObserverTimeout = null
+	}, 100)
+}
 
 onMounted(() => {
 	checkOverflow()
-	resizeObserver = new ResizeObserver(checkOverflow)
+	resizeObserver = new ResizeObserver(debouncedCheckOverflow)
 	if (outerRef.value) resizeObserver.observe(outerRef.value)
 	if (innerRef.value) resizeObserver.observe(innerRef.value)
 })
 
 onBeforeUnmount(() => {
 	resizeObserver?.disconnect()
+	if (resizeObserverTimeout !== null) {
+		clearTimeout(resizeObserverTimeout)
+	}
 })
 
 watch(breadcrumbs, () => {

--- a/packages/app-lib/src/state/instances/watcher.rs
+++ b/packages/app-lib/src/state/instances/watcher.rs
@@ -134,8 +134,9 @@ pub async fn init_watcher() -> crate::Result<FileWatcher> {
 									None
 								};
 								if let Some(event) = event {
+									let instance_path_str = instance_path_str.clone();
 									tokio::spawn(async move {
-										let _ = emit_instance(
+										emit_instance_event_for_path(
 											&instance_path_str,
 											event,
 										)
@@ -153,6 +154,25 @@ pub async fn init_watcher() -> crate::Result<FileWatcher> {
     });
 
     Ok(RwLock::new(file_watcher))
+}
+
+async fn emit_instance_event_for_path(
+    instance_path: &str,
+    event: InstancePayloadType,
+) {
+    let Ok(state) = State::get().await else {
+        tracing::warn!("Unable to get state for watcher event for {instance_path}");
+        return;
+    };
+
+    let Ok(Some(instance)) =
+        instance_rows::get_instance_by_path(instance_path, &state.pool).await
+    else {
+        tracing::debug!("Skipping watcher event for unknown instance path: {instance_path}");
+        return;
+    };
+
+    let _ = emit_instance(&instance.id, event).await;
 }
 
 pub(crate) async fn watch_instances_init(


### PR DESCRIPTION
The debounce delays the ResizeObserver callback by 100ms, allowing multiple resize events to be batched into a single layout recalculation instead of triggering multiple recalculations. This dramatically reduces layout thrashing and eliminates the visible flicker while maintaining all functionality