### PR TITLE
chore: add NSLocalNetworkUsageDescription to Info.plist

### DIFF
--- a/apps/app/Info.plist
+++ b/apps/app/Info.plist
@@ -19,6 +19,8 @@
 		<string>A Minecraft mod wants to access your camera.</string>
 		<key>NSMicrophoneUsageDescription</key>
 		<string>A Minecraft mod wants to access your microphone.</string>
+		<key>NSLocalNetworkUsageDescription</key>
+		<string>Minecraft or a Minecraft mod wants to access the LAN.</string>
 		<key>NSAppTransportSecurity</key>
 		<dict>
 			<key>NSExceptionDomains</key>


### PR DESCRIPTION
Should fix DEV-1334 and closes #7123

From my own testing I got the local network usage prompt regardless but it may be due to my environment, according to Apple's docs we should be adding this key regardless