### PR TITLE
fix(app-frontend): instances' images don't break library layout

### DIFF
--- a/apps/app-frontend/src/components/ui/library/instance-group/instance-card-view.vue
+++ b/apps/app-frontend/src/components/ui/library/instance-group/instance-card-view.vue
@@ -36,7 +36,7 @@ const versionRef = ref<HTMLElement | null>(null)
 		}"
 	>
 		<div
-			class="relative flex shrink-0 items-center overflow-clip"
+			class="relative flex shrink-0 items-center max-w-full overflow-clip"
 			:class="compactMode ? 'size-10 rounded-lg' : 'aspect-square min-w-full rounded-2xl'"
 		>
 			<Avatar


### PR DESCRIPTION
# Description

Previously instances with vertical images (height greater than width) would break library grid-like layout.

Solved by adding max-w-full class (max-width: 100%) to image wrapper

# Showcase

## Before

<img width="1531" height="573" alt="before" src="https://github.com/user-attachments/assets/f53d61e9-d1ca-44b2-93d8-b7777704a059" />

## After

<img width="1530" height="434" alt="after" src="https://github.com/user-attachments/assets/61e8967f-df58-42bb-ba4f-6013b9a751bf" />
