### PR TITLE
feat(labrinth): add Resourcify and OneClient download source

### DIFF
--- a/apps/labrinth/src/routes/v3/analytics_get/metrics/project_downloads.rs
+++ b/apps/labrinth/src/routes/v3/analytics_get/metrics/project_downloads.rs
@@ -661,6 +661,8 @@ static DOWNLOAD_SOURCE_PATTERNS: LazyLock<Vec<(Regex, DownloadSourcePattern)>> =
             (r"^DawnLauncher/", P::Named("Dawn")),
             (r"^Complementary-Installer", P::Named("Complementary Installer")),
             (r"^noriskclient-launcher-v3/", P::Named("NoRisk Client")),
+            (r"^Resourcify/", P::Named("Resourcify")),
+            (r"^OneClient", P::Named("OneClient")),
             (
                 r"^(Mozilla/|Chrome/|Chromium/|Firefox/|Safari/|AppleWebKit/|Edg/|OPR/)",
                 P::Website,


### PR DESCRIPTION
Adds the user agents of [Resourcify](https://github.com/DeDiamondPro/Resourcify) and [OneClient](https://github.com/Polyfrost/OneLauncher) to the list of download source patterns.

I hope this is okay, I'm just curious about the analytics tbh.