### PR TITLE
refactor(daedalus_client): replace serde-xml-rs with quick-xml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2666,10 +2666,10 @@ dependencies = [
  "futures",
  "indexmap 2.11.4",
  "itertools 0.14.0",
+ "quick-xml 0.38.3",
  "reqwest 0.12.24",
  "rust-s3",
  "serde",
- "serde-xml-rs",
  "serde_json",
  "sha1_smol",
  "thiserror 2.0.17",
@@ -9430,18 +9430,6 @@ dependencies = [
  "serde",
  "serde_core",
  "typeid",
-]
-
-[[package]]
-name = "serde-xml-rs"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53630160a98edebde0123eb4dfd0fce6adff091b2305db3154a9e920206eb510"
-dependencies = [
- "log",
- "serde",
- "thiserror 1.0.69",
- "xml-rs",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,6 @@ serde_cbor = "0.11.2"
 serde_ini = "0.2.0"
 serde_json = "1.0.145"
 serde_with = "3.15.0"
-serde-xml-rs = "0.8.1"  # Also an XML (de)serializer, consider dropping yaserde in favor of this
 sha1 = "0.10.6"
 sha1_smol = { version = "1.0.1", features = ["std"] }
 sha2 = "0.10.9"

--- a/apps/daedalus_client/Cargo.toml
+++ b/apps/daedalus_client/Cargo.toml
@@ -20,6 +20,7 @@ dotenvy = { workspace = true }
 futures = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
+quick-xml = { workspace = true }
 reqwest = { workspace = true, features = [
   "json",
   "rustls-tls-native-roots",
@@ -28,7 +29,6 @@ reqwest = { workspace = true, features = [
 rust-s3 = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-serde-xml-rs = { workspace = true }
 sha1_smol = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync"] }

--- a/apps/daedalus_client/src/error.rs
+++ b/apps/daedalus_client/src/error.rs
@@ -11,7 +11,7 @@ pub enum ErrorKind {
     #[error("Error while deserializing JSON: {0}")]
     SerdeJSON(#[from] serde_json::Error),
     #[error("Error while deserializing XML: {0}")]
-    SerdeXML(#[from] serde_xml_rs::Error),
+    QuickXML(#[from] quick_xml::DeError),
     #[error(
         "Failed to validate file checksum at url {url} with hash {hash} after {tries} tries"
     )]

--- a/apps/daedalus_client/src/util.rs
+++ b/apps/daedalus_client/src/util.rs
@@ -304,7 +304,7 @@ pub async fn fetch_xml<T: DeserializeOwned>(
     url: &str,
     semaphore: &Arc<Semaphore>,
 ) -> Result<T, Error> {
-    Ok(serde_xml_rs::from_reader(
+    Ok(quick_xml::de::from_reader(
         &*download_file(url, None, semaphore).await?,
     )?)
 }


### PR DESCRIPTION
`serde-xml-rs` was only used in `daedalus_client` for parsing Forge/NeoForge maven-metadata.xml. `quick-xml` has become the standard XML (de)serializer for Rust and is already used elsewhere in the workspace, so this switches `daedalus_client` over and drops the now-unused `serde-xml-rs` dependency. No functional change, verified `quick-xml`'s serde deserialization against the existing `Metadata`/`Versioning`/`Versions` structs.