### PR TITLE
fix(app): rate-limit repeated command error logging

### DIFF
--- a/apps/app/src/error.rs
+++ b/apps/app/src/error.rs
@@ -1,12 +1,128 @@
+use std::collections::HashMap;
+use std::fmt::Write as _;
+use std::hash::{DefaultHasher, Hasher};
+use std::sync::{LazyLock, Mutex};
+use std::time::{Duration, Instant};
+
 use tracing_error::ExtractSpanTrace;
 
-pub fn display_tracing_error(err: &theseus::Error) {
-    match get_span_trace(err) {
-        Some(span_trace) => {
-            tracing::error!(error = %err, span_trace = %span_trace);
+/// Minimum interval between two logs of the same error message.
+///
+/// A failing Tauri command is usually retried by the frontend, so a single
+/// persistent fault (a saturated database pool, a missing file) can otherwise
+/// produce thousands of identical lines per second.
+const REPEAT_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Maximum number of distinct error messages tracked at once. Bounded so the
+/// suppression table cannot itself grow without limit.
+const MAX_TRACKED_ERRORS: usize = 256;
+
+struct SuppressionState {
+    last_logged: Instant,
+    suppressed: u64,
+}
+
+static RECENT_ERRORS: LazyLock<Mutex<HashMap<u64, SuppressionState>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Hashes a `Display` implementation without allocating an intermediate
+/// `String`, so the common (suppressed) path stays cheap under a storm.
+struct HashWriter(DefaultHasher);
+
+impl std::fmt::Write for HashWriter {
+    fn write_str(&mut self, s: &str) -> std::fmt::Result {
+        self.0.write(s.as_bytes());
+        Ok(())
+    }
+}
+
+fn error_key(err: &theseus::Error) -> u64 {
+    let mut writer = HashWriter(DefaultHasher::new());
+    // Writing to a hasher cannot fail.
+    let _ = write!(writer, "{err}");
+    writer.0.finish()
+}
+
+/// Decides whether an occurrence should be logged now. Returns the number of
+/// occurrences suppressed since this message was last logged, or `None` if
+/// this occurrence should itself be suppressed.
+///
+/// Split from [`should_log`] so it can be tested without the global table.
+fn should_log_in(
+    recent: &mut HashMap<u64, SuppressionState>,
+    key: u64,
+    now: Instant,
+) -> Option<u64> {
+    match recent.get_mut(&key) {
+        Some(state) => {
+            if now.duration_since(state.last_logged) < REPEAT_INTERVAL {
+                state.suppressed += 1;
+                return None;
+            }
+
+            let suppressed = std::mem::take(&mut state.suppressed);
+            state.last_logged = now;
+            Some(suppressed)
         }
         None => {
+            // Evict the least recently logged entry to stay within bounds.
+            if recent.len() >= MAX_TRACKED_ERRORS
+                && let Some(oldest) = recent
+                    .iter()
+                    .min_by_key(|(_, state)| state.last_logged)
+                    .map(|(key, _)| *key)
+            {
+                recent.remove(&oldest);
+            }
+
+            recent.insert(
+                key,
+                SuppressionState {
+                    last_logged: now,
+                    suppressed: 0,
+                },
+            );
+            Some(0)
+        }
+    }
+}
+
+fn should_log(key: u64, now: Instant) -> Option<u64> {
+    let mut recent = RECENT_ERRORS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    should_log_in(&mut recent, key, now)
+}
+
+pub fn display_tracing_error(err: &theseus::Error) {
+    let Some(suppressed) = should_log(error_key(err), Instant::now()) else {
+        return;
+    };
+
+    // When nothing was dropped the output is byte-for-byte what it was
+    // before, so existing log greps keep working.
+    match (get_span_trace(err), suppressed) {
+        (Some(span_trace), 0) => {
+            tracing::error!(error = %err, span_trace = %span_trace);
+        }
+        (Some(span_trace), suppressed) => {
+            tracing::error!(
+                error = %err,
+                span_trace = %span_trace,
+                suppressed,
+                "identical errors were suppressed since the last log"
+            );
+        }
+        (None, 0) => {
             tracing::error!(error = %err);
+        }
+        (None, suppressed) => {
+            tracing::error!(
+                error = %err,
+                suppressed,
+                "identical errors were suppressed since the last log"
+            );
         }
     }
 }
@@ -15,4 +131,59 @@ pub fn get_span_trace<'a>(
     error: &'a (dyn std::error::Error + 'static),
 ) -> Option<&'a tracing_error::SpanTrace> {
     error.source().and_then(|e| e.span_trace())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn first_occurrence_always_logs() {
+        let mut recent = HashMap::new();
+        assert_eq!(should_log_in(&mut recent, 1, Instant::now()), Some(0));
+    }
+
+    #[test]
+    fn repeats_within_the_interval_are_suppressed_and_counted() {
+        let mut recent = HashMap::new();
+        let start = Instant::now();
+
+        assert_eq!(should_log_in(&mut recent, 1, start), Some(0));
+        for _ in 0..1000 {
+            assert_eq!(should_log_in(&mut recent, 1, start), None);
+        }
+
+        // Once the interval has passed, the backlog is reported exactly once.
+        let later = start + REPEAT_INTERVAL;
+        assert_eq!(should_log_in(&mut recent, 1, later), Some(1000));
+        assert_eq!(should_log_in(&mut recent, 1, later), None);
+    }
+
+    #[test]
+    fn distinct_errors_do_not_suppress_each_other() {
+        let mut recent = HashMap::new();
+        let now = Instant::now();
+
+        assert_eq!(should_log_in(&mut recent, 1, now), Some(0));
+        assert_eq!(should_log_in(&mut recent, 2, now), Some(0));
+        assert_eq!(should_log_in(&mut recent, 1, now), None);
+    }
+
+    #[test]
+    fn tracking_table_stays_bounded() {
+        let mut recent = HashMap::new();
+        let start = Instant::now();
+
+        for key in 0..(MAX_TRACKED_ERRORS as u64 * 4) {
+            // Stagger the timestamps so eviction has a well-defined victim.
+            let _ = should_log_in(
+                &mut recent,
+                key,
+                start + Duration::from_millis(key),
+            );
+            assert!(recent.len() <= MAX_TRACKED_ERRORS);
+        }
+
+        assert_eq!(recent.len(), MAX_TRACKED_ERRORS);
+    }
 }


