### PR TITLE
fix(app): clean up online/offline listeners on Browse unmount

### DIFF
--- a/apps/app-frontend/src/pages/Browse.vue
+++ b/apps/app-frontend/src/pages/Browse.vue
@@ -34,7 +34,7 @@ import {
 } from '@modrinth/ui'
 import { useQuery, useQueryClient } from '@tanstack/vue-query'
 import type { Ref } from 'vue'
-import { computed, ref, shallowRef, watch } from 'vue'
+import { computed, onBeforeUnmount, ref, shallowRef, watch } from 'vue'
 import type { LocationQuery } from 'vue-router'
 import { useRoute, useRouter } from 'vue-router'
 
@@ -530,13 +530,20 @@ const {
 })
 
 const offline = ref(!navigator.onLine)
-window.addEventListener('offline', () => {
+const handleOffline = () => {
 	debugLog('went offline')
 	offline.value = true
-})
-window.addEventListener('online', () => {
+}
+const handleOnline = () => {
 	debugLog('went online')
 	offline.value = false
+}
+window.addEventListener('offline', handleOffline)
+window.addEventListener('online', handleOnline)
+
+onBeforeUnmount(() => {
+	window.removeEventListener('offline', handleOffline)
+	window.removeEventListener('online', handleOnline)
 })
 
 const messages = defineMessages({


### PR DESCRIPTION
## Summary
- `Browse.vue` registers `window.addEventListener('online'/'offline', ...)` but never removes the listeners.
- The router only keeps `LibraryPage` alive via `<KeepAlive include="LibraryPage">` (`App.vue`), so `Browse.vue` unmounts every time the user navigates away (e.g. into a project) and remounts on return.
- Each remount leaks a new pair of closures on `window`, pinning the whole component setup scope from being garbage collected. Over a browsing session this accumulates continuously, contributing to reports of high/growing memory usage while browsing mods on Linux (related: #3057).

## Fix
Store the handlers in named refs, remove them in `onBeforeUnmount`, matching the cleanup pattern already used elsewhere in the app (e.g. `ContextMenu.vue`, `QuickInstanceSwitcher.vue`).

## Test plan
- [x] Confirmed no other unmatched `addEventListener`/`removeEventListener` pairs were introduced
- [ ] Would appreciate a maintainer/CI check on the frontend build, since I verified this locally by reading the router keep-alive config and lifecycle hooks, not with the full app-frontend dev toolchain