### PR TITLE
fix: encode project slugs in canonical URLs

### DIFF
--- a/apps/frontend/src/middleware/project.global.ts
+++ b/apps/frontend/src/middleware/project.global.ts
@@ -62,7 +62,7 @@ export default defineNuxtRouteMiddleware(async (to) => {
 		const remainder = pathParts.filter((x) => x).join('/')
 
 		// Build the canonical path
-		const canonicalPath = `/${correctType}/${project.slug}${remainder ? `/${remainder}` : ''}`
+		const canonicalPath = `/${correctType}/${encodeURIComponent(project.slug)}${remainder ? `/${remainder}` : ''}`
 
 		// Only redirect if the path actually changed
 		if (to.path !== canonicalPath) {


### PR DESCRIPTION
fixes a bug where if a project had a ` (backtick) it would force the page into an infinite redirect loop
the slug is now encoded with `encodeURIComponent()`
fixes #6939