### PR DESCRIPTION
Closes part of #7371.

## Problem

A failing Tauri command is retried by the frontend, and the error is logged from inside `Serialize` for `TheseusSerializableError` (`apps/app/src/api/mod.rs`). So one persistent fault turns into an unbounded log storm rather than a single message.

On the machine in #7371 a saturated SQLite pool produced, measured from the launcher logs:

- **~4,000–5,000 identical lines per second**
- **338,142** errors inside a single two-minute window
- a **189 MB** session log; **1.1 GB** of `launcher_logs/` total (it gzips 43:1, which is itself a measure of how repetitive it is)
- **1,390,704** copies of one message across the logs on that install

Pushing that many error events into the WebView drives `WebKitWebProcess` to 11–15 GiB until it is OOM-killed or crashes. Because the Tauri frame outlives the renderer, the user is left with a grey window that still has a working titlebar — which is how this presents in the wild, and why it reads as a rendering bug rather than a logging one.

## What this changes

Deduplicate by rendered error message:

- first occurrence logs immediately, exactly as before
- subsequent identical messages log at most once per 5 seconds, reporting a `suppressed` count of what was dropped
- output is **byte-for-byte unchanged when nothing was suppressed**, so existing log greps keep working

Two details to keep the fix from becoming its own problem:

- the suppression table is capped at 256 entries with least-recently-logged eviction, so it cannot grow without bound
- hashing goes through a `Hasher` sink implementing `fmt::Write` rather than allocating a `String`, so the common (suppressed) path does no allocation

## Scope

This is deliberately narrow: it fixes the **amplifier**, not the underlying fault. The root cause in #7371 is a separate file-descriptor/connection leak — that install had **1,774 open fds on `app.db`** after under four hours, with exactly 100 `app.db-wal` handles matching `max_connections(100)` in `packages/app-lib/src/state/db.rs`. I have not diagnosed that half and am not touching it here.

I think this is worth doing on its own merits regardless of that: any fault that makes a frequently-retried command fail will take the renderer down through this path, and rate-limiting is the general defence.

## Testing

`apps/app` does not currently build on my machine (no webkit2gtk dev headers), so I could not run the crate's own test suite. What I did verify, on **rustc 1.95.0 / edition 2024**, matching `rust-toolchain.toml`:

- the pure suppression logic and all four logging arms were extracted **verbatim** into a scratch crate with `tracing` as its only dependency, and 7 unit tests pass — first-occurrence, suppression counting and backlog reporting, independence of distinct messages, table bounding under 4× overload, hash stability, the `LazyLock`/`Mutex` wrapper, and reachability of every macro arm
- four of those tests ship in this PR as `#[cfg(test)] mod tests` against `should_log_in`, which is split out from `should_log` precisely so it is testable without the global table
- `rustfmt --edition 2024 --config max_width=80 --check` is clean

So the logic and syntax are verified; the integration against the real `theseus::Error` is not, and I would appreciate CI confirming it.

## Note on the interval

`REPEAT_INTERVAL` of 5 seconds is a judgement call. It is short enough that a genuinely recurring problem stays visible in the logs and long enough to cut a 5,000/sec storm to 0.2/sec. Happy to change it, or to make it scale with observed rate, if you would rather.
