### PR TITLE
fix(hosting frontend): fix zip extraction

### DIFF
--- a/packages/ui/src/layouts/wrapped/hosting/manage/files.vue
+++ b/packages/ui/src/layouts/wrapped/hosting/manage/files.vue
@@ -347,7 +347,7 @@ const createMutation = useMutation({
 // Extraction
 async function extractFile(path: string, override: boolean, dry: boolean) {
 	if (fileWriteDisabled.value) return
-	const target = path.slice(0, path.lastIndexOf('/')) || '/'
+	const target = path.replace(/\.zip$/i, '')
 	if (dry) {
 		return await client.kyros.files_v0.extractFile(path, override, true, target)
 	}


### PR DESCRIPTION
Extracting a zip file in the server's root currently sets the target directory to that file's name without the final `p`: `world.zip` is extacted to `world.zi`.

This fixes the issue and changes the extraction logic to target a directory named after the zip file, without the zip extension, instead of the parent. So, `world.zip` extracts to `world` rather than into `/`.

Closes DEV-1413