### PR TITLE
fix: handle minecraft version grouping for versions containing release name

### DIFF
--- a/apps/frontend/src/components/ui/create-project-version/components/McVersionPicker.vue
+++ b/apps/frontend/src/components/ui/create-project-version/components/McVersionPicker.vue
@@ -193,7 +193,15 @@ function groupVersions(gameVersions: GameVersion[]) {
 			if (!groups[currentGroupKey]) groups[currentGroupKey] = []
 			groups[currentGroupKey].push(gameVersion.version)
 		} else {
-			if (!currentGroupKey) currentGroupKey = getSnapshotGroupKey(gameVersion.version)
+			// there are two different types of snapshot names:
+			// - the new YY.D-snapshot.*
+			// - and the old YYw.*
+			// for the new one (or any pre/rc release), the version that it will be released in is always included
+			// - we also have to check that the dot is in the first or second character, and in the other place is a number, because of `3D-Shareware-v1.34` for example
+			// - *and* also because of really old versions, the first character has to be a number
+			const containsVersionName: boolean = /^\d(\d\.|\.\d)/.test(gameVersion.version)
+			if (!currentGroupKey || containsVersionName)
+				currentGroupKey = getSnapshotGroupKey(gameVersion.version)
 
 			const key = `${currentGroupKey} ${DEV_RELEASE_KEY}`
 			if (!groups[key]) groups[key] = []


### PR DESCRIPTION
This pull request would fix `26.2-snapshot-1` being grouped inside of `26.1 Snapshots`.

The main thing that I do, is just check whether the name at the beginning of the version is a valid version, if it is, then that's the group that it will go into.

So while everything works, I've found one issue with this, `26w14a` is now grouped as `26.2 Snapshots` instead of `26.1 Snapshots`. I'm not really sure where it should even go, because that's the april fools version, it was made right before `26.2-snapshot-1` so it goes in the same place as that version.

The only real change are comments, and the extra regex, which:
- checks whether the first character is a number
- checks whether the second character is a number and the next is a dot, OR a dot and then a number