### PR TITLE
Docs: More description at how to set up the development environment

### DIFF
--- a/apps/docs/src/content/docs/contributing/docs.md
+++ b/apps/docs/src/content/docs/contributing/docs.md
@@ -8,14 +8,17 @@ This project is part of our [monorepo](https://github.com/modrinth/code). You ca
 [Docs] are the very site you are looking at right now.
 They are here to help developers and contributors work with Modrinth's codebase and API.
 
-To set up a development environment, you will need to install [pnpm] and run the following commands:
+To set up a development environment, you will need to install [pnpm] and [git], if you haven't already, and run the following commands:
 
 ```bash
+git clone https://github.com/modrinth/code.git modrinth
+cd "modrinth"
 pnpm install
 pnpm run docs:dev
 ```
 
 When ready, you will have a hot-reloading environment of the docs site running on port 4321.
+To open it up, enter http://localhost:4321 on your Browser.
 
 ## Ready to open a PR?
 
@@ -23,3 +26,4 @@ While there is no linting requirement on Docs, we do ask that you quickly check 
 
 [docs]: https://github.com/modrinth/code/tree/main/apps/docs
 [pnpm]: https://pnpm.io
+[git]: https://git-scm.com/

--- a/apps/docs/src/content/docs/contributing/docs.md
+++ b/apps/docs/src/content/docs/contributing/docs.md
@@ -18,7 +18,7 @@ pnpm run docs:dev
 ```
 
 When ready, you will have a hot-reloading environment of the docs site running on port 4321.
-To open it up, enter http://localhost:4321 on your Browser.
+To open it up, enter http://localhost:4321 on your Browser, or click [here].
 
 ## Ready to open a PR?
 
@@ -27,3 +27,4 @@ While there is no linting requirement on Docs, we do ask that you quickly check 
 [docs]: https://github.com/modrinth/code/tree/main/apps/docs
 [pnpm]: https://pnpm.io
 [git]: https://git-scm.com/
+[here]: http://localhost:4321/


### PR DESCRIPTION
Updated the "Contributing to Modrinth - Docs" guide to prevent setup issues for new contributors.

Changes included:

    Added Git to the list of required prerequisites alongside pnpm.

    Specified that git clone and the initial setup commands must be executed from the workspace root.

    Added the local browser URL (http://localhost:4321) to quickly preview the hot-reloading environment.
