### PR TITLE
feat: Add `/version/{version}` redirect

### DIFF
--- a/apps/frontend/src/middleware/project.global.ts
+++ b/apps/frontend/src/middleware/project.global.ts
@@ -87,7 +87,7 @@ export default defineNuxtRouteMiddleware(async (to) => {
 	}
 })
 
-async function getProjectMiddlewareClient(route: RouteLocationNormalized) {
+export async function getProjectMiddlewareClient(route: RouteLocationNormalized) {
 	if (import.meta.server) {
 		const authToken = useCookie('auth-token')
 		return useServerModrinthClient({ authToken: authToken.value || undefined })

--- a/apps/frontend/src/middleware/redirect-version.global.ts
+++ b/apps/frontend/src/middleware/redirect-version.global.ts
@@ -1,0 +1,50 @@
+import { projectQueryOptions } from '~/composables/queries/project.ts'
+import { versionQueryOptions } from '~/composables/queries/version.ts'
+import { useAppQueryClient } from '~/composables/query-client.ts'
+import { getProjectTypeForUrl } from '~/helpers/projects'
+import { getProjectMiddlewareClient } from '~/middleware/project.global.ts'
+
+export default defineNuxtRouteMiddleware(async (to) => {
+	const match = to.path.match(/^\/version\/(\w+)\/?$/)
+	if (!match) return
+
+	const versionId = match[1]
+
+	try {
+		const client = await getProjectMiddlewareClient(to)
+		const queryClient = useAppQueryClient()
+
+		const version = await queryClient.fetchQuery(versionQueryOptions.v3(versionId, client))
+
+		if (version) {
+			const project = await queryClient.fetchQuery(
+				projectQueryOptions.v3(version.project_id, client),
+			)
+			const type =
+				project.minecraft_server == null
+					? getProjectTypeForUrl(project.project_types[0], project.loaders)
+					: 'server'
+
+			if (project) {
+				return navigateTo(
+					{
+						name: 'type-project-version-version',
+						params: {
+							type: type,
+							project: project.slug ? project.slug : project.id,
+							version: version.id,
+						},
+					},
+					{
+						redirectCode: 302,
+						replace: true,
+					},
+				)
+			}
+		}
+	} catch {
+		// Project or Version not found moment
+	}
+
+	return createError({ fatal: true, statusCode: 404, statusMessage: 'Version not found' })
+})


### PR DESCRIPTION
Just allows for `/version/{version}` to redirect to `{project_type}/{slug}/version/{version}` using global middleware