### PR TITLE
feat: Add google "select_account" option to auth

### DIFF
--- a/apps/labrinth/src/routes/internal/flows.rs
+++ b/apps/labrinth/src/routes/internal/flows.rs
@@ -307,7 +307,7 @@ impl AuthProvider {
                 let client_id = &ENV.GOOGLE_CLIENT_ID;
 
                 format!(
-                    "https://accounts.google.com/o/oauth2/v2/auth?client_id={}&state={}&scope={}&response_type=code&redirect_uri={}",
+                    "https://accounts.google.com/o/oauth2/v2/auth?client_id={}&prompt=select_account&state={}&scope={}&response_type=code&redirect_uri={}",
                     client_id,
                     state,
                     urlencoding::encode(


### PR DESCRIPTION
Adds the "select_account" prompt to Google OAuth for those with multiple accounts.

This is already used in Microsoft and GitHub

https://developers.google.com/identity/protocols/oauth2/javascript-implicit-flow#oauth-2.0-endpoints

