### PR TITLE
fix: disable explicit sync on NVIDIA Wayland

### DIFF
--- a/apps/app/src/linux.rs
+++ b/apps/app/src/linux.rs
@@ -8,7 +8,9 @@ pub fn configure_webkit() {
         Path::new("/sys/module/nvidia").exists(),
         env::var_os(NVIDIA_EXPLICIT_SYNC_ENV).is_some(),
     ) {
-        env::set_var(NVIDIA_EXPLICIT_SYNC_ENV, "1");
+        unsafe {
+            env::set_var(NVIDIA_EXPLICIT_SYNC_ENV, "1");
+        }
     }
 }
 

--- a/apps/app/src/linux.rs
+++ b/apps/app/src/linux.rs
@@ -8,9 +8,7 @@ pub fn configure_webkit() {
         Path::new("/sys/module/nvidia").exists(),
         env::var_os(NVIDIA_EXPLICIT_SYNC_ENV).is_some(),
     ) {
-        unsafe {
-            env::set_var(NVIDIA_EXPLICIT_SYNC_ENV, "1");
-        }
+        env::set_var(NVIDIA_EXPLICIT_SYNC_ENV, "1");
     }
 }
 

--- a/apps/app/src/linux.rs
+++ b/apps/app/src/linux.rs
@@ -1,0 +1,44 @@
+use std::{env, path::Path};
+
+const NVIDIA_EXPLICIT_SYNC_ENV: &str = "__NV_DISABLE_EXPLICIT_SYNC";
+
+pub fn configure_webkit() {
+    if should_disable_nvidia_explicit_sync(
+        env::var_os("WAYLAND_DISPLAY").is_some(),
+        Path::new("/sys/module/nvidia").exists(),
+        env::var_os(NVIDIA_EXPLICIT_SYNC_ENV).is_some(),
+    ) {
+        unsafe {
+            env::set_var(NVIDIA_EXPLICIT_SYNC_ENV, "1");
+        }
+    }
+}
+
+fn should_disable_nvidia_explicit_sync(
+    wayland: bool,
+    nvidia: bool,
+    explicitly_configured: bool,
+) -> bool {
+    wayland && nvidia && !explicitly_configured
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_disable_nvidia_explicit_sync;
+
+    #[test]
+    fn disables_explicit_sync_for_nvidia_wayland() {
+        assert!(should_disable_nvidia_explicit_sync(true, true, false));
+    }
+
+    #[test]
+    fn leaves_other_graphics_stacks_unchanged() {
+        assert!(!should_disable_nvidia_explicit_sync(false, true, false));
+        assert!(!should_disable_nvidia_explicit_sync(true, false, false));
+    }
+
+    #[test]
+    fn preserves_explicit_configuration() {
+        assert!(!should_disable_nvidia_explicit_sync(true, true, true));
+    }
+}

--- a/apps/app/src/main.rs
+++ b/apps/app/src/main.rs
@@ -17,6 +17,9 @@ mod error;
 #[cfg(target_os = "macos")]
 mod macos;
 
+#[cfg(target_os = "linux")]
+mod linux;
+
 #[cfg(feature = "updater")]
 mod updater_impl;
 #[cfg(not(feature = "updater"))]
@@ -114,6 +117,9 @@ async fn set_restart_after_pending_update(
 // if Tauri app is called with arguments, then those arguments will be treated as commands
 // ie: deep links or filepaths for .mrpacks
 fn main() {
+    #[cfg(target_os = "linux")]
+    linux::configure_webkit();
+
     #[cfg(feature = "export-app-events")]
     theseus::export_app_event_bindings(
         std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))


### PR DESCRIPTION
Summary:\n- Set __NV_DISABLE_EXPLICIT_SYNC=1 automatically on Linux when running on Wayland with NVIDIA loaded.\n- Added early startup hook for Linux in apps/app/src/main.rs and added apps/app/src/linux.rs.\n- Added unit tests for decision logic to keep behavior safe.\n\nWhy:\n- NVIDIA + Wayland + WebKit render path can trigger crashes in some environments.\n- This mirrors a known stable workaround while preserving explicit user overrides when the variable is already set.\n\nValidation:\n- Unit tests pass for the new decision path.