### PR TITLE
fix(frontend): added spacing to "Make Organization" message on mobile

### DIFF
--- a/apps/frontend/src/pages/dashboard/organizations.vue
+++ b/apps/frontend/src/pages/dashboard/organizations.vue
@@ -46,7 +46,9 @@
 					</ButtonLink>
 				</div>
 			</template>
-			<template v-else> {{ formatMessage(messages.makeOrganization) }} </template>
+			<template v-else>
+				<p class="mt-0">{{ formatMessage(messages.makeOrganization) }}</p>
+			</template>
 		</section>
 	</div>
 </template>


### PR DESCRIPTION
# Description
"Make Organization!" message didn't have any spacing with the "Create Organization" button on mobile. 
Solved by wrapping the message in a `<p>` tag.

## Before 
<img width="796" height="330" alt="image" src="https://github.com/user-attachments/assets/b0e14f4f-be13-4f6d-92a1-7010a80073c0" />

## After
<img width="796" height="330" alt="image" src="https://github.com/user-attachments/assets/f85522a8-8574-4a91-8f0b-1289fa0ca10a" />
