### PR TITLE
fix: stretched server panel img on hosting page

### DIFF
--- a/apps/frontend/src/pages/hosting/index.vue
+++ b/apps/frontend/src/pages/hosting/index.vue
@@ -78,7 +78,7 @@
 					src="https://cdn.modrinth.com/servers/panel-right-dark.webp"
 					alt=""
 					aria-hidden="true"
-					class="pointer-events-none h-full w-fit select-none"
+					class="pointer-events-none h-full w-auto select-none"
 				/>
 			</div>
 


### PR DESCRIPTION
Currently, the example server panel on https://modrinth.com/hosting is stretched.
With this simple pr, the image is no longer stretched.

Current result:
<img width="1588" height="983" alt="stretched panel" src="https://github.com/user-attachments/assets/155e5ff0-d669-4068-9d98-a3c3fb386f0b" />

New result:
<img width="1588" height="983" alt="non stretched panel" src="https://github.com/user-attachments/assets/44b3c488-b865-44a3-8d17-dea27e2510a8" />